### PR TITLE
fix(browser): update playwright to use chrome channel for CVE mitigation

### DIFF
--- a/src/cuga/backend/browser_env/browser/chat_async.py
+++ b/src/cuga/backend/browser_env/browser/chat_async.py
@@ -36,7 +36,9 @@ class Chat:
     async def init(self):
         pw: playwright.async_api.Playwright = await _get_global_playwright_async()
         self.browser = await pw.chromium.launch(
-            headless=self.headless, args=[f"--window-size={self.chat_size[0]},{self.chat_size[1]}"]
+            channel="chrome",
+            headless=self.headless,
+            args=[f"--window-size={self.chat_size[0]},{self.chat_size[1]}"],
         )
         self.context = await self.browser.new_context(
             no_viewport=True,

--- a/src/cuga/backend/browser_env/browser/env.py
+++ b/src/cuga/backend/browser_env/browser/env.py
@@ -64,7 +64,9 @@ class BrowserEnvSimple:
 
     def start_browser(self, headless=False):
         # Launch the browser
-        self.browser = self.playwright.chromium.launch(headless=headless, args=["--no-sandbox"])
+        self.browser = self.playwright.chromium.launch(
+            channel="chrome", headless=headless, args=["--no-sandbox"]
+        )
         self.page = self.browser.new_page()
         self.context = self.browser.contexts[0]
 

--- a/src/cuga/backend/browser_env/browser/gym_env.py
+++ b/src/cuga/backend/browser_env/browser/gym_env.py
@@ -248,6 +248,7 @@ class BrowserEnvGym(gym.Env, ABC):
         # create a new browser context for pages
         self.context = pw.chromium.launch_persistent_context(
             "",
+            channel="chrome",
             no_viewport=True if self.resizeable_window else None,
             headless=self.headless,
             slow_mo=slow_mo,

--- a/src/cuga/demo_tools/docs_mcp/docs_mcp_server.py
+++ b/src/cuga/demo_tools/docs_mcp/docs_mcp_server.py
@@ -46,7 +46,7 @@ async def _fetch_single_page(url: str) -> str:
     from playwright.async_api import async_playwright
 
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
+        browser = await p.chromium.launch(channel="chrome", headless=True)
         try:
             context = await browser.new_context(user_agent=_UA)
             page = await context.new_page()


### PR DESCRIPTION
## Bug fix

### Summary
Update Playwright to use the stable Chrome channel instead of the bundled Chromium. This change helps mitigate recent security vulnerabilities (CVEs) where no fix version is currently available for the bundled browser.

**Changes:**
- Added `channel="chrome"` to `chromium.launch` in:
  - `src/cuga/backend/browser_env/browser/chat_async.py`
  - `src/cuga/demo_tools/docs_mcp/docs_mcp_server.py`
  - `src/cuga/backend/browser_env/browser/env.py`
- Added `channel="chrome"` to `launch_persistent_context` in:
  - `src/cuga/backend/browser_env/browser/gym_env.py`

### Testing
- [x] Verified code changes locally
- [x] Passed linter and formatting checks (ruff)
- [x] Verified commit history follows conventional commit standard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated browser launch configuration across multiple components to explicitly use the Chrome browser channel instead of the default Chromium launch settings. This ensures consistent browser initialization across the chat, environment, and documentation server modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->