### PR TITLE
fix(context): resolve WatsonX context window overflow (issue #189)

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/task_decomposition_planning/analyze_task.py
+++ b/src/cuga/backend/cuga_graph/nodes/task_decomposition_planning/analyze_task.py
@@ -243,8 +243,8 @@ class TaskAnalyzer(BaseNode):
         # if not settings.features.chat:
         # state.variables_manager.reset()
 
-        # Apply sliding window to message history at the start of task analysis
-        state.apply_message_sliding_window()
+        # Apply context management to message history at the start of task analysis
+        await state.manage_message_context()
 
         # Check supervisor mode first (takes priority over fast mode)
         if await TaskAnalyzer.should_use_supervisor_mode(state):

--- a/src/cuga/sdk_core/tests/test_context_summarization_sdk.py
+++ b/src/cuga/sdk_core/tests/test_context_summarization_sdk.py
@@ -96,16 +96,11 @@ class TestSDKContextSummarization:
         import os
         from cuga.config import settings
 
-        # Save original settings and check if env vars existed
-        original_enabled = settings.context_summarization.enabled
-        original_fraction = settings.context_summarization.trigger_fraction
-        original_keep = settings.context_summarization.keep_last_n_messages
-        
         # Track whether env vars were originally set
         env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
         env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
         env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
-        
+
         # Save original env var values if they existed
         original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
         original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
@@ -152,17 +147,17 @@ class TestSDKContextSummarization:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
-            
+
             if env_fraction_existed and original_env_fraction is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
-            
+
             if env_keep_existed and original_env_keep is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
-            
+
             settings.reload()
 
     @pytest.mark.asyncio
@@ -182,15 +177,11 @@ class TestSDKContextSummarization:
         import os
         from cuga.config import settings
 
-        original_enabled = settings.context_summarization.enabled
-        original_fraction = settings.context_summarization.trigger_fraction
-        original_keep = settings.context_summarization.keep_last_n_messages
-        
         # Track whether env vars were originally set
         env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
         env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
         env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
-        
+
         # Save original env var values if they existed
         original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
         original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
@@ -236,17 +227,17 @@ class TestSDKContextSummarization:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
-            
+
             if env_fraction_existed and original_env_fraction is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
-            
+
             if env_keep_existed and original_env_keep is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
-            
+
             settings.reload()
 
     def _generate_large_context_history(self):
@@ -370,15 +361,11 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         import os
         from cuga.config import settings
 
-        original_enabled = settings.context_summarization.enabled
-        original_fraction = settings.context_summarization.trigger_fraction
-        original_keep = settings.context_summarization.keep_last_n_messages
-        
         # Track whether env vars were originally set
         env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
         env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
         env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
-        
+
         # Save original env var values if they existed
         original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
         original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
@@ -583,17 +570,17 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
-            
+
             if env_fraction_existed and original_env_fraction is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
-            
+
             if env_keep_existed and original_env_keep is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
-            
+
             settings.reload()
 
     @pytest.mark.asyncio
@@ -612,15 +599,11 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         from cuga.config import settings
         from langchain_core.messages import HumanMessage, AIMessage
 
-        original_enabled = settings.context_summarization.enabled
-        original_fraction = settings.context_summarization.trigger_fraction
-        original_keep = settings.context_summarization.keep_last_n_messages
-        
         # Track whether env vars were originally set
         env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
         env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
         env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
-        
+
         # Save original env var values if they existed
         original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
         original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
@@ -773,17 +756,17 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
-            
+
             if env_fraction_existed and original_env_fraction is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
-            
+
             if env_keep_existed and original_env_keep is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
-            
+
             settings.reload()
 
     @pytest.mark.asyncio
@@ -798,11 +781,9 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         import os
         from cuga.config import settings
 
-        original_enabled = settings.context_summarization.enabled
-        
         # Track whether env var was originally set
         env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
-        
+
         # Save original env var value if it existed
         original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
 
@@ -833,7 +814,7 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
-            
+
             settings.reload()
 
     @pytest.mark.asyncio
@@ -851,16 +832,11 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         if not json_path.exists():
             pytest.skip(f"conversation_messages.json not found at {json_path}")
 
-        # Save original settings
-        original_enabled = settings.context_summarization.enabled
-        original_fraction = settings.context_summarization.trigger_fraction
-        original_keep = settings.context_summarization.keep_last_n_messages
-        
         # Track whether env vars were originally set
         env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
         env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
         env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
-        
+
         # Save original env var values if they existed
         original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
         original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
@@ -980,17 +956,17 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
-            
+
             if env_fraction_existed and original_env_fraction is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
-            
+
             if env_keep_existed and original_env_keep is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
-            
+
             settings.reload()
 
     @pytest.mark.asyncio
@@ -1005,16 +981,11 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         import os
         from cuga.config import settings
 
-        # Save original settings
-        original_fraction = settings.context_summarization.trigger_fraction
-        original_keep = settings.context_summarization.keep_last_n_messages
-        original_enabled = settings.context_summarization.enabled
-        
         # Track whether env vars were originally set
         env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
         env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
         env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
-        
+
         # Save original env var values if they existed
         original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
         original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
@@ -1128,17 +1099,17 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
-            
+
             if env_fraction_existed and original_env_fraction is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
-            
+
             if env_keep_existed and original_env_keep is not None:
                 os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
             else:
                 os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
-            
+
             settings.reload()
 
     @pytest.mark.asyncio

--- a/src/cuga/sdk_core/tests/test_context_summarization_sdk.py
+++ b/src/cuga/sdk_core/tests/test_context_summarization_sdk.py
@@ -96,10 +96,20 @@ class TestSDKContextSummarization:
         import os
         from cuga.config import settings
 
-        # Save original settings
+        # Save original settings and check if env vars existed
         original_enabled = settings.context_summarization.enabled
         original_fraction = settings.context_summarization.trigger_fraction
         original_keep = settings.context_summarization.keep_last_n_messages
+        
+        # Track whether env vars were originally set
+        env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
+        env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
+        env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
+        
+        # Save original env var values if they existed
+        original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
+        original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
+        original_env_keep = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES")
 
         try:
             # Configure for aggressive summarization using trigger_fraction
@@ -137,10 +147,22 @@ class TestSDKContextSummarization:
             )
 
         finally:
