### PR TITLE
test(mcp-manager): add regression tests for SSE transport auth (issue #191)

### DIFF
--- a/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
@@ -1,0 +1,163 @@
+"""
+Regression tests for issue #191:
+SSE MCP servers with authentication — auth config must not be dropped.
+
+The SSE branch of _create_transport must attach auth headers the same way
+the HTTP/streamable-http branch does.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cuga.backend.tools_env.registry.config.config_loader import Auth, ServiceConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manager():
+    """Return an MCPManager instance without triggering any I/O."""
+    from cuga.backend.tools_env.registry.mcp_manager.mcp_manager import MCPManager
+
+    return MCPManager.__new__(MCPManager)
+
+
+def _sse_config(auth: Auth | None = None, url: str = "https://example.com/sse") -> ServiceConfig:
+    return ServiceConfig(url=url, transport="sse", auth=auth)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSSETransportAuth:
+    """_create_transport('sse') must forward auth as headers."""
+
+    def test_no_auth_passes_none_headers(self):
+        """Without auth config, SSETransport should receive headers=None."""
+        manager = _make_manager()
+        config = _sse_config(auth=None)
+
+        fake_transport = MagicMock()
+        with patch(
+            "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+            return_value=fake_transport,
+        ) as MockSSE:
+            result = manager._create_transport("test_server", config)
+
+        MockSSE.assert_called_once_with(url=config.url, headers=None)
+        assert result is fake_transport
+
+    def test_bearer_auth_sets_authorization_header(self):
+        """Bearer auth must produce Authorization: Bearer <token>."""
+        manager = _make_manager()
+        config = _sse_config(auth=Auth(type="bearer", value="my-secret-token"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        call_kwargs = MockSSE.call_args.kwargs
+        assert call_kwargs["headers"] == {"Authorization": "Bearer my-secret-token"}
+        assert result is fake_transport
+
+    def test_header_auth_sets_custom_header(self):
+        """Header auth must produce the named custom header."""
+        manager = _make_manager()
+        config = _sse_config(auth=Auth(type="header", value="abc123", key="X-API-Key"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        call_kwargs = MockSSE.call_args.kwargs
+        assert call_kwargs["headers"] == {"X-API-Key": "abc123"}
+        assert result is fake_transport
+
+    def test_basic_auth_sets_authorization_header(self):
+        """Basic auth must produce Authorization: Basic <base64(user:pass)>."""
+        import base64
+
+        manager = _make_manager()
+        config = _sse_config(auth=Auth(type="basic", value="user:pass"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        expected = base64.b64encode(b"user:pass").decode()
+        call_kwargs = MockSSE.call_args.kwargs
+        assert call_kwargs["headers"] == {"Authorization": f"Basic {expected}"}
+        assert result is fake_transport
+
+    def test_api_key_auth_does_not_set_headers(self):
+        """api-key auth goes into query params, not headers — headers should be None."""
+        manager = _make_manager()
+        config = _sse_config(auth=Auth(type="api-key", value="key123", key="api_key"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        # api-key goes to query_params, not headers — so headers dict is empty → None
+        call_kwargs = MockSSE.call_args.kwargs
+        assert call_kwargs["headers"] is None
+        assert result is fake_transport
+
+    def test_missing_url_raises(self):
+        """SSE transport without a URL must raise immediately."""
+        manager = _make_manager()
+        config = ServiceConfig(transport="sse", auth=None)  # no url
+
+        with patch("cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport", MagicMock()):
+            with pytest.raises(Exception, match="SSE transport requires 'url'"):
+                manager._create_transport("test_server", config)
+
+    def test_sse_transport_unavailable_raises(self):
+        """If SSETransport import failed, _create_transport must raise."""
+        manager = _make_manager()
+        config = _sse_config()
+
+        with patch("cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport", None):
+            with pytest.raises(Exception, match="SSETransport not available"):
+                manager._create_transport("test_server", config)

--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -69,6 +69,7 @@ run_pytest_with_e2b() {
 
 echo "Running unit tests (registry + variables manager + local sandbox + E2B lite)..."
 run_pytest ./src/cuga/backend/tools_env/registry/tests/
+run_pytest ./src/cuga/backend/tools_env/registry/mcp_manager/tests/
 run_pytest ./src/cuga/backend/cuga_graph/nodes/api/variables_manager/tests/
 run_pytest_with_e2b ./src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/
 echo "Running knowledge tests..."


### PR DESCRIPTION
## Bug fix

Refs #191

### Summary

The code fix for issue #191 was already present in `mcp_manager.py` — the SSE branch of `_create_transport` already calls `apply_authentication` and passes headers to `SSETransport`, mirroring the HTTP branch exactly.

This PR adds regression test coverage and wires the tests into the standard test suite:

**Commits:**
1. `test(mcp-manager)`: Add `test_sse_auth.py` — 7 regression tests covering all auth types for SSE transport
2. `chore(tests)`: Add `mcp_manager/tests/` to `run_tests.sh` so these (and other existing mcp_manager unit tests) run with the standard suite

**Tests added** (`test_sse_auth.py`):
- No auth → `headers=None` passed to `SSETransport`
- Bearer auth → `Authorization: Bearer <token>` header
- Custom header auth → named header set correctly
- Basic auth → `Authorization: Basic <base64>` header
- API-key auth (query param) → `headers=None` (key goes to query params, not headers)
- Missing URL → raises immediately
- Unavailable `SSETransport` import → raises immediately

### Testing
- [x] Verified fix locally; tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests covering SSE transport authentication across bearer, basic, header and API-key scenarios, plus error cases for missing config and unavailable transport.
* **Chores**
  * Test runner updated to include the new SSE auth test suite during unit test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuga-project/cuga-agent/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->