### PR TITLE
fix(security): bump playwright >=1.59.0 to close CVE-2025-9611, CVE-2025-59288

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "fastapi[standard]",
     "langfuse",
     "dynaconf>=3.2.13",
-    "playwright>=1.49.0",
+    "playwright>=1.59.0",  # CVE-2025-9611 (MCP origin/DNS rebinding), CVE-2025-59288 (browser download SSL)
     "browsergym-core==0.13.0",
     "python-dotenv",
     "loguru",

--- a/uv.lock
+++ b/uv.lock
@@ -1091,7 +1091,7 @@ requires-dist = [
     { name = "opensandbox", marker = "extra == 'opensandbox'" },
     { name = "opensandbox-code-interpreter", marker = "extra == 'opensandbox'" },
     { name = "pgvector", specifier = ">=0.4.2" },
-    { name = "playwright", specifier = ">=1.49.0" },
+    { name = "playwright", specifier = ">=1.59.0" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },


### PR DESCRIPTION
## Summary
Closes #210. Tightens the lower bound on `playwright` from `>=1.49.0` to `>=1.59.0`. `uv.lock` already resolved to 1.59.0, so this is a defensive floor bump (one-line lock diff).

- **CVE-2025-9611** (HIGH, CVSS 7.2) — MCP server fails to validate the `Origin` header, enabling DNS rebinding. Fixed in 1.56.0.
- **CVE-2025-59288** (MEDIUM, CVSS 5.3) — Browser downloads do not verify SSL cert authenticity, enabling adjacent-network spoofing. Fixed in 1.55.1.

### Out of scope (deferred)
While triaging the Dependabot alerts, I evaluated bundling related fixes in this PR:

- `langchain-openai>=1.1.14` (CVE-2026-41488, DNS rebinding SSRF — same family as CVE-2025-9611): **blocked** — requires `openai>=2.26.0`, but `litellm==1.83.14` pins `openai==2.24.0`. Revisit when `litellm` 1.85.x stabilizes.
- `langchain-core>=1.3.3` (CVE-2026-44843, unsafe deserialization): tried, dropped after seeing churn in the lock; can be a follow-up after the failing policy tests below are resolved.
- `urllib3>=2.7.0`, `authlib>=1.6.11`: deferred to a separate constraint-bump PR to keep this one focused.

## Automated test plan (run locally, mirrors CI)
- [x] `uv sync --all-extras --dev` — clean resolve, `uv.lock` diff is one line
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — 482 files already formatted
- [x] `uv run playwright install --with-deps chromium` — chromium-headless-shell v1217 downloaded
- [x] `bash src/scripts/run_tests.sh` — ran unit + integration + policy e2e (see flaky-tests note below)

### Test results
| Stage | Result |
|---|---|
| Ruff check / format | ✅ pass |
| Registry unit tests (`src/cuga/backend/tools_env/registry/tests/`) | ✅ pass |
| Variables-manager tests | ✅ pass |
| CugaLite executor tests (with e2b extra) | ✅ pass |
| Knowledge tests (`tests/unit/test_knowledge_*`, `tests/integration/test_knowledge_integration.py`) | ✅ pass |
| SDK integration (`src/cuga/sdk_core/tests/`) | ✅ pass |
| Policy e2e (`src/cuga/backend/cuga_graph/policy/tests/`) | ⚠️ 48 passed, 9 failed — **pre-existing on `main`, not introduced by this PR** |
| Manager API system tests | ⏭️ not reached (`run_tests.sh` exits at first failed pytest stage) |
| Stability suite (`run_stability_tests.py`) | ⏭️ not reached |

### Flaky tests note (per CONTRIBUTING.md §123)
The 9 policy-e2e failures were reproduced with a clean revert to `main`'s `uv.lock` (only the `playwright` constraint changed), so they are unrelated to this PR. Failure patterns are `RuntimeError: Event loop is closed` during `_resolve_nl_trigger_conflicts` LLM calls and downstream `AttributeError: 'NoneType' object has no attribute 'matched_policy_index'` / `AssertionError`. The failing tests do not touch playwright:

```
test_e2e_healthcare_family_claims.py::test_healthcare_family_claims_e2e_with_tools
test_e2e_intent_guard.py::test_e2e_intent_guard_blocks_in_cuga_lite
test_e2e_output_formatter.py::test_e2e_output_formatter_with_natural_language_trigger
test_e2e_output_formatter.py::test_e2e_output_formatter_json_schema_structured_output
test_e2e_output_formatter.py::test_e2e_output_formatter_sdk_integration
test_e2e_playbook_guidance.py::test_e2e_playbook_guides_execution_in_cuga_lite
test_e2e_playbook_refinement.py::test_e2e_playbook_refinement_with_progress
test_e2e_tool_enrichment.py::test_tool_guide_with_keyword_trigger
test_nl_trigger_conflict_resolution.py::test_nl_trigger_conflict_playbook_vs_intent_guard
```

Recommend a separate triage issue for the policy-test asyncio teardown.

## Manual test plan (from issue #210)
**Prereqs:** branch checked out, `.env` populated, ports 7860/8001 free.

1. **Start services** — `uv run cuga start demo_docs`
   ✅ Console panel "Demo Docs (docs-only mode)" with Docs MCP `…/sse`, Registry `:8001`, Demo `:7860`. No tracebacks.
2. **MCP connectivity** (CVE-2025-9611 regression check)
   - `curl -fsS http://localhost:8001/status` → 200
   - `curl -fsSI <docs-mcp>/sse` → 200, `content-type: text/event-stream`
   - No mixed-origin warnings in console.
3. **Demo UI loads** — open `http://localhost:7860`; chat UI renders, no DevTools console errors, IBM Docs tools listed.
4. **Agent ↔ docs MCP** — prompt: *"Use the IBM Docs MCP to search for `playwright security` and summarize the top result."*
   ✅ Tool invoked, coherent answer with citation; no tool-call exceptions in terminal.
5. **Browser-use smoke** (the playwright launch path the CVEs touch) — prompt: *"Open https://example.com and tell me the page title."*
   ✅ Returns "Example Domain"; logs reference `chromium-headless-shell v1217` (the 1.59.0 build); no SSL warnings.
6. **Clean shutdown** — Ctrl+C; `lsof -iTCP -sTCP:LISTEN -P | grep -E '7860|8001'` empty.

**Regressions to flag:**
- `OriginValidationError` / 403 on docs MCP `/sse` (would mean the new origin check in playwright 1.56+ rejects the local caller)
- urllib3 / cryptography deprecation warnings during browser download
- Any langchain-core deserialization warning at startup

## Links
- Issue: #210
- CVE-2025-9611: https://security.snyk.io/vuln/SNYK-JS-PLAYWRIGHT-14888269
- CVE-2025-59288: https://nvd.nist.gov/vuln/detail/CVE-2025-59288
- Advisory: https://github.com/advisories/GHSA-7mvr-c777-76hp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to a newer version to address identified security vulnerabilities related to DNS rebinding and browser download processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuga-project/cuga-agent/pull/212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
