### PR TITLE
Fix that enables correct evaluation for appworld with policies

### DIFF
--- a/src/cuga/backend/cuga_graph/utils/agent_loop.py
+++ b/src/cuga/backend/cuga_graph/utils/agent_loop.py
@@ -565,7 +565,11 @@ class AgentLoop:
             # Check if this is a policy event by looking at cuga_lite_metadata (unified handling)
             answer = state.final_answer
             # Do not insert policies into appworld answer
-            if hasattr(state, 'cuga_lite_metadata') and state.cuga_lite_metadata and settings.advanced_features.benchmark != "appworld":
+            if (
+                hasattr(state, 'cuga_lite_metadata')
+                and state.cuga_lite_metadata
+                and settings.advanced_features.benchmark != "appworld"
+            ):
                 metadata = state.cuga_lite_metadata
                 if metadata.get('policy_blocked') or metadata.get('policy_matched'):
                     policy_type = metadata.get('policy_type', 'unknown')


### PR DESCRIPTION
[Final suggestion](https://github.com/cuga-project/cuga-agent/issues/83) was used 

It is assumed that attributes in added condition always exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted policy metadata handling so that when running in the "appworld" benchmark mode, policy-wrapped final outputs are not injected for events flagged as policy-blocked or policy-matched. This ensures benchmark-mode outputs remain unwrapped and consistent with expected evaluation behavior, while preserving previous wrapping behavior in other modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->