### PR TITLE
feat: add deploy image workflow for IBM Cloud

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,47 @@
+# Required secrets: RIS_CLOUD_ACCOUNT_API_KEY, IBM_CLOUD_URL, IBM_CLOUD_REGION,
+# IBM_CLOUD_GROUP, IBM_REGISTRY_URL, IBM_CR_NAMESPACE
+# Required variables: IMAGE_NAME, IMAGE_TAG
+name: Deploy Image to IBM Cloud
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.ubi
+          push: false
+          load: true
+          tags: ${{ secrets.IBM_REGISTRY_URL }}/${{ secrets.IBM_CR_NAMESPACE }}/${{ vars.IMAGE_NAME }}:${{ vars.IMAGE_TAG }}
+
+      - name: Install IBM Cloud CLI
+        run: |
+          curl -fsSL https://clis.cloud.ibm.com/download/bluemix-cli/latest/linux64 | tar xz
+          sudo mv Bluemix_CLI/bin/ibmcloud /usr/local/bin/
+          ibmcloud version
+
+      - name: Deploy to IBM Cloud Registry
+        env:
+          RIS_CLOUD_ACCOUNT_API_KEY: ${{ secrets.RIS_CLOUD_ACCOUNT_API_KEY }}
+          TARGET_IBM_CLOUD_URL: ${{ secrets.IBM_CLOUD_URL }}
+          TARGET_IBM_CLOUD_REGION: ${{ secrets.IBM_CLOUD_REGION }}
+          TARGET_IBM_CLOUD_GROUP: ${{ secrets.IBM_CLOUD_GROUP }}
+          TARGET_IBM_REGISTRY_URL: ${{ secrets.IBM_REGISTRY_URL }}
+          CR_NAMESPACE: ${{ secrets.IBM_CR_NAMESPACE }}
+          IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+          IMAGE_TAG: ${{ vars.IMAGE_TAG }}
+        run: |
+          chmod +x ./scripts/deploy-image.sh
+          ./scripts/deploy-image.sh

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,0 +1,30 @@
+FROM registry.access.redhat.com/ubi8/python-312:latest
+
+USER root
+RUN dnf install -y curl && dnf clean all
+
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.local/bin/:$PATH"
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+COPY src/ ./src/
+COPY docs/ ./docs/
+
+RUN uv sync
+
+RUN mkdir -p /app/cuga_workspace
+
+COPY docs/examples/huggingface/contacts.txt /app/cuga_workspace/contacts.txt
+COPY docs/examples/huggingface/cuga_knowledge.md /app/cuga_workspace/cuga_knowledge.md
+COPY docs/examples/huggingface/cuga_playbook.md /app/cuga_workspace/cuga_playbook.md
+COPY docs/examples/huggingface/email_template.md /app/cuga_workspace/email_template.md
+
+EXPOSE 7860
+
+ENV CUGA_HOST=0.0.0.0
+ENV DYNACONF_SERVER_PORTS__DEMO=7860
+
+CMD ["uv", "run", "cuga", "start", "manager", "--host", "0.0.0.0", "--crm", "--email", "--filesystem", "--cuga-workspace", "/app/cuga_workspace"]

--- a/scripts/deploy-image.sh
+++ b/scripts/deploy-image.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+echo "--------------------------------------------------------------"
+echo 'Commencing image push to registry!'
+
+chmod +x ./scripts/* 2>/dev/null || true
+
+TARGET_IBM_CLOUD_URL=${1:-$TARGET_IBM_CLOUD_URL}
+TARGET_IBM_CLOUD_REGION=${2:-$TARGET_IBM_CLOUD_REGION}
+TARGET_IBM_CLOUD_GROUP=${3:-$TARGET_IBM_CLOUD_GROUP}
+TARGET_IBM_REGISTRY_URL=${4:-$TARGET_IBM_REGISTRY_URL}
+CR_NAMESPACE=${5:-$CR_NAMESPACE}
+IMAGE_NAME=${6:-$IMAGE_NAME}
+IMAGE_TAG=${7:-$IMAGE_TAG}
+
+echo "Login to IBM Cloud using apikey"
+ibmcloud login -a "$TARGET_IBM_CLOUD_URL" --apikey "$RIS_CLOUD_ACCOUNT_API_KEY" -r "$TARGET_IBM_CLOUD_REGION" -g "$TARGET_IBM_CLOUD_GROUP"
+if [ $? -ne 0 ]; then
+  echo "Failed to authenticate to IBM Cloud"
+  exit 1
+fi
+
+echo "Logging into IBM Cloud container registry"
+ibmcloud cr login
+if [ $? -ne 0 ]; then
+  echo "Failed to authenticate to IBM Cloud container registry"
+  exit 1
+fi
+
+echo "Pushing image to registry"
+docker push $TARGET_IBM_REGISTRY_URL/$CR_NAMESPACE/$IMAGE_NAME:$IMAGE_TAG
+echo "Done pushing image to registry"


### PR DESCRIPTION
## Feature Pull Request

### Related Issue
Closes #

### Description
Adds GitHub Action workflow to build and deploy Docker image to IBM Cloud Container Registry:
- **Dockerfile.ubi**: UBI-based image using `registry.access.redhat.com/ubi8/python-312`
- **scripts/deploy-image.sh**: Deploy script for IBM Cloud login and image push
- **deploy-image.yml**: Manual workflow using secrets for IBM config, repo variables for IMAGE_NAME and IMAGE_TAG

### Type of Changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Testing
- [x] I have tested this feature locally
- [ ] I have added tests that prove my feature works
- [ ] All new and existing tests passed

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added docstrings to new functions/classes

### Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added containerization configuration to package and run the app as a container, including a ready demo workspace and network port for access.
  * Implemented an automated deployment pipeline and helper script to build and publish container images to IBM Cloud Registry for streamlined releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->