### PR TITLE
Feature : Improve WatsonX.ai configuration to allow SpaceID and InstanceID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,14 @@ AGENT_SETTING_CONFIG="settings.groq.toml"
 # MODEL_NAME="gpt-4o"
 # AGENT_SETTING_CONFIG="settings.openai.toml"
 
+# WatsonX
+# WATSONX_APIKEY="your-watsonx-api-key"
+# WATSONX_PROJECT_ID="your-project-id"
+# WATSONX_SPACE_ID="your-space-id"   # Alternative to WATSONX_PROJECT_ID
+# WATSONX_URL="https://us-south.ml.cloud.ibm.com"
+# AGENT_SETTING_CONFIG="settings.watsonx.toml"
+# MODEL_NAME="meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+
 # Optional: Langfuse tracing
 # LANGFUSE_SECRET_KEY="sk-lf-xxx"
 # LANGFUSE_PUBLIC_KEY="pk-lf-xxx"

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ AGENT_SETTING_CONFIG="settings.groq.toml"
 # AGENT_SETTING_CONFIG="settings.openai.toml"
 
 # WatsonX
-# WATSONX_APIKEY="your-watsonx-api-key"
+# WATSONX_API_KEY="your-watsonx-api-key"
 # WATSONX_PROJECT_ID="your-project-id"
 # WATSONX_SPACE_ID="your-space-id"   # Alternative to WATSONX_PROJECT_ID
 # WATSONX_URL="https://us-south.ml.cloud.ibm.com"

--- a/README.md
+++ b/README.md
@@ -277,10 +277,6 @@ CUGA supports multiple LLM providers with flexible configuration options. You ca
    MODEL_NAME=meta-llama/llama-4-maverick-17b-128e-instruct-fp8  # Override model for all agents
    ```
 
-**Notes:**
-- Use either [`WATSONX_PROJECT_ID`](README.md:271) or [`WATSONX_SPACE_ID`](README.md:272) depending on how your WatsonX assets are organized.
-- [`WATSONX_SPACE_ID`](README.md:272) is supported as an alternative to [`WATSONX_PROJECT_ID`](README.md:271) in CUGA.
-
 **Default Values:**
 
 - Model: `meta-llama/llama-4-maverick-17b-128e-instruct-fp8`

--- a/README.md
+++ b/README.md
@@ -259,22 +259,27 @@ CUGA supports multiple LLM providers with flexible configuration options. You ca
 **Setup Instructions:**
 
 1. Access [IBM WatsonX](https://www.ibm.com/watsonx)
-2. Create a project and get your credentials:
-   - Project ID
+2. Create a project or space and get your credentials:
+   - Project ID or Space ID
    - API Key
    - Region/URL
 3. Add to your `.env` file:
 
    ```env
    # WatsonX Configuration
-   WATSONX_API_KEY=your-watsonx-api-key
+   WATSONX_APIKEY=your-watsonx-api-key
    WATSONX_PROJECT_ID=your-project-id
+   # WATSONX_SPACE_ID=your-space-id  # Alternative to WATSONX_PROJECT_ID
    WATSONX_URL=https://us-south.ml.cloud.ibm.com  # or your region
    AGENT_SETTING_CONFIG="settings.watsonx.toml"
 
    # Optional override
    MODEL_NAME=meta-llama/llama-4-maverick-17b-128e-instruct-fp8  # Override model for all agents
    ```
+
+**Notes:**
+- Use either [`WATSONX_PROJECT_ID`](README.md:271) or [`WATSONX_SPACE_ID`](README.md:272) depending on how your WatsonX assets are organized.
+- [`WATSONX_SPACE_ID`](README.md:272) is supported as an alternative to [`WATSONX_PROJECT_ID`](README.md:271) in CUGA.
 
 **Default Values:**
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ CUGA supports multiple LLM providers with flexible configuration options. You ca
 
    ```env
    # WatsonX Configuration
