### PR TITLE
fix(policies): load .cuga policies in demo mode

### DIFF
--- a/src/cuga/backend/server/demo_manage_setup.py
+++ b/src/cuga/backend/server/demo_manage_setup.py
@@ -148,6 +148,56 @@ def load_oak_policy_entries() -> list[dict[str, Any]]:
     return list(data.get("policies") or [])
 
 
+def load_cuga_policy_entries_for_demo(cuga_folder: str | None = None) -> list[dict[str, Any]]:
+    """One-way import of local .cuga policy markdown files into demo manage config.
+
+    This intentionally does not initialize PolicyFilesystemSync. The UI can edit the
+    managed config copy without writing changes back to .cuga.
+    """
+    from cuga.backend.cuga_graph.policy.folder_loader import (
+        POLICY_CREATORS,
+        parse_markdown_with_frontmatter,
+    )
+
+    root = Path(cuga_folder or os.getenv("CUGA_FOLDER", settings.policy.cuga_folder))
+    if not root.exists():
+        return []
+
+    subfolders = {
+        "playbooks": "playbook",
+        "output_formatters": "output_formatter",
+        "tool_guides": "tool_guide",
+        "intent_guards": "intent_guard",
+        "tool_approvals": "tool_approval",
+    }
+    policies: list[dict[str, Any]] = []
+
+    for subfolder_name, default_policy_type in subfolders.items():
+        subfolder = root / subfolder_name
+        if not subfolder.exists():
+            continue
+
+        for policy_file in sorted(subfolder.glob("*.md")):
+            try:
+                frontmatter, content = parse_markdown_with_frontmatter(str(policy_file))
+                policy_type = frontmatter.get("type", default_policy_type)
+                creator = POLICY_CREATORS.get(policy_type)
+                if creator is None:
+                    raise ValueError(f"Unknown policy type: {policy_type}")
+
+                policy_obj = creator(str(policy_file), frontmatter, content)
+                policy_data = policy_obj.model_dump(mode="json")
+                policy_data["policy_type"] = policy_data.get("type", policy_type)
+                policies.append(policy_data)
+            except Exception as e:
+                logger.warning("Skipping demo policy preload from %s: %s", policy_file, e)
+
+    if policies:
+        logger.info("Preloaded %s local .cuga policy file(s) into demo config", len(policies))
+
+    return policies
+
+
 def _get_docs_tool() -> dict[str, Any]:
     docs_port = int(
         os.environ.get(
@@ -672,6 +722,7 @@ def setup_demo_manage_config(
         _sandbox_mode = getattr(settings.advanced_features, "sandbox_mode", "opensandbox")
         if _sandbox_mode == "local":
             policies.append(DEMO_SKILLS_SHELL_TOOL_APPROVAL)
+    policies.extend(load_cuga_policy_entries_for_demo())
     policies_struct: dict[str, Any] = {"enablePolicies": True, "policies": policies}
     config: dict[str, Any] = {
         "agent": agent_meta,

--- a/src/cuga/backend/server/demo_manage_setup.py
+++ b/src/cuga/backend/server/demo_manage_setup.py
@@ -161,6 +161,10 @@ def load_cuga_policy_entries_for_demo(cuga_folder: str | None = None) -> list[di
 
     root = Path(cuga_folder or os.getenv("CUGA_FOLDER", settings.policy.cuga_folder))
     if not root.exists():
+        logger.warning(
+            "Demo policy preload: .cuga folder not found at %s; skipping local policy import",
+            root,
+        )
         return []
 
     subfolders = {


### PR DESCRIPTION
## Bug fix

Fixes #222

### Summary

Policies from the `.cuga` directory were not being loaded when starting Cuga in demo mode (e.g., `cuga start demo`). This fix adds a new function `load_cuga_policy_entries_for_demo()` that:

- Scans local `.cuga` policy subfolders (playbooks, output_formatters, tool_guides, intent_guards, tool_approvals)
- Parses markdown files with frontmatter
- Creates policy objects using POLICY_CREATORS
- Integrates loaded policies into the demo configuration

The function performs a one-way import without initializing PolicyFilesystemSync, allowing the UI to edit the managed config copy without writing changes back to `.cuga`.

### Testing
- [x] Verified fix locally; tests pass
- [x] Ruff formatting and linting checks pass
- [x] Function includes proper error handling and logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo setup now preloads local policy markdown files into the demo configuration so they appear in the managed policies list.
  * Preloaded policies are editable through the UI without modifying the original files.
  * Invalid or unparsable files are skipped with warnings; the system logs the number of successfully preloaded policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuga-project/cuga-agent/pull/223)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->