### PR TITLE
chore: Upgrade langchain text splitters package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cuga"
-version = "0.2.19"
+version = "0.2.20"
 description = "CUGA is an open-source generalist agent for the enterprise, supporting complex task execution on web and APIs, OpenAPI/MCP integrations, composable architecture, reasoning modes, and policy-aware features."
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     # Knowledge engine (replaces OpenRAG)
     "langchain-docling>=2.0,<3.0",
     "langchain-ollama>=0.2.0",
-    "langchain-text-splitters>=0.3,<0.4",
+    "langchain-text-splitters>=1.0,<2.0",
     "beautifulsoup4>=4.12",
     "psycopg[binary]>=3.2",
 ]

--- a/src/cuga/__init__.py
+++ b/src/cuga/__init__.py
@@ -28,7 +28,7 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.tool_call_tracker import tracked_to
 from cuga.backend.knowledge import KnowledgeClient, KnowledgeEngine
 from cuga.backend.knowledge.config import KnowledgeConfig
 
-__version__ = "0.2.6"
+__version__ = "0.2.20"
 __all__ = [
     "CugaAgent",
     "CugaSupervisor",

--- a/uv.lock
+++ b/uv.lock
@@ -934,7 +934,7 @@ wheels = [
 
 [[package]]
 name = "cuga"
-version = "0.2.19"
+version = "0.2.20"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },

--- a/uv.lock
+++ b/uv.lock
@@ -1055,7 +1055,7 @@ requires-dist = [
     { name = "langchain-mcp-adapters" },
     { name = "langchain-ollama", specifier = ">=0.2.0" },
     { name = "langchain-openai" },
-    { name = "langchain-text-splitters", specifier = ">=0.3,<0.4" },
+    { name = "langchain-text-splitters", specifier = ">=1.0,<2.0" },
     { name = "langfuse" },
     { name = "langgraph" },
     { name = "litellm", specifier = ">=1.83.0" },
@@ -2913,14 +2913,14 @@ wheels = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "0.3.11"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/43/dcda8fd25f0b19cb2835f2f6bb67f26ad58634f04ac2d8eae00526b0fa55/langchain_text_splitters-0.3.11.tar.gz", hash = "sha256:7a50a04ada9a133bbabb80731df7f6ddac51bc9f1b9cab7fa09304d71d38a6cc", size = 46458, upload-time = "2025-08-31T23:02:58.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/38/14121ead61e0e75f79c3a35e5148ac7c2fe754a55f76eab3eed573269524/langchain_text_splitters-1.1.1.tar.gz", hash = "sha256:34861abe7c07d9e49d4dc852d0129e26b32738b60a74486853ec9b6d6a8e01d2", size = 279352, upload-time = "2026-02-18T23:02:42.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/0d/41a51b40d24ff0384ec4f7ab8dd3dcea8353c05c973836b5e289f1465d4f/langchain_text_splitters-0.3.11-py3-none-any.whl", hash = "sha256:cf079131166a487f1372c8ab5d0bfaa6c0a4291733d9c43a34a16ac9bcd6a393", size = 33845, upload-time = "2025-08-31T23:02:57.195Z" },
+    { url = "https://files.pythonhosted.org/packages/84/66/d9e0c3b83b0ad75ee746c51ba347cacecb8d656b96e1d513f3e334d1ccab/langchain_text_splitters-1.1.1-py3-none-any.whl", hash = "sha256:5ed0d7bf314ba925041e7d7d17cd8b10f688300d5415fb26c29442f061e329dc", size = 35734, upload-time = "2026-02-18T23:02:41.913Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR bumps the package version from `0.2.19` to `0.2.20` and updates `langchain-text-splitters` from `>=0.3,<0.4` to `>=1.0,<2.0`, with `uv.lock` refreshed to a modern resolved version.

## What changed

- Bumped `cuga` version from `0.2.19` to `0.2.20`
- Aligned runtime `cuga.__version__` with the package version
- Updated `pyproject.toml` to allow `langchain-text-splitters>=1.0,<2.0`
- Refreshed `uv.lock`
- Resolved `langchain-text-splitters` from `0.3.11` to `1.1.1`

## Why

The repo only uses `RecursiveCharacterTextSplitter` in the knowledge engine, and that usage is compatible with the current `1.x` line. This keeps the dependency modern while preserving a bounded major-version range for safety.

The version bump to `0.2.20` captures the dependency update in the package metadata and keeps runtime version reporting consistent.

## Risk / compatibility

Risk is low.

- The current code path uses stable splitter APIs only
- `langchain-text-splitters 1.1.1` depends on `langchain-core>=1.2.13,<2.0.0`
- This repo already requires `langchain-core>=1.2.22`, so the dependency graph remains compatible
- No code changes were needed in the knowledge engine beyond dependency and version metadata updates

## Validation

Ran:

```bash
uv run pytest tests/unit/test_knowledge_engine.py tests/integration/test_knowledge_integration.py
uv run python -c "import cuga; print(cuga.__version__)"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.2.20.
  * Updated langchain-text-splitters dependency compatibility to support version 1.x releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
