### PR TITLE
Fix missing authentication when the transport type is SSE'

### DIFF
--- a/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
@@ -22,7 +22,7 @@ except ImportError:
 from cuga.backend.tools_env.registry.config.config_loader import Auth
 from cuga.backend.tools_env.registry.config.config_loader import ServiceConfig, Service
 from cuga.backend.tools_env.registry.mcp_manager.openapi_parser import SimpleOpenAPIParser
-from cuga.backend.tools_env.registry.mcp_manager.adapter import new_mcp_from_custom_parser
+from cuga.backend.tools_env.registry.mcp_manager.adapter import new_mcp_from_custom_parser, apply_authentication
 import threading
 from collections import defaultdict
 from urllib.parse import urlparse
@@ -928,7 +928,14 @@ class MCPManager:
                 raise Exception(f"SSE transport requires 'url' for {name}")
 
             print(f"Connecting to MCP server '{name}' via SSE at {config.url}")
-            return SSETransport(url=config.url)
+
+            # Build headers from auth config if available
+            headers = {}
+            if config.auth:
+                query_params = {}
+                apply_authentication(config.auth, headers, query_params)
+
+            return SSETransport(url=config.url, headers=headers if headers else None)
 
         elif transport_type == 'http':
             if not StreamableHttpTransport:
@@ -943,8 +950,6 @@ class MCPManager:
             # Build headers from auth config if available
             headers = {}
             if config.auth:
-                from cuga.backend.tools_env.registry.mcp_manager.adapter import apply_authentication
-
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
 


### PR DESCRIPTION
Fixing  Authentication for MCP servers with SSE (see https://github.com/cuga-project/cuga-agent/issues/191)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication handling for Server-Sent Events (SSE) transport connections. Authentication headers and parameters configured for MCP servers are now properly applied during transport initialization, ensuring secure communication is established as configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->