### PR TITLE
feat: add versioned image tagging to deploy-image-ghcr workflow

### DIFF
--- a/.github/workflows/deploy-image-ghcr.yml
+++ b/.github/workflows/deploy-image-ghcr.yml
@@ -1,17 +1,16 @@
-# Required vars: IMAGE_NAME, IMAGE_TAG (optional, defaults to 'latest')
+# Required vars: IMAGE_NAME
 name: Deploy Image to GHCR
 
 on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag (e.g. 1.0.0, latest)'
+        description: 'Image tag (e.g. 1.0.0). Omit to use git tag or latest.'
         required: false
-        default: 'latest'
-      branch:
-        description: 'Git ref to build (branch, tag, or SHA). Defaults to main.'
-        required: false
-        default: 'main'
+        default: ''
 
 jobs:
   deploy:
@@ -24,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.branch != '' && inputs.branch || 'main' }}
+          ref: ${{ github.ref }}
 
       - name: Validate vars
         run: |
@@ -46,13 +45,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve image tag
-        id: tag
-        run: |
-          TAG="${{ inputs.image_tag }}"
-          [ -z "$TAG" ] && TAG="${{ vars.IMAGE_TAG }}"
-          [ -z "$TAG" ] && TAG="latest"
-          echo "value=$TAG" >> $GITHUB_OUTPUT
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
+            type=raw,value=latest,enable=${{ inputs.image_tag == '' && github.event_name != 'push' }}
+          labels: |
+            org.opencontainers.image.title=${{ vars.IMAGE_NAME }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Build and push image to GHCR
         uses: docker/build-push-action@v6
@@ -61,7 +67,5 @@ jobs:
           file: ./Dockerfile.ubi
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:${{ steps.tag.outputs.value }}
-          labels: |
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Feature

Closes #105

### Summary

Updates `.github/workflows/deploy-image-ghcr.yml` to produce versioned, immutable image tags on every release instead of only overwriting `latest`.

**Changes:**
- Add `push: tags: v[0-9]+.[0-9]+.[0-9]+` trigger so the workflow fires automatically when a git tag is pushed (e.g. from `release-tag.yml`)
- Replace the manual `Resolve image tag` step with `docker/metadata-action@v5`, which derives semver tags (`0.2.10`, `0.2`, `0`) automatically from the git tag
- On `workflow_dispatch`, an optional `image_tag` input still allows manual override (e.g. for hotfix images)
- `latest` is only pushed on manual dispatch without an explicit tag — never on a git-tag push, keeping versioned images immutable
- Remove the redundant `branch` input — the GitHub Actions UI already provides a ref selector for `workflow_dispatch`
- Full OCI labels (`title`, `source`, `revision`, `version`, `created`) via metadata-action output

### Testing
- [ ] Tested locally; tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now triggers automatically on semantic version tag pushes (vX.Y.Z) in addition to manual dispatch.
  * Enhanced image tagging and OCI label generation with improved metadata handling.
  * Simplified manual workflow inputs, removing branch selection and refining image tag defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->