### PR TITLE
fix(executor): serialize pandas DataFrame/Series and numpy scalars in variable collector

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
@@ -1,7 +1,7 @@
 import types
 from typing import Any, Optional, Set
-from loguru import logger
 
+from loguru import logger
 
 _TODO_CONFIRMATION_VALUES = frozenset({"Todos updated", "Todos have been updated"})
 
@@ -28,6 +28,77 @@ class VariableUtils:
         if "find_tools" not in code:
             return new_vars
         return {k: v for k, v in new_vars.items() if k != "tools_output"}
+
+    @staticmethod
+    def _sanitize_numpy_scalars(obj: Any) -> Any:
+        """Recursively convert numpy scalars inside dicts and lists to Python natives."""
+        try:
+            import numpy as np  # type: ignore[import-untyped]
+
+            if isinstance(obj, np.integer):
+                return int(obj)
+            if isinstance(obj, np.floating):
+                return float(obj)
+            if isinstance(obj, np.bool_):
+                return bool(obj)
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+        except ImportError:
+            return obj
+
+        if isinstance(obj, dict):
+            return {k: VariableUtils._sanitize_numpy_scalars(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [VariableUtils._sanitize_numpy_scalars(v) for v in obj]
+        return obj
+
+    @staticmethod
+    def sanitize_value(value: Any) -> Any:
+        """Convert non-JSON-serializable types to serializable equivalents.
+
+        - pd.DataFrame → dict with records (numpy scalars in cells are converted)
+        - pd.Series    → list (numpy scalars converted)
+        - numpy scalars / arrays → Python native types
+
+        All other values are returned unchanged.
+        """
+        try:
+            import numpy as np  # type: ignore[import-untyped]
+
+            if isinstance(value, np.integer):
+                return int(value)
+            if isinstance(value, np.floating):
+                return float(value)
+            if isinstance(value, np.bool_):
+                return bool(value)
+            if isinstance(value, np.ndarray):
+                return value.tolist()
+        except ImportError:
+            pass
+
+        try:
+            import pandas as pd
+
+            if isinstance(value, pd.DataFrame):
+                records = VariableUtils._sanitize_numpy_scalars(value.to_dict("records"))
+                return {
+                    "__pandas_type__": "DataFrame",
+                    "records": records,
+                    "columns": list(value.columns),
+                    "reconstruct": "pd.DataFrame(value['records'])",
+                }
+            if isinstance(value, pd.Series):
+                return {
+                    "__pandas_type__": "Series",
+                    "data": VariableUtils._sanitize_numpy_scalars(value.tolist()),
+                    "name": value.name,
+                    "reconstruct": "pd.Series(value['data'], name=value['name'])",
+                }
+        except ImportError:
+            pass
+
+        return value
+
 
     @staticmethod
     def is_serializable(value: Any) -> bool:
@@ -59,8 +130,11 @@ class VariableUtils:
         try:
             import pandas as pd
 
-            if isinstance(value, (pd.DataFrame, pd.Series)):
-                return True
+            if isinstance(value, pd.DataFrame):
+                return False  
+            if isinstance(value, pd.Series):
+                return False
+
         except ImportError:
             pass
 
@@ -102,7 +176,7 @@ class VariableUtils:
             if key.startswith('_'):
                 continue
 
-            value = all_locals[key]
+            value = VariableUtils.sanitize_value(all_locals[key])
             if VariableUtils.is_serializable(value):
                 new_vars[key] = value
             else:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
@@ -30,75 +30,120 @@ class VariableUtils:
         return {k: v for k, v in new_vars.items() if k != "tools_output"}
 
     @staticmethod
-    def _sanitize_numpy_scalars(obj: Any) -> Any:
-        """Recursively convert numpy scalars inside dicts and lists to Python natives."""
+    def _sanitize_recursive(obj: Any) -> Any:
+        """Recursively convert non-JSON-serializable scalars and containers.
+
+        Handles:
+        - numpy: integer, floating, complexfloating, bool_, ndarray
+        - pandas scalars: NaT → None, Timestamp → ISO string, Timedelta → seconds
+        - Python datetime: datetime/date/time → ISO string, timedelta → seconds
+        - bytes: UTF-8 string if decodable, else base64-encoded ASCII string
+        - complex: {"real": float, "imag": float}
+        - dict / list: recursive traversal
+
+        DataFrame and Series are intentionally excluded; sanitize_value wraps
+        those with metadata before delegating cell content here.
+        """
+        import base64
+        import datetime as dt
+
+        if obj is None:
+            return obj
+
+        # --- numpy ---
         try:
             import numpy as np  # type: ignore[import-untyped]
 
             if isinstance(obj, np.integer):
                 return int(obj)
             if isinstance(obj, np.floating):
-                return float(obj)
+                # nan and inf are not valid JSON — map to None
+                v = float(obj)
+                return None if (v != v or v == float("inf") or v == float("-inf")) else v
+            if isinstance(obj, np.complexfloating):
+                return {"real": float(obj.real), "imag": float(obj.imag)}
             if isinstance(obj, np.bool_):
                 return bool(obj)
             if isinstance(obj, np.ndarray):
-                return obj.tolist()
+                # tolist() converts simple dtypes to Python natives; recurse to
+                # catch object-dtype arrays that may still contain exotic types.
+                return VariableUtils._sanitize_recursive(obj.tolist())
         except ImportError:
-            return obj
+            pass
 
+        # --- pandas scalars ---
+        try:
+            import pandas as pd  # type: ignore[import-untyped]
+
+            if obj is pd.NaT or obj is pd.NA:
+                return None
+            if isinstance(obj, pd.Timestamp):
+                return obj.isoformat()
+            if isinstance(obj, pd.Timedelta):
+                return obj.total_seconds()
+        except ImportError:
+            pass
+
+        # --- Python stdlib datetime (datetime before date: it's a subclass) ---
+        if isinstance(obj, dt.datetime):
+            return obj.isoformat()
+        if isinstance(obj, dt.date):
+            return obj.isoformat()
+        if isinstance(obj, dt.time):
+            return obj.isoformat()
+        if isinstance(obj, dt.timedelta):
+            return obj.total_seconds()
+
+        # --- bytes ---
+        if isinstance(obj, bytes):
+            try:
+                return obj.decode("utf-8")
+            except UnicodeDecodeError:
+                return base64.b64encode(obj).decode("ascii")
+
+        # --- complex ---
+        if isinstance(obj, complex):
+            return {"real": obj.real, "imag": obj.imag}
+
+        # --- containers ---
         if isinstance(obj, dict):
-            return {k: VariableUtils._sanitize_numpy_scalars(v) for k, v in obj.items()}
+            return {k: VariableUtils._sanitize_recursive(v) for k, v in obj.items()}
         if isinstance(obj, list):
-            return [VariableUtils._sanitize_numpy_scalars(v) for v in obj]
+            return [VariableUtils._sanitize_recursive(v) for v in obj]
+
         return obj
 
     @staticmethod
     def sanitize_value(value: Any) -> Any:
         """Convert non-JSON-serializable types to serializable equivalents.
 
-        - pd.DataFrame → dict with records (numpy scalars in cells are converted)
-        - pd.Series    → list (numpy scalars converted)
-        - numpy scalars / arrays → Python native types
+        - pd.DataFrame → dict with records (cells recursively sanitized)
+        - pd.Series    → dict with data list (values recursively sanitized)
+        - All other types → delegated to _sanitize_recursive
 
         All other values are returned unchanged.
         """
         try:
-            import numpy as np  # type: ignore[import-untyped]
-
-            if isinstance(value, np.integer):
-                return int(value)
-            if isinstance(value, np.floating):
-                return float(value)
-            if isinstance(value, np.bool_):
-                return bool(value)
-            if isinstance(value, np.ndarray):
-                return value.tolist()
-        except ImportError:
-            pass
-
-        try:
-            import pandas as pd
+            import pandas as pd  # type: ignore[import-untyped]
 
             if isinstance(value, pd.DataFrame):
-                records = VariableUtils._sanitize_numpy_scalars(value.to_dict("records"))
                 return {
                     "__pandas_type__": "DataFrame",
-                    "records": records,
+                    "records": VariableUtils._sanitize_recursive(value.to_dict("records")),
                     "columns": list(value.columns),
                     "reconstruct": "pd.DataFrame(value['records'])",
                 }
             if isinstance(value, pd.Series):
                 return {
                     "__pandas_type__": "Series",
-                    "data": VariableUtils._sanitize_numpy_scalars(value.tolist()),
+                    "data": VariableUtils._sanitize_recursive(value.tolist()),
                     "name": value.name,
                     "reconstruct": "pd.Series(value['data'], name=value['name'])",
                 }
         except ImportError:
             pass
 
-        return value
-
+        return VariableUtils._sanitize_recursive(value)
 
     @staticmethod
     def is_serializable(value: Any) -> bool:
@@ -131,7 +176,7 @@ class VariableUtils:
             import pandas as pd
 
             if isinstance(value, pd.DataFrame):
-                return False  
+                return False
             if isinstance(value, pd.Series):
                 return False
 


### PR DESCRIPTION
## Bug fix

Fixes https://github.com/cuga-project/cuga-agent/issues/192

### Summary

`is_serializable()` previously returned `True` for `pd.DataFrame` and `pd.Series`, but these types are not JSON-serializable, causing variables containing pandas objects to be silently dropped or cause errors in the variable collector.

Changes:
- `is_serializable()` now returns `False` for `DataFrame` and `Series`
- New `sanitize_value()` converts `DataFrame` to a dict of records and `Series` to a list before the serializable check
- New `_sanitize_numpy_scalars()` recursively converts numpy scalar types inside DataFrame cells to Python natives, so DataFrames with numpy-typed cells survive the serializable check

### Testing
- [x] Verified fix locally in the example that was created for CRM demo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization of NumPy, pandas, datetime, bytes, complex, and other non-JSON-friendly types so they are reliably converted to JSON-friendly primitives.
  * pandas DataFrame/Series are now represented as structured, JSON-safe objects rather than treated as directly serializable.
  * Values are now sanitized before serializability checks to prevent incorrect acceptance of unsupported types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuga-project/cuga-agent/pull/224)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->