-   WATSONX_APIKEY=your-watsonx-api-key
+   WATSONX_API_KEY=your-watsonx-api-key
    WATSONX_PROJECT_ID=your-project-id
    # WATSONX_SPACE_ID=your-space-id  # Alternative to WATSONX_PROJECT_ID
    WATSONX_URL=https://us-south.ml.cloud.ibm.com  # or your region

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -603,7 +603,7 @@ class LLMManager:
             watsonx_params: Dict[str, Any] = {
                 "params": {
                     "temperature": temperature,
-                    "max_tokens": max_tokens,
+                    "max_completion_tokens": max_tokens,
                 },
             }
 

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -601,7 +601,6 @@ class LLMManager:
             )
         elif platform == "watsonx":
             watsonx_params: Dict[str, Any] = {
-                "apikey": os.environ["WATSONX_APIKEY"],
                 "params": {
                     "temperature": temperature,
                     "max_tokens": max_tokens,
@@ -625,9 +624,6 @@ class LLMManager:
                 watsonx_params["space_id"] = os.environ["WATSONX_SPACE_ID"]
             elif os.getenv("WATSONX_PROJECT_ID"):
                 watsonx_params["project_id"] = os.environ["WATSONX_PROJECT_ID"]
-
-            if os.getenv("WATSONX_INSTANCE_ID"):
-                watsonx_params["instance_id"] = os.environ["WATSONX_INSTANCE_ID"]
 
             llm = ChatWatsonx(**watsonx_params)
         elif platform == "rits":

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -620,10 +620,18 @@ class LLMManager:
                 # model id is not used when using a deployment id
                 watsonx_params["model_id"] = model_name
 
-            if os.getenv("WATSONX_SPACE_ID"):
-                watsonx_params["space_id"] = os.environ["WATSONX_SPACE_ID"]
-            elif os.getenv("WATSONX_PROJECT_ID"):
-                watsonx_params["project_id"] = os.environ["WATSONX_PROJECT_ID"]
+            space_id = os.getenv("WATSONX_SPACE_ID")
+            project_id = os.getenv("WATSONX_PROJECT_ID")
+
+            if space_id:
+                watsonx_params["space_id"] = space_id
+            elif project_id:
+                watsonx_params["project_id"] = project_id
+            elif not deployment_id:
+                raise ValueError(
+                    "WatsonX requires WATSONX_SPACE_ID or WATSONX_PROJECT_ID "
+                    "to be set when not using a deployment_id."
+                )
 
             llm = ChatWatsonx(**watsonx_params)
         elif platform == "rits":

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -600,12 +600,36 @@ class LLMManager:
                 temperature=temperature,
             )
         elif platform == "watsonx":
-            llm = ChatWatsonx(
-                model_id=model_name,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                project_id=os.environ['WATSONX_PROJECT_ID'],
-            )
+            watsonx_params: Dict[str, Any] = {
+                "apikey": os.environ["WATSONX_APIKEY"],
+                "params": {
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                },
+            }
+
+            watsonx_url = model_settings.get("url")
+            if watsonx_url:
+                watsonx_params["url"] = watsonx_url
+
+            deployment_id = model_settings.get("deployment_id")
+            if deployment_id:
+                # Deployment id is model-specific configuration representating
+                # the id of a deployed model in production
+                watsonx_params["deployment_id"] = deployment_id
+            else:
+                # model id is not used when using a deployment id
+                watsonx_params["model_id"] = model_name
+
+            if os.getenv("WATSONX_SPACE_ID"):
+                watsonx_params["space_id"] = os.environ["WATSONX_SPACE_ID"]
+            elif os.getenv("WATSONX_PROJECT_ID"):
+                watsonx_params["project_id"] = os.environ["WATSONX_PROJECT_ID"]
+
+            if os.getenv("WATSONX_INSTANCE_ID"):
+                watsonx_params["instance_id"] = os.environ["WATSONX_INSTANCE_ID"]
+
+            llm = ChatWatsonx(**watsonx_params)
         elif platform == "rits":
             apikey_name = model_settings.get("apikey_name")
             api_key = _normalize_secret(resolve_secret(apikey_name)) if apikey_name else None

--- a/tests/unit/test_llm_override.py
+++ b/tests/unit/test_llm_override.py
@@ -312,5 +312,3 @@ class TestLLMOverrideMechanism:
         assert "url" not in kwargs
         assert kwargs["deployment_id"] == "deployment-123"
         assert "model_id" not in kwargs
-
-

--- a/tests/unit/test_llm_override.py
+++ b/tests/unit/test_llm_override.py
@@ -231,16 +231,41 @@ class TestLLMOverrideMechanism:
 
         kwargs = mock_chat_watsonx.call_args.kwargs
         assert "url" not in kwargs
-        assert kwargs["apikey"] == "wx-api-key"
         assert kwargs["model_id"] == "configured-model-name"
         assert kwargs["project_id"] == "project-123"
         assert kwargs["params"]["temperature"] == BASE_MODEL_SETTINGS["temperature"]
         assert kwargs["params"]["max_tokens"] == BASE_MODEL_SETTINGS["max_tokens"]
 
+    def test_watsonx_ignores_env_url_and_uses_only_model_settings_url(self):
+        """WatsonX url should come from model settings, not WATSONX_URL."""
+        env = {
+            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_URL": "https://env.watsonx.ai",
+            "WATSONX_PROJECT_ID": "project-123",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("cuga.backend.llm.models.ChatWatsonx") as mock_chat_watsonx:
+                mock_chat_watsonx.return_value = object()
+                mgr = LLMManager()
+                settings_for_watsonx = {
+                    **BASE_MODEL_SETTINGS,
+                    "platform": "watsonx",
+                    "model": "configured-model-name",
+                }
+
+                mgr.get_model(settings_for_watsonx)
+
+        kwargs = mock_chat_watsonx.call_args.kwargs
+        assert "url" not in kwargs
+        assert kwargs["model_id"] == "configured-model-name"
+        assert kwargs["project_id"] == "project-123"
+
     def test_watsonx_uses_model_settings_url_when_set(self):
         """When url is provided in model settings, it should be forwarded to ChatWatsonx."""
         env = {
             "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_URL": "https://env.watsonx.ai",
             "WATSONX_PROJECT_ID": "project-123",
         }
 
@@ -259,7 +284,6 @@ class TestLLMOverrideMechanism:
 
         kwargs = mock_chat_watsonx.call_args.kwargs
         assert kwargs["url"] == "https://model-settings.watsonx.ai"
-        assert kwargs["apikey"] == "wx-api-key"
         assert kwargs["model_id"] == "configured-model-name"
         assert kwargs["project_id"] == "project-123"
 
@@ -285,32 +309,8 @@ class TestLLMOverrideMechanism:
                 mgr.get_model(settings_for_watsonx)
 
         kwargs = mock_chat_watsonx.call_args.kwargs
-        assert kwargs["url"] == "https://example.watsonx.ai"
+        assert "url" not in kwargs
         assert kwargs["deployment_id"] == "deployment-123"
         assert "model_id" not in kwargs
 
-    def test_watsonx_prefers_space_id_and_includes_instance_id(self):
-        """space_id should win over project_id, and instance_id should be forwarded when present."""
-        env = {
-            "WATSONX_APIKEY": "wx-api-key",
-            "WATSONX_SPACE_ID": "space-123",
-            "WATSONX_PROJECT_ID": "project-123",
-            "WATSONX_INSTANCE_ID": "instance-123",
-        }
 
-        with patch.dict(os.environ, env, clear=True):
-            with patch("cuga.backend.llm.models.ChatWatsonx") as mock_chat_watsonx:
-                mock_chat_watsonx.return_value = object()
-                mgr = LLMManager()
-                settings_for_watsonx = {
-                    **BASE_MODEL_SETTINGS,
-                    "platform": "watsonx",
-                    "model": "fallback-model",
-                }
-
-                mgr.get_model(settings_for_watsonx)
-
-        kwargs = mock_chat_watsonx.call_args.kwargs
-        assert kwargs["space_id"] == "space-123"
-        assert "project_id" not in kwargs
-        assert kwargs["instance_id"] == "instance-123"

--- a/tests/unit/test_llm_override.py
+++ b/tests/unit/test_llm_override.py
@@ -4,6 +4,9 @@ is picked up by LLMManager.get_model() at call-time, and that a bad API key
 produces an authentication/connection error rather than silently using defaults.
 """
 
+import os
+from unittest.mock import patch
+
 import pytest
 
 from cuga.backend.llm.models import (
@@ -47,7 +50,7 @@ class TestLLMOverrideMechanism:
 
         mgr = LLMManager()
         with pytest.raises(openai.OpenAIError, match="api_key"):
-            mgr.get_model(_ModelSettingsWrap(BASE_MODEL_SETTINGS))
+            mgr.get_model(BASE_MODEL_SETTINGS)
 
     def test_override_is_applied(self):
         """Override fields are merged into the resolved model settings."""
@@ -207,3 +210,108 @@ class TestLLMOverrideMechanism:
             kw in error_lower
             for kw in ("auth", "api key", "invalid", "401", "403", "incorrect", "connection")
         ), f"Expected an auth/connection error, got: {error_msg}"
+
+    def test_watsonx_uses_default_endpoint_when_url_unset(self):
+        """When WATSONX_URL is absent, ChatWatsonx should rely on its default endpoint."""
+        env = {
+            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_PROJECT_ID": "project-123",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("cuga.backend.llm.models.ChatWatsonx") as mock_chat_watsonx:
+                mock_chat_watsonx.return_value = object()
+                mgr = LLMManager()
+                settings_for_watsonx = {
+                    **BASE_MODEL_SETTINGS,
+                    "platform": "watsonx",
+                    "model": "configured-model-name",
+                }
+
+                mgr.get_model(settings_for_watsonx)
+
+        kwargs = mock_chat_watsonx.call_args.kwargs
+        assert "url" not in kwargs
+        assert kwargs["apikey"] == "wx-api-key"
+        assert kwargs["model_id"] == "configured-model-name"
+        assert kwargs["project_id"] == "project-123"
+        assert kwargs["params"]["temperature"] == BASE_MODEL_SETTINGS["temperature"]
+        assert kwargs["params"]["max_tokens"] == BASE_MODEL_SETTINGS["max_tokens"]
+
+    def test_watsonx_uses_model_settings_url_when_set(self):
+        """When url is provided in model settings, it should be forwarded to ChatWatsonx."""
+        env = {
+            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_PROJECT_ID": "project-123",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("cuga.backend.llm.models.ChatWatsonx") as mock_chat_watsonx:
+                mock_chat_watsonx.return_value = object()
+                mgr = LLMManager()
+                settings_for_watsonx = {
+                    **BASE_MODEL_SETTINGS,
+                    "platform": "watsonx",
+                    "model": "configured-model-name",
+                    "url": "https://model-settings.watsonx.ai",
+                }
+
+                mgr.get_model(settings_for_watsonx)
+
+        kwargs = mock_chat_watsonx.call_args.kwargs
+        assert kwargs["url"] == "https://model-settings.watsonx.ai"
+        assert kwargs["apikey"] == "wx-api-key"
+        assert kwargs["model_id"] == "configured-model-name"
+        assert kwargs["project_id"] == "project-123"
+
+    def test_watsonx_uses_model_settings_deployment_id_over_model_id(self):
+        """deployment_id should come from model settings and replace model_id when provided."""
+        env = {
+            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_URL": "https://example.watsonx.ai",
+            "WATSONX_PROJECT_ID": "project-123",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("cuga.backend.llm.models.ChatWatsonx") as mock_chat_watsonx:
+                mock_chat_watsonx.return_value = object()
+                mgr = LLMManager()
+                settings_for_watsonx = {
+                    **BASE_MODEL_SETTINGS,
+                    "platform": "watsonx",
+                    "model": "configured-model-name",
+                    "deployment_id": "deployment-123",
+                }
+
+                mgr.get_model(settings_for_watsonx)
+
+        kwargs = mock_chat_watsonx.call_args.kwargs
+        assert kwargs["url"] == "https://example.watsonx.ai"
+        assert kwargs["deployment_id"] == "deployment-123"
+        assert "model_id" not in kwargs
+
+    def test_watsonx_prefers_space_id_and_includes_instance_id(self):
+        """space_id should win over project_id, and instance_id should be forwarded when present."""
+        env = {
+            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_SPACE_ID": "space-123",
+            "WATSONX_PROJECT_ID": "project-123",
+            "WATSONX_INSTANCE_ID": "instance-123",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("cuga.backend.llm.models.ChatWatsonx") as mock_chat_watsonx:
+                mock_chat_watsonx.return_value = object()
+                mgr = LLMManager()
+                settings_for_watsonx = {
+                    **BASE_MODEL_SETTINGS,
+                    "platform": "watsonx",
+                    "model": "fallback-model",
+                }
+
+                mgr.get_model(settings_for_watsonx)
+
+        kwargs = mock_chat_watsonx.call_args.kwargs
+        assert kwargs["space_id"] == "space-123"
+        assert "project_id" not in kwargs
+        assert kwargs["instance_id"] == "instance-123"

--- a/tests/unit/test_llm_override.py
+++ b/tests/unit/test_llm_override.py
@@ -213,7 +213,7 @@ class TestLLMOverrideMechanism:
     def test_watsonx_uses_default_endpoint_when_url_unset(self):
         """When WATSONX_URL is absent, ChatWatsonx should rely on its default endpoint."""
         env = {
-            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_API_KEY": "wx-api-key",
             "WATSONX_PROJECT_ID": "project-123",
         }
 
@@ -239,7 +239,7 @@ class TestLLMOverrideMechanism:
     def test_watsonx_ignores_env_url_and_uses_only_model_settings_url(self):
         """WatsonX url should come from model settings, not WATSONX_URL."""
         env = {
-            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_API_KEY": "wx-api-key",
             "WATSONX_URL": "https://env.watsonx.ai",
             "WATSONX_PROJECT_ID": "project-123",
         }
@@ -264,7 +264,7 @@ class TestLLMOverrideMechanism:
     def test_watsonx_uses_model_settings_url_when_set(self):
         """When url is provided in model settings, it should be forwarded to ChatWatsonx."""
         env = {
-            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_API_KEY": "wx-api-key",
             "WATSONX_URL": "https://env.watsonx.ai",
             "WATSONX_PROJECT_ID": "project-123",
         }
@@ -290,7 +290,7 @@ class TestLLMOverrideMechanism:
     def test_watsonx_uses_model_settings_deployment_id_over_model_id(self):
         """deployment_id should come from model settings and replace model_id when provided."""
         env = {
-            "WATSONX_APIKEY": "wx-api-key",
+            "WATSONX_API_KEY": "wx-api-key",
             "WATSONX_URL": "https://example.watsonx.ai",
             "WATSONX_PROJECT_ID": "project-123",
         }

--- a/tests/unit/test_llm_override.py
+++ b/tests/unit/test_llm_override.py
@@ -11,7 +11,6 @@ import pytest
 
 from cuga.backend.llm.models import (
     LLMManager,
-    _ModelSettingsWrap,
     get_current_llm_override,
     set_current_llm_override,
 )


### PR DESCRIPTION
see https://github.com/cuga-project/cuga-agent/issues/184

Added support for WatsonX.ai SpaceID as well as InstanceID for dedicated WatsonX deployment. 
Added some tests around this. 
Also support changing WatsonX.ai URL in the LLM config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for WatsonX space configuration as an alternative to project-based setup.

* **Documentation**
  * Clarified README to instruct creating a project or space and updated credential guidance.

* **Chores**
  * Added WatsonX environment variable placeholders to the example config.

* **Bug Fixes**
  * Model selection now prefers deployment ID, uses model-provided endpoints over env values, and errors when no project/space/deployment is set.

* **Tests**
  * Added and updated tests covering WatsonX URL, deployment precedence, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->