### PR TITLE
test: refresh stale unit-test expectations

### DIFF
--- a/src/cuga/backend/llm/errors.py
+++ b/src/cuga/backend/llm/errors.py
@@ -42,9 +42,26 @@ def is_tool_choice_none_tool_use_failed(err: Any) -> bool:
     True when the provider rejected the request because the model emitted a tool call
     while tool_choice was none (e.g. Groq 400 tool_use_failed).
     Safe to retry the same plain-text completion call.
+
+    Inspects both ``str(err)`` and ``err.body`` because LangChain typically wraps the
+    underlying provider error and surfaces the structured payload via ``.body``, while
+    ``str(err)`` collapses to the HTTP status line.
     """
     err_str = err if isinstance(err, str) else str(err)
-    return "tool_use_failed" in err_str and "Tool choice is none" in err_str
+    if "tool_use_failed" in err_str and "Tool choice is none" in err_str:
+        return True
+    body = getattr(err, "body", None)
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, dict):
+            code = error.get("code")
+            message = error.get("message") or ""
+            body_str = str(body)
+            has_failure = code == "tool_use_failed" or "tool_use_failed" in body_str
+            has_tool_choice = "Tool choice is none" in message or "Tool choice is none" in body_str
+            if has_failure and has_tool_choice:
+                return True
+    return False
 
 
 async def ainvoke_with_retry_on_tool_choice_none(

--- a/tests/unit/test_find_tools_exception.py
+++ b/tests/unit/test_find_tools_exception.py
@@ -111,5 +111,5 @@ async def test_find_tools_composes_query_with_initial_user_message(mock_tools, m
     mock_find.assert_awaited_once()
     call_kw = mock_find.await_args.kwargs
     assert call_kw["query"] == (
-        "query: list calendar tools,\nTask context (initial user message): Book a flight to NYC"
+        "Query: list calendar tools\nTask context (initial user message): Book a flight to NYC"
     )

--- a/tests/unit/test_manage_publish_sync.py
+++ b/tests/unit/test_manage_publish_sync.py
@@ -46,11 +46,12 @@ def test_publish_syncs_draft_with_published_knowledge_flags(monkeypatch):
         params={"agent_id": "test-agent"},
         json={
             "config": {
+                "agent": {"name": "test-agent"},
                 "knowledge": {
                     "enabled": True,
                     "agent_level_enabled": True,
                     "session_level_enabled": False,
-                }
+                },
             }
         },
     )
@@ -87,11 +88,12 @@ def test_publish_syncs_draft_with_published_agent_level_disabled(monkeypatch):
         params={"agent_id": "test-agent"},
         json={
             "config": {
+                "agent": {"name": "test-agent"},
                 "knowledge": {
                     "enabled": True,
                     "agent_level_enabled": False,
                     "session_level_enabled": True,
-                }
+                },
             }
         },
     )

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -80,7 +80,7 @@ def test_skill_registry_load_skill_emits_install_steps_for_requirements() -> Non
     loaded = registry.load_skill("deck")
 
     assert "await run_command('uv pip install --quiet python-pptx')" in loaded
-    assert "await run_command('cd /tmp && npm install sharp')" in loaded
+    assert "await run_command('npm install sharp')" in loaded
     assert "STEP 2 — SKILL INSTRUCTIONS" in loaded
     assert "`python -m <module> ...` → `uv run python -m <module> ...`" in loaded
     assert "`pip list` / `pip show` / `pip freeze` → `uv pip list`" in loaded

--- a/tests/unit/test_workspace_sandbox.py
+++ b/tests/unit/test_workspace_sandbox.py
@@ -13,8 +13,8 @@ from cuga.backend.server.workspace_sandbox import (
 )
 
 
-def test_sandbox_workspace_root_is_tmp_for_skills_mode() -> None:
-    assert SANDBOX_WORKSPACE_ROOT == "/tmp"
+def test_sandbox_workspace_root_is_workspace_for_skills_mode() -> None:
+    assert SANDBOX_WORKSPACE_ROOT == "/workspace"
 
 
 def test_native_workspace_root_is_virtual_workspace_for_native_mode() -> None:
@@ -25,13 +25,13 @@ def test_native_workspace_root_is_virtual_workspace_for_native_mode() -> None:
 @pytest.mark.parametrize(
     ("public_path", "expected"),
     [
-        ("tmp/foo.txt", "/tmp/foo.txt"),
-        ("/tmp/foo.txt", "/tmp/foo.txt"),
-        ("cuga_workspace/foo.txt", "/tmp/foo.txt"),
-        ("/tmp/cuga_workspace/foo.txt", "/tmp/foo.txt"),
-        ("tmp/nested/foo.txt", "/tmp/nested/foo.txt"),
-        ("/tmp", "/tmp"),
-        ("tmp", "/tmp"),
+        ("tmp/foo.txt", "/workspace/foo.txt"),
+        ("/tmp/foo.txt", "/workspace/foo.txt"),
+        ("cuga_workspace/foo.txt", "/workspace/foo.txt"),
+        ("/tmp/cuga_workspace/foo.txt", "/workspace/foo.txt"),
+        ("tmp/nested/foo.txt", "/workspace/nested/foo.txt"),
+        ("/tmp", "/workspace"),
+        ("tmp", "/workspace"),
     ],
 )
 def test_public_path_to_sandbox_abs_accepts_tmp_and_legacy_paths(public_path: str, expected: str) -> None:
@@ -55,28 +55,28 @@ def test_public_path_to_sandbox_abs_rejects_paths_outside_public_workspace(bad_p
         public_path_to_sandbox_abs(bad_path)
 
 
-def test_sandbox_paths_to_tree_uses_tmp_public_paths_and_hides_dotfiles() -> None:
+def test_sandbox_paths_to_tree_uses_workspace_public_paths_and_hides_dotfiles() -> None:
     tree = sandbox_paths_to_tree(
         [
-            "/tmp",
-            "/tmp/reports",
-            "/tmp/.venv",
+            "/workspace",
+            "/workspace/reports",
+            "/workspace/.venv",
         ],
         [
-            "/tmp/reports/deck.pptx",
-            "/tmp/notes.txt",
-            "/tmp/.venv/pyvenv.cfg",
+            "/workspace/reports/deck.pptx",
+            "/workspace/notes.txt",
+            "/workspace/.venv/pyvenv.cfg",
         ],
     )
 
     assert tree == [
         {
             "name": "reports",
-            "path": "tmp/reports",
+            "path": "workspace/reports",
             "type": "directory",
-            "children": [{"name": "deck.pptx", "path": "tmp/reports/deck.pptx", "type": "file"}],
+            "children": [{"name": "deck.pptx", "path": "workspace/reports/deck.pptx", "type": "file"}],
         },
-        {"name": "notes.txt", "path": "tmp/notes.txt", "type": "file"},
+        {"name": "notes.txt", "path": "workspace/notes.txt", "type": "file"},
     ]
 
 


### PR DESCRIPTION
## Summary

Five unit-test files have been failing locally on `main` (and every branch) for some time because their expected strings drifted away from the current source. They went unnoticed because `run_tests.sh` hand-picks a specific list of test files for CI and these aren't on that list.

This PR refreshes them with minimal, scoped commits — one file per commit:

- **`test_skill_loader.py`** — skill registry no longer prefixes npm installs with `cd /tmp &&` after the `/tmp` → `/workspace` workspace-root move.
- **`test_find_tools_exception.py`** — the composed query prefix is `Query:` (capital Q) and the line lacks a trailing comma; the literal was stale.
- **`test_manage_publish_sync.py`** — `/api/manage/config` now requires `config.agent.name`; both publish-sync POST bodies were missing it and failed at the status-code assertion.
- **`test_workspace_sandbox.py`** — `SANDBOX_WORKSPACE_ROOT` and `DISPLAY_ROOT` were renamed from `/tmp`/`tmp` to `/workspace`/`workspace`. Updated the root-constant assertion, parametrised mapping outputs, and the default-args tree-builder case. Legacy `/tmp` and `cuga_workspace` inputs are still accepted by the source, so those input cases are preserved — only the *expected outputs* were updated.
- **`test_tool_use_failed_recovery.py`** + **`src/cuga/backend/llm/errors.py`** — chose **Option B** here (one source change). `is_tool_choice_none_tool_use_failed` was inspecting `str(err)` only, but LangChain wraps provider errors so the structured payload lives on `err.body` and `str(err)` collapses to "400". The sibling helper `parse_tool_use_failed_generation` already inspects `err.body` for this reason; bringing this predicate into line is a one-place additive change that fixes the realistic LangChain-wrapped retry case the test exercises. No callers regress (only one internal caller, `ainvoke_with_retry_on_tool_choice_none`).

## Test plan

- [x] `uv run pytest tests/unit/test_skill_loader.py tests/unit/test_find_tools_exception.py tests/unit/test_manage_publish_sync.py tests/unit/test_workspace_sandbox.py tests/unit/test_tool_use_failed_recovery.py -v` — 60 passed (15 originally failing + 45 siblings).
- [x] `uv run ruff check` on all touched files — clean.
- [x] `uv run ruff format --check` on all touched files — clean.
- [x] Confirmed `is_tool_choice_none_tool_use_failed` only has one in-tree caller (`ainvoke_with_retry_on_tool_choice_none`), so the predicate broadening is safely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error detection for tool use failures through improved inspection of both string messages and structured error data.

* **Tests**
  * Updated unit tests to reflect changes in tool selection querying, API configuration payloads, installation commands, and sandbox workspace path mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuga-project/cuga-agent/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->