### PR TITLE
Fix: show processing indicator during pre-token latency (turnInFlight)

### DIFF
--- a/docs/DEMO_RECORDING.md
+++ b/docs/DEMO_RECORDING.md
@@ -1,0 +1,31 @@
+Demo recording instructions
+==========================
+
+This document explains how to record a quick demo showing the `turnInFlight` UI behavior (pre-token processing indicator).
+
+Prerequisites
+- Node.js (16+)
+- Playwright (will be installed via npm)
+- A running frontend dev server (e.g. `pnpm start` or your usual dev command) serving the chat UI at `http://localhost:3000`
+
+Steps
+1. Ensure the frontend is running locally. If you rely on the fake stream mode, enable `FAKE_STREAM` when building or set it in the environment so the UI simulates a slow LLM.
+2. Install Playwright dependencies (once):
+
+```bash
+npm init -y
+npm i -D playwright
+npx playwright install
+```
+
+3. Run the recorder script (passes URL as first arg or use `DEMO_URL` env var):
+
+```bash
+node scripts/playwright/record_demo.spec.js http://localhost:3000
+```
+
+4. After the script completes, find the recorded video under `demo-recordings/`.
+
+Notes
+- The script uses a generic input selector; if your chat input uses a custom element, update `scripts/playwright/record_demo.spec.js` accordingly.
+- If you'd like, I can run this here to produce a recording (I'll install Playwright and run it). Reply `run demo` to let me proceed.

--- a/scripts/playwright/record_demo.spec.js
+++ b/scripts/playwright/record_demo.spec.js
@@ -1,0 +1,44 @@
+const { chromium } = require('playwright');
+const fs = require('fs');
+
+// Usage: node record_demo.spec.js [URL]
+// Example: node record_demo.spec.js http://localhost:3000
+(async () => {
+  const url = process.argv[2] || process.env.DEMO_URL || 'http://localhost:3000';
+  const outDir = 'demo-recordings';
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    recordVideo: { dir: outDir, size: { width: 1280, height: 720 } },
+  });
+  const page = await context.newPage();
+
+  console.log('Opening', url);
+  await page.goto(url, { waitUntil: 'networkidle' });
+
+  // Short waits to let the app bootstrap. Adjust selectors if your app differs.
+  await page.waitForTimeout(1000);
+
+  // If your app has a chat input with a known selector, update this.
+  const inputSelector = 'textarea, input[type=text], [contenteditable="true"]';
+  await page.waitForSelector(inputSelector, { timeout: 5000 });
+
+  // Focus the input and type a query that triggers the fake stream
+  await page.click(inputSelector);
+  await page.keyboard.type('Show processing indicator demo');
+
+  // Submit — try Enter key; if your UI needs a button, change selector accordingly
+  await page.keyboard.press('Enter');
+
+  // Wait long enough to capture pre-token latency + streaming
+  console.log('Recording demo — waiting 12s to capture pre-token phase and streaming');
+  await page.waitForTimeout(12000);
+
+  // Stop and save video
+  const video = await page.video().path();
+  console.log('Video saved to:', video);
+
+  await browser.close();
+  console.log('Done. Files in', outDir);
+})();

--- a/src/frontend_workspaces/agentic_chat/src/StreamManager.tsx
+++ b/src/frontend_workspaces/agentic_chat/src/StreamManager.tsx
@@ -1,24 +1,47 @@
 // streamStateManager.ts
 import { apiFetch } from "../../frontend/src/api";
