### PR TITLE
Propagate multi-user context (user_id, namespace_id, session_id) to Evolve MCP server

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_graph.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_graph.py
@@ -441,6 +441,7 @@ class CugaLiteState(BaseModel):
     - hitl_response: Optional[ActionResponse] (human-in-the-loop response)
     - sender: str (node that sent the current state)
     - service_scope: Dict[str, str] (tenant_id, instance_id for multi-tenant/prod scoping)
+    - user_id: str (caller user ID for Evolve attribution and scoping)
 
     Subgraph-only keys:
     - script, execution_complete, error, metrics
@@ -456,6 +457,7 @@ class CugaLiteState(BaseModel):
     chat_messages: Optional[List[BaseMessage]] = Field(default_factory=list)
     final_answer: Optional[str] = ""
     thread_id: Optional[str] = None
+    user_id: Optional[str] = "default"  # Shared with AgentState for per-user Evolve context
     service_scope: Optional[Dict[str, str]] = Field(
         default_factory=lambda: {"tenant_id": "", "instance_id": ""}
     )
@@ -1160,7 +1162,12 @@ def create_cuga_lite_graph(
                             task_description = msg.content
                             break
                 if task_description:
-                    evolve_guidelines = await EvolveIntegration.get_guidelines(task_description)
+                    evolve_guidelines = await EvolveIntegration.get_guidelines(
+                        task_description,
+                        user_id=state.user_id or None,
+                        namespace_id=(state.service_scope or {}).get("tenant_id") or None,
+                        session_id=state.thread_id or None,
+                    )
                     if evolve_guidelines:
                         evolve_section = f"\n\n## Evolve Guidelines\n{evolve_guidelines}"
                         special_instructions_final = (special_instructions_final or "") + evolve_section

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_graph.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_graph.py
@@ -441,7 +441,7 @@ class CugaLiteState(BaseModel):
     - hitl_response: Optional[ActionResponse] (human-in-the-loop response)
     - sender: str (node that sent the current state)
     - service_scope: Dict[str, str] (tenant_id, instance_id for multi-tenant/prod scoping)
-    - user_id: str (caller user ID for Evolve attribution and scoping)
+    - user_id: Optional[str] (caller user ID for Evolve attribution; None when unset)
 
     Subgraph-only keys:
     - script, execution_complete, error, metrics
@@ -457,7 +457,7 @@ class CugaLiteState(BaseModel):
     chat_messages: Optional[List[BaseMessage]] = Field(default_factory=list)
     final_answer: Optional[str] = ""
     thread_id: Optional[str] = None
-    user_id: Optional[str] = "default"  # Shared with AgentState for per-user Evolve context
+    user_id: Optional[str] = None  # Shared with AgentState; None means unset (no user context sent to Evolve)
     service_scope: Optional[Dict[str, str]] = Field(
         default_factory=lambda: {"tenant_id": "", "instance_id": ""}
     )

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
@@ -395,14 +395,27 @@ class CugaLiteNode(BaseNode):
             state_error = getattr(state, "error", None)
             success = not (self._has_error(state.final_answer or "") or bool(state_error))
             messages_snapshot = list(state.chat_messages)
+            _evolve_user_id = state.user_id or None
+            _evolve_namespace_id = (state.service_scope or {}).get("tenant_id") or None
+            _evolve_session_id = state.thread_id or None
             if settings.evolve.async_save:
                 task = _asyncio.create_task(
-                    EvolveIntegration.save_trajectory(messages_snapshot, task_id, success)
+                    EvolveIntegration.save_trajectory(
+                        messages_snapshot, task_id, success,
+                        user_id=_evolve_user_id,
+                        namespace_id=_evolve_namespace_id,
+                        session_id=_evolve_session_id,
+                    )
                 )
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
             else:
-                await EvolveIntegration.save_trajectory(messages_snapshot, task_id, success)
+                await EvolveIntegration.save_trajectory(
+                    messages_snapshot, task_id, success,
+                    user_id=_evolve_user_id,
+                    namespace_id=_evolve_namespace_id,
+                    session_id=_evolve_session_id,
+                )
 
         # Get metadata from state
         metadata = state.cuga_lite_metadata or {}

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
@@ -401,7 +401,9 @@ class CugaLiteNode(BaseNode):
             if settings.evolve.async_save:
                 task = _asyncio.create_task(
                     EvolveIntegration.save_trajectory(
-                        messages_snapshot, task_id, success,
+                        messages_snapshot,
+                        task_id,
+                        success,
                         user_id=_evolve_user_id,
                         namespace_id=_evolve_namespace_id,
                         session_id=_evolve_session_id,
@@ -411,7 +413,9 @@ class CugaLiteNode(BaseNode):
                 task.add_done_callback(self._background_tasks.discard)
             else:
                 await EvolveIntegration.save_trajectory(
-                    messages_snapshot, task_id, success,
+                    messages_snapshot,
+                    task_id,
+                    success,
                     user_id=_evolve_user_id,
                     namespace_id=_evolve_namespace_id,
                     session_id=_evolve_session_id,

--- a/src/cuga/backend/evolve/integration.py
+++ b/src/cuga/backend/evolve/integration.py
@@ -39,12 +39,25 @@ class EvolveIntegration:
         return True
 
     @classmethod
-    async def get_guidelines(cls, task: str) -> Optional[str]:
+    async def get_guidelines(
+        cls,
+        task: str,
+        user_id: Optional[str] = None,
+        namespace_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> Optional[str]:
         """Fetch guidelines from Evolve for the given task description."""
         if not cls.is_enabled():
             return None
         try:
-            result = await cls._call_tool("get_guidelines", {"task": task})
+            args: dict = {"task": task}
+            if user_id:
+                args["user_id"] = user_id
+            if namespace_id:
+                args["namespace_id"] = namespace_id
+            if session_id:
+                args["session_id"] = session_id
+            result = await cls._call_tool("get_guidelines", args)
             if result:
                 logger.info(f"Evolve: Received guidelines ({len(str(result))} chars)")
                 return str(result)
@@ -60,6 +73,9 @@ class EvolveIntegration:
         chat_messages: List[BaseMessage],
         task_id: str,
         success: bool,
+        user_id: Optional[str] = None,
+        namespace_id: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> None:
         """Save the agent trajectory to Evolve for tip generation."""
         if not cls.is_enabled():
@@ -86,13 +102,17 @@ class EvolveIntegration:
                 f"task_id={task_id[:80]}, success={success})"
             )
             logger.debug(f"Evolve: trajectory_data preview: {trajectory_json[:500]}")
-            await cls._call_tool(
-                "save_trajectory",
-                {
-                    "trajectory_data": trajectory_json,
-                    "task_id": task_id,
-                },
-            )
+            args: dict = {
+                "trajectory_data": trajectory_json,
+                "task_id": task_id,
+            }
+            if user_id:
+                args["user_id"] = user_id
+            if namespace_id:
+                args["namespace_id"] = namespace_id
+            if session_id:
+                args["session_id"] = session_id
+            await cls._call_tool("save_trajectory", args)
             logger.info("Evolve: Trajectory saved successfully")
         except Exception as e:
             logger.warning(f"Evolve save_trajectory failed (non-fatal): {e}")

--- a/src/cuga/backend/evolve/tests/test_integration.py
+++ b/src/cuga/backend/evolve/tests/test_integration.py
@@ -150,6 +150,32 @@ class TestGetGuidelines:
         result = await EvolveIntegration.get_guidelines("test task")
         assert result is None
 
+    @pytest.mark.asyncio
+    @patch.object(EvolveIntegration, "_call_tool", new_callable=AsyncMock)
+    @patch("cuga.backend.evolve.integration.settings")
+    async def test_passes_multi_user_params(self, mock_settings, mock_call_tool):
+        mock_settings.evolve.enabled = True
+        mock_settings.evolve.lite_mode_only = False
+        mock_call_tool.return_value = "guideline text"
+        result = await EvolveIntegration.get_guidelines(
+            "test task", user_id="user-1", namespace_id="tenant-a", session_id="thread-99"
+        )
+        assert result == "guideline text"
+        mock_call_tool.assert_called_once_with(
+            "get_guidelines",
+            {"task": "test task", "user_id": "user-1", "namespace_id": "tenant-a", "session_id": "thread-99"},
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(EvolveIntegration, "_call_tool", new_callable=AsyncMock)
+    @patch("cuga.backend.evolve.integration.settings")
+    async def test_omits_none_multi_user_params(self, mock_settings, mock_call_tool):
+        mock_settings.evolve.enabled = True
+        mock_settings.evolve.lite_mode_only = False
+        mock_call_tool.return_value = "guideline text"
+        await EvolveIntegration.get_guidelines("test task", user_id=None, namespace_id=None)
+        mock_call_tool.assert_called_once_with("get_guidelines", {"task": "test task"})
+
 
 class TestToolDispatch:
     """Test transport selection and fallback behavior."""
@@ -298,3 +324,42 @@ class TestSaveTrajectory:
         mock_settings.evolve.save_on_failure = True
         mock_call_tool.side_effect = asyncio.TimeoutError("Operation timed out")
         await EvolveIntegration.save_trajectory([HumanMessage(content="test")], "task_1", success=True)
+
+    @pytest.mark.asyncio
+    @patch.object(EvolveIntegration, "_call_tool", new_callable=AsyncMock)
+    @patch("cuga.backend.evolve.integration.settings")
+    async def test_passes_multi_user_params(self, mock_settings, mock_call_tool):
+        mock_settings.evolve.enabled = True
+        mock_settings.evolve.lite_mode_only = False
+        mock_settings.evolve.save_on_success = True
+        mock_settings.evolve.save_on_failure = True
+        messages = [HumanMessage(content="Hello"), AIMessage(content="Hi")]
+        await EvolveIntegration.save_trajectory(
+            messages, "task_1", success=True,
+            user_id="user-1", namespace_id="tenant-a", session_id="thread-99",
+        )
+        mock_call_tool.assert_called_once()
+        call_args = mock_call_tool.call_args[0]
+        assert call_args[0] == "save_trajectory"
+        payload = call_args[1]
+        assert payload["user_id"] == "user-1"
+        assert payload["namespace_id"] == "tenant-a"
+        assert payload["session_id"] == "thread-99"
+        assert "trajectory_data" in payload
+        assert payload["task_id"] == "task_1"
+
+    @pytest.mark.asyncio
+    @patch.object(EvolveIntegration, "_call_tool", new_callable=AsyncMock)
+    @patch("cuga.backend.evolve.integration.settings")
+    async def test_omits_none_multi_user_params(self, mock_settings, mock_call_tool):
+        mock_settings.evolve.enabled = True
+        mock_settings.evolve.lite_mode_only = False
+        mock_settings.evolve.save_on_success = True
+        mock_settings.evolve.save_on_failure = True
+        messages = [HumanMessage(content="Hello"), AIMessage(content="Hi")]
+        await EvolveIntegration.save_trajectory(messages, "task_1", success=True)
+        mock_call_tool.assert_called_once()
+        payload = mock_call_tool.call_args[0][1]
+        assert "user_id" not in payload
+        assert "namespace_id" not in payload
+        assert "session_id" not in payload

--- a/src/cuga/backend/evolve/tests/test_integration.py
+++ b/src/cuga/backend/evolve/tests/test_integration.py
@@ -335,8 +335,12 @@ class TestSaveTrajectory:
         mock_settings.evolve.save_on_failure = True
         messages = [HumanMessage(content="Hello"), AIMessage(content="Hi")]
         await EvolveIntegration.save_trajectory(
-            messages, "task_1", success=True,
-            user_id="user-1", namespace_id="tenant-a", session_id="thread-99",
+            messages,
+            "task_1",
+            success=True,
+            user_id="user-1",
+            namespace_id="tenant-a",
+            session_id="thread-99",
         )
         mock_call_tool.assert_called_once()
         call_args = mock_call_tool.call_args[0]

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -1178,6 +1178,7 @@ async def event_stream(
         from cuga.config import get_service_instance_id, get_tenant_id
 
         local_state.service_scope = {"tenant_id": get_tenant_id(), "instance_id": get_service_instance_id()}
+        local_state.user_id = user_id  # Propagate authenticated user into graph state
         if os.getenv("CUGA_DEMO_MODE") == "health" and not local_state.pi:
             from cuga.backend.server.demo_manage_setup import HEALTH_USER_CONTEXT
 


### PR DESCRIPTION
## Problem
ALTK-Evolve's MCP server already supports multi-user parameters (`user_id`, `namespace_id`, `session_id`) across `get_guidelines`, `save_trajectory`, and `get_entities`. However, the CUGA agent never sends these values — all Evolve interactions appear as `"default"` user with no tenant or session context.
**Root causes:**
1. `event_stream()` in `server/main.py` receives `user_id` from the authenticated request but never assigns it to `local_state.user_id`
2. `CugaLiteState` lacks a `user_id` field, so the subgraph cannot propagate user identity
3. `EvolveIntegration.get_guidelines()` and `save_trajectory()` don't accept or forward any context parameters
## Changes
| File | Change |
|---|---|
| `server/main.py` | Populate `local_state.user_id = user_id` after `service_scope` is set |
| `cuga_lite_graph.py` | Add `user_id: Optional[str]` to `CugaLiteState` shared keys |
| `evolve/integration.py` | Extend `get_guidelines()` and `save_trajectory()` with optional `user_id`, `namespace_id`, `session_id` |
| `cuga_lite_graph.py` | Pass context from `CugaLiteState` to `get_guidelines()` call |
| `cuga_lite_node.py` | Pass context from `AgentState` to `save_trajectory()` calls |
| `tests/test_integration.py` | 4 new tests for parameter propagation and backward compatibility |
## Behavior
- **Retrieval stays broad** — `get_guidelines` does not hard-filter by user/session; context is logged for attribution only
- **Writes are scoped** — `save_trajectory` stamps `user_id`, `namespace_id`, `session_id` into entity metadata
- **Fully backward-compatible** — all new parameters default to `None` and are omitted from the MCP payload when not set
## Testing
29/29 unit tests pass (25 existing + 4 new).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User identity context (user, namespace, session) is now tracked and propagated through request state, enabling guideline retrieval and execution history to include that context.

* **Tests**
  * Added async tests validating that guideline retrieval and execution-tracking calls include or omit user/namespace/session identifiers as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->