### PR TITLE
feat: improve Vault KV v2 support and path resolution

### DIFF
--- a/src/cuga/backend/secrets/backends/vault_backend.py
+++ b/src/cuga/backend/secrets/backends/vault_backend.py
@@ -175,8 +175,23 @@ def _resolve_vault_path(
     list_prefix = _vault_list_prefix(vault_secret_path, mp, kv)
 
     sid = (secret_id or "").strip()
+    # Strip leading mount point if it's already in the sid to avoid double-prepending
+    if sid.startswith(mp + "/"):
+        sid = sid[len(mp) + 1 :]
+
     if not sid:
         return mp, "", list_prefix
+
+    if (vault_secret_path or "").strip():
+        # If a base path is set, we never want to guess the mount from the path.
+        # We always use the explicitly configured mount_point.
+        merged = _merge_vault_secret_base(sid, vault_secret_path)
+        # Ensure we don't accidentally double-strip "data/" if it's part of the base path
+        # but normalize the ID portion if it was provided as "data/..."
+        crud_path = merged
+        if kv != "1":
+            crud_path = _normalize_kv_v2_data_prefix(crud_path)
+        return mp, crud_path, list_prefix
 
     merged = _merge_vault_secret_base(sid, vault_secret_path)
     crud_mount, crud_path = _split_mount_and_path(merged, default_mount=mp, kv_version=kv)
@@ -319,19 +334,14 @@ class VaultBackend:
                 )
                 payload = (resp or {}).get("data", {})
             else:
-                try:
-                    resp = client.secrets.kv.v2.read_secret_version(
-                        path=secret_path,
-                        mount_point=mount_point,
-                    )
-                    data = (resp or {}).get("data", {}) or {}
-                    payload = data.get("data", data)
-                except Exception:
-                    resp = client.secrets.kv.v1.read_secret(
-                        path=secret_path,
-                        mount_point=mount_point,
-                    )
-                    payload = (resp or {}).get("data", {})
+                # Empty / unset defaults to KV v2 only. Do not fall back to v1: that hits
+                # /v1/{mount}/{path} and fails on versioned KV with "Invalid path..." warnings.
+                resp = client.secrets.kv.v2.read_secret_version(
+                    path=secret_path,
+                    mount_point=mount_point,
+                )
+                data = (resp or {}).get("data", {}) or {}
+                payload = data.get("data", data)
             if not isinstance(payload, dict):
                 return None
             if key_field:

--- a/src/cuga/config.py
+++ b/src/cuga/config.py
@@ -162,6 +162,7 @@ validators = [
     Validator("secrets.vault_skip_verify", default=False),
     Validator("secrets.vault_mount", default="secret"),
     Validator("secrets.vault_kv_version", default=""),
+    Validator("secrets.vault_secret_path", default=""),
     Validator("secrets.vault_write_enabled", default=False),
     Validator("secrets.aws_region", default=""),
     Validator("auth.enabled", default=False),

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -108,7 +108,8 @@ vault_k8s_jwt_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 vault_cacert = ""  # PEM bundle path; env VAULT_CACERT (internal / route CA)
 vault_skip_verify = false  # dev only; env VAULT_SKIP_VERIFY=true
 vault_mount = "secret"
-vault_kv_version = ""  # "1" or "2"; leave empty to auto-detect
+vault_kv_version = ""  # "1" or "2"; empty = KV v2 (use "1" only for KV v1 mounts)
+vault_secret_path = ""  # Base path for secrets (env: DYNACONF_SECRETS__VAULT_SECRET_PATH)
 vault_write_enabled = false
 aws_region = ""
 


### PR DESCRIPTION
- Fix "mount stealing" bug where base path was incorrectly guessed as mount point
- Remove misleading KV v1 fallback on read to provide clearer error logs
- Add `vault_secret_path` to Dynaconf schema to support base path configuration
- Fix double-prepending of mount point when URI includes the mount name
- Ensure KV v2 methods are used by default for better compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `vault_secret_path` configuration option to define base secrets path in Vault.

* **Bug Fixes**
  * Fixed vault path resolution logic to prevent double-prepending of mount points.
  * Changed default KV version handling to use KV v2 instead of attempting KV v1 as fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->