-type StreamStateListener = (isStreaming: boolean) => void;
+type StreamStateListener = (isProcessing: boolean) => void;
 
 class StreamStateManager {
   private isStreaming = false;
+  private turnInFlight = false;
   private listeners: Set<StreamStateListener> = new Set();
   private currentAbortController: AbortController | null = null;
+
+  // Combined processing state: either a turn is in-flight or tokens are streaming
+  getIsProcessing() {
+    return this.turnInFlight || this.isStreaming;
+  }
 
   setStreaming(streaming: boolean) {
     this.isStreaming = streaming;
     console.log("listeners", this.listeners);
-    this.listeners.forEach((listener) => listener(streaming));
+    const combined = this.getIsProcessing();
+    this.listeners.forEach((listener) => listener(combined));
   }
 
   getIsStreaming() {
     return this.isStreaming;
   }
 
+  setTurnInFlight(inFlight: boolean) {
+    this.turnInFlight = inFlight;
+    const combined = this.getIsProcessing();
+    this.listeners.forEach((listener) => listener(combined));
+  }
+
+  getIsTurnInFlight() {
+    return this.turnInFlight;
+  }
+
   subscribe(listener: StreamStateListener): () => void {
     this.listeners.add(listener);
+    // Immediately notify the new subscriber of current combined state
+    try {
+      listener(this.getIsProcessing());
+    } catch (e) {
+      // noop
+    }
     return () => {
       this.listeners.delete(listener);
     };
@@ -49,6 +72,7 @@ class StreamStateManager {
     }
 
     this.setStreaming(false);
+    this.setTurnInFlight(false);
   }
 }
 

--- a/src/frontend_workspaces/agentic_chat/src/StreamingWorkflow.ts
+++ b/src/frontend_workspaces/agentic_chat/src/StreamingWorkflow.ts
@@ -503,6 +503,12 @@ export const streamViaBackground = async (
     return;
   }
 
+  // Mark a turn as in-flight as soon as the user submits the query so
+  // the UI can show a processing indicator before any tokens stream in.
+  streamStateManager.setTurnInFlight(true);
+
+  try {
+
   // -------------------------------------------------------------
   // Replicate the original workflow UI behaviour (same as in
   // fetchStreamingData) so that incoming agent responses are
@@ -579,6 +585,11 @@ export const streamViaBackground = async (
   // -------------------------------------------------------------
   // Listener for streaming responses coming back from the background
   // -------------------------------------------------------------
+  // Promise used to signal when the background processing completes
+  let completionResolver: (() => void) | null = null;
+  const completionPromise = new Promise<void>((resolve) => {
+    completionResolver = resolve;
+  });
   const listener = (message: any) => {
     if (!message || message.source !== "background") return;
 
@@ -622,7 +633,12 @@ export const streamViaBackground = async (
         if (window.aiSystemInterface && !isStopped) {
           window.aiSystemInterface.setProcessingComplete?.(true);
         }
-
+        // Resolve completion promise so caller can proceed
+        try {
+          (completionResolver as any)?.();
+        } catch (e) {
+          // noop
+        }
         (window as any).chrome.runtime.onMessage.removeListener(listener);
         break;
       }
@@ -634,6 +650,11 @@ export const streamViaBackground = async (
         );
         if (window.aiSystemInterface && !isStopped) {
           window.aiSystemInterface.setProcessingComplete?.(true);
+        }
+        try {
+          (completionResolver as any)?.();
+        } catch (e) {
+          // noop
         }
         (window as any).chrome.runtime.onMessage.removeListener(listener);
         break;
@@ -680,6 +701,12 @@ export const streamViaBackground = async (
         window.aiSystemInterface.setProcessingComplete?.(true);
       }
     });
+  // Wait until the background signals completion via the listener
+  await completionPromise;
+  } finally {
+    // Ensure we clear the in-flight flag when this function completes.
+    streamStateManager.setTurnInFlight(false);
+  }
 };
 
 export { fetchStreamingData, USE_FAKE_STREAM, FAKE_STREAM_FILE, FAKE_STREAM_DELAY };

--- a/src/frontend_workspaces/agentic_chat/src/StreamingWorkflow.ts
+++ b/src/frontend_workspaces/agentic_chat/src/StreamingWorkflow.ts
@@ -689,6 +689,12 @@ export const streamViaBackground = async (
           bgResp.message || "Background error"
         );
         window.aiSystemInterface?.setProcessingComplete?.(true);