-            # Restore original settings
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled).lower()
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
+            # Restore original settings - remove env vars if they didn't exist, otherwise restore values
+            if env_enabled_existed and original_env_enabled is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
+            
+            if env_fraction_existed and original_env_fraction is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
+            
+            if env_keep_existed and original_env_keep is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
+            
             settings.reload()
 
     @pytest.mark.asyncio
@@ -163,6 +185,16 @@ class TestSDKContextSummarization:
         original_enabled = settings.context_summarization.enabled
         original_fraction = settings.context_summarization.trigger_fraction
         original_keep = settings.context_summarization.keep_last_n_messages
+        
+        # Track whether env vars were originally set
+        env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
+        env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
+        env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
+        
+        # Save original env var values if they existed
+        original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
+        original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
+        original_env_keep = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES")
 
         try:
             # Configure for aggressive summarization
@@ -199,10 +231,22 @@ class TestSDKContextSummarization:
             # as that's non-deterministic and causes flaky tests
 
         finally:
-            # Restore original settings
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled).lower()
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
+            # Restore original settings - remove env vars if they didn't exist, otherwise restore values
+            if env_enabled_existed and original_env_enabled is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
+            
+            if env_fraction_existed and original_env_fraction is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
+            
+            if env_keep_existed and original_env_keep is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
+            
             settings.reload()
 
     def _generate_large_context_history(self):
@@ -329,6 +373,16 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         original_enabled = settings.context_summarization.enabled
         original_fraction = settings.context_summarization.trigger_fraction
         original_keep = settings.context_summarization.keep_last_n_messages
+        
+        # Track whether env vars were originally set
+        env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
+        env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
+        env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
+        
+        # Save original env var values if they existed
+        original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
+        original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
+        original_env_keep = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES")
 
         try:
             # Configure for 75% threshold summarization
@@ -524,10 +578,22 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
                 print(f"\nLangfuse trace: {langfuse_handler.get_trace_url()}")
 
         finally:
-            # Restore original settings
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled).lower()
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
+            # Restore original settings - remove env vars if they didn't exist, otherwise restore values
+            if env_enabled_existed and original_env_enabled is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
+            
+            if env_fraction_existed and original_env_fraction is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
+            
+            if env_keep_existed and original_env_keep is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
+            
             settings.reload()
 
     @pytest.mark.asyncio
@@ -549,6 +615,16 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         original_enabled = settings.context_summarization.enabled
         original_fraction = settings.context_summarization.trigger_fraction
         original_keep = settings.context_summarization.keep_last_n_messages
+        
+        # Track whether env vars were originally set
+        env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
+        env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
+        env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
+        
+        # Save original env var values if they existed
+        original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
+        original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
+        original_env_keep = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES")
 
         try:
             # Configure for moderate summarization (50% threshold)
@@ -692,10 +768,22 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
             # It's okay if it says it doesn't know or doesn't have that information
 
         finally:
-            # Restore original settings
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled).lower()
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
+            # Restore original settings - remove env vars if they didn't exist, otherwise restore values
+            if env_enabled_existed and original_env_enabled is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
+            
+            if env_fraction_existed and original_env_fraction is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
+            
+            if env_keep_existed and original_env_keep is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
+            
             settings.reload()
 
     @pytest.mark.asyncio
@@ -711,6 +799,12 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         from cuga.config import settings
 
         original_enabled = settings.context_summarization.enabled
+        
+        # Track whether env var was originally set
+        env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
+        
+        # Save original env var value if it existed
+        original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
 
         try:
             # Enable context summarization
@@ -734,8 +828,12 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
             )
 
         finally:
-            # Restore original settings
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled).lower()
+            # Restore original settings - remove env var if it didn't exist, otherwise restore value
+            if env_enabled_existed and original_env_enabled is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
+            
             settings.reload()
 
     @pytest.mark.asyncio
@@ -757,6 +855,16 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         original_enabled = settings.context_summarization.enabled
         original_fraction = settings.context_summarization.trigger_fraction
         original_keep = settings.context_summarization.keep_last_n_messages
+        
+        # Track whether env vars were originally set
+        env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
+        env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
+        env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
+        
+        # Save original env var values if they existed
+        original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
+        original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
+        original_env_keep = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES")
 
         try:
             # Configure for 75% threshold summarization (same as test_invoke_with_large_context_triggers_summarization)
@@ -867,10 +975,22 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
                 print(f"\nLangfuse trace: {langfuse_handler.get_trace_url()}")
 
         finally:
-            # Restore original settings
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled).lower()
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
+            # Restore original settings - remove env vars if they didn't exist, otherwise restore values
+            if env_enabled_existed and original_env_enabled is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
+            
+            if env_fraction_existed and original_env_fraction is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
+            
+            if env_keep_existed and original_env_keep is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
+            
             settings.reload()
 
     @pytest.mark.asyncio
@@ -889,6 +1009,16 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         original_fraction = settings.context_summarization.trigger_fraction
         original_keep = settings.context_summarization.keep_last_n_messages
         original_enabled = settings.context_summarization.enabled
+        
+        # Track whether env vars were originally set
+        env_enabled_existed = "DYNACONF_CONTEXT_SUMMARIZATION__ENABLED" in os.environ
+        env_fraction_existed = "DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION" in os.environ
+        env_keep_existed = "DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES" in os.environ
+        
+        # Save original env var values if they existed
+        original_env_enabled = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED")
+        original_env_fraction = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION")
+        original_env_keep = os.environ.get("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES")
 
         try:
             # Configure moderate summarization settings
@@ -993,10 +1123,22 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
             print(f"   - Summary preview: {summary_content[:200]}...")
 
         finally:
-            # Restore original settings
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled)
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
-            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
+            # Restore original settings - remove env vars if they didn't exist, otherwise restore values
+            if env_enabled_existed and original_env_enabled is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = original_env_enabled
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__ENABLED", None)
+            
+            if env_fraction_existed and original_env_fraction is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = original_env_fraction
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION", None)
+            
+            if env_keep_existed and original_env_keep is not None:
+                os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = original_env_keep
+            else:
+                os.environ.pop("DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES", None)
+            
             settings.reload()
 
     @pytest.mark.asyncio

--- a/src/cuga/sdk_core/tests/test_context_summarization_sdk.py
+++ b/src/cuga/sdk_core/tests/test_context_summarization_sdk.py
@@ -6,6 +6,7 @@ with CugaAgent.invoke() and CugaAgent.stream().
 """
 
 import json
+import os
 from pathlib import Path
 
 import uuid
@@ -994,6 +995,73 @@ ENTITY_2000: risk 0.67 -> 0.95 (escalation required)""",
         finally:
             # Restore original settings
             os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled)
+            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
+            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
+            settings.reload()
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("WATSONX_PROJECT_ID"),
+        reason="WatsonX credentials not configured (WATSONX_PROJECT_ID not set)",
+    )
+    async def test_invoke_with_large_context_triggers_summarization_watsonx(self):
+        """
+        WatsonX-specific regression test for issue #189.
+
+        Verifies that a large conversation (~96k tokens) against a WatsonX model:
+        1. Completes without HTTP 400 (the reported failure mode)
+        2. Triggers context summarization (message count is reduced)
+
+        Uses _generate_large_context_history() — same helper as the OpenAI variant.
+        Skips if WATSONX_PROJECT_ID is not set.
+        """
+        import os
+        from cuga.config import settings
+
+        original_config = os.environ.get("AGENT_SETTING_CONFIG")
+        original_enabled = settings.context_summarization.enabled
+        original_fraction = settings.context_summarization.trigger_fraction
+        original_keep = settings.context_summarization.keep_last_n_messages
+
+        try:
+            os.environ["AGENT_SETTING_CONFIG"] = "settings.watsonx.toml"
+            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = "true"
+            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = "0.75"
+            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = "5"
+            settings.reload()
+
+            agent = CugaAgent(tools=[])
+            thread_id = str(uuid.uuid4())
+
+            large_history = self._generate_large_context_history()
+            print(f"\n=== WatsonX: Loading {len(large_history)} messages (~96k tokens) ===")
+
+            # Must complete without HTTP 400 (regression for issue #189)
+            result = await agent.invoke(large_history, thread_id=thread_id)
+            assert result is not None
+            assert result.error is None, f"Expected no error, got: {result.error}"
+            print("✓ No HTTP 400 error")
+
+            # Verify summarization fired (message count reduced)
+            config = {"configurable": {"thread_id": thread_id}}
+            checkpoint = agent.graph.checkpointer.get(config)
+            assert checkpoint is not None, "Failed to get checkpoint"
+            state_dict = checkpoint.get("channel_values", {})
+            message_count = len(state_dict.get("chat_messages", []))
+
+            max_expected = max(35, len(large_history) // 3)
+            assert message_count < max_expected, (
+                f"Summarization should have reduced message count. "
+                f"Input: {len(large_history)}, After: {message_count}, Max expected: {max_expected}"
+            )
+            print(f"✓ Summarization fired: {len(large_history)} → {message_count} messages")
+
+        finally:
+            if original_config:
+                os.environ["AGENT_SETTING_CONFIG"] = original_config
+            elif "AGENT_SETTING_CONFIG" in os.environ:
+                del os.environ["AGENT_SETTING_CONFIG"]
+            os.environ["DYNACONF_CONTEXT_SUMMARIZATION__ENABLED"] = str(original_enabled).lower()
             os.environ["DYNACONF_CONTEXT_SUMMARIZATION__TRIGGER_FRACTION"] = str(original_fraction)
             os.environ["DYNACONF_CONTEXT_SUMMARIZATION__KEEP_LAST_N_MESSAGES"] = str(original_keep)
             settings.reload()

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -187,7 +187,7 @@ trm_url = 8080
 oak_health_api = 8090  # cuga-oak-health OpenAPI (demo_health)
 
 [context_summarization]
-enabled = false  # Enable intelligent context summarization
+enabled = true  # Enable intelligent context summarization
 keep_last_n_messages = 10  # Number of recent messages to preserve unsummarized
 trim_tokens_to_summarize = 500  # Target token count for generated summaries
 summarization_model = "gpt-4o-mini"  # Model to use for generating summaries (fast and cost-effective)


### PR DESCRIPTION
## Bug fix

Fixes #189

### Summary

This PR resolves context window overflow issues when using WatsonX models with large conversation histories (~96k tokens). The issue manifested as HTTP 400 errors when the conversation context exceeded the model's token limit.

**Changes:**
1. **Enabled context summarization by default** - Set  in settings.toml to activate intelligent context management for all deployments
2. **Migrated to async context management** - Replaced synchronous  with async  in task analyzer, enabling intelligent summarization instead of simple truncation
3. **Added WatsonX regression test** - Created  to verify large conversations complete without errors and that summarization triggers correctly

**Root Cause:**
The previous sliding window approach simply truncated old messages without considering token limits or model-specific context windows, causing WatsonX models to receive contexts exceeding their limits.

**Solution:**
Intelligent context summarization that:
- Monitors token usage against model context windows
- Triggers at 75% capacity (configurable)
- Preserves recent messages while summarizing older context
- Reduces token count while maintaining conversation continuity

### Testing
- [x] Verified fix locally; tests pass
- [x] Added WatsonX-specific regression test
- [x] Confirmed summarization triggers with large contexts
- [x] Verified no HTTP 400 errors with ~96k token conversations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Task analysis now uses asynchronous message context management for more reliable handling of conversation history.
  * Context summarization is enabled by default to intelligently compress and manage conversation history.

* **Tests**
  * Added a WatsonX-specific regression test that verifies summarization triggers with a large conversation history and restores configuration after running.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuga-project/cuga-agent/pull/207)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->