+        try {
+          (completionResolver as any)?.();
+        } catch (e) {
+          // noop
+        }
+        (window as any).chrome.runtime.onMessage.removeListener(listener);
       }
     })
     .catch((err: any) => {
@@ -699,6 +705,13 @@ export const streamViaBackground = async (
           `An error occurred: ${err.message || "Failed to dispatch query"}`
         );
         window.aiSystemInterface.setProcessingComplete?.(true);
+      }
+      try {
+        (completionResolver as any)?.();
+      } catch (e) {
+        // noop
+      }
+      (window as any).chrome.runtime.onMessage.removeListener(listener);
       }
     });
   // Wait until the background signals completion via the listener

--- a/src/frontend_workspaces/agentic_chat/src/customSendMessage.ts
+++ b/src/frontend_workspaces/agentic_chat/src/customSendMessage.ts
@@ -1,5 +1,6 @@
 import { ChatInstance, CustomSendMessageOptions, GenericItem, MessageRequest, StreamChunk } from "@carbon/ai-chat";
 import { fetchStreamingData, streamViaBackground } from "./StreamingWorkflow";
+import { streamStateManager } from "./StreamManager";
 import { setCardManagerState, resetCardManagerState } from "./renderUserDefinedResponse";
 import { randomUUID } from "./uuid";
 import { RESPONSE_USER_PROFILE } from "./constants";
@@ -135,10 +136,15 @@ async function customStreamMessage(
       },
     });
   } else {
-    switch (request.input.text) {
-      default:
-        await streamViaBackground(instance, request.input.text || "");
-        break;
+    try {
+      streamStateManager.setTurnInFlight(true);
+      switch (request.input.text) {
+        default:
+          await streamViaBackground(instance, request.input.text || "");
+          break;
+      }
+    } finally {
+      streamStateManager.setTurnInFlight(false);
     }
   }
 }
@@ -195,10 +201,15 @@ async function customSendMessage(
     });
     console.log("CardManager host message created");
 
-    switch (request.input.text) {
-      default:
-        await fetchStreamingData(instance, request.input.text || "");
-        break;
+    try {
+      streamStateManager.setTurnInFlight(true);
+      switch (request.input.text) {
+        default:
+          await fetchStreamingData(instance, request.input.text || "");
+          break;
+      }
+    } finally {
+      streamStateManager.setTurnInFlight(false);
     }
   }
 }

--- a/src/frontend_workspaces/agentic_chat/src/floating/stop_button.tsx
+++ b/src/frontend_workspaces/agentic_chat/src/floating/stop_button.tsx
@@ -7,10 +7,10 @@ interface StopButtonProps {
 }
 
 export const StopButton: React.FC<StopButtonProps> = ({ location = "sidebar" }) => {
-  const [isStreaming, setIsStreaming] = useState(() => streamStateManager.getIsStreaming());
+  const [isProcessing, setIsProcessing] = useState(() => streamStateManager.getIsProcessing());
 
   useEffect(() => {
-    const unsubscribe = streamStateManager.subscribe(setIsStreaming);
+    const unsubscribe = streamStateManager.subscribe(setIsProcessing);
     return unsubscribe;
   }, []);
 
@@ -26,7 +26,7 @@ export const StopButton: React.FC<StopButtonProps> = ({ location = "sidebar" }) 
     }
   };
 
-  if (!isStreaming) {
+  if (!isProcessing) {
     return null;
   }
 


### PR DESCRIPTION
Show a processing indicator as soon as the user submits a message (before first tokens arrive) by introducing a `turnInFlight` state in the frontend stream manager.

Changes:
- Added `turnInFlight` and `getIsProcessing()` to `StreamManager.tsx`.
- Stop button uses the combined processing state.
- Set/clear `turnInFlight` in `customSendMessage.ts` and `StreamingWorkflow.ts`.

This reduces pre-token UI blankness and prevents users from retrying while the agent is actually working.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated processing state so the app reliably shows when any turn or stream is active, preventing stale status.
  * Stop button now appears and responds correctly for all in-progress operations, not just active streaming.

* **UX**
  * Background-driven streaming reliably signals completion so UI elements update promptly when work finishes.

* **Documentation**
  * Added a demo recording guide showing how to capture the new turn-in-flight behavior.

* **Tests**
  * Added a Playwright script to record demo videos for QA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->