### PR TITLE
fix(code-agent): include nested tool schemas in prompt

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/api/code_agent/code_act_agent.py
+++ b/src/cuga/backend/cuga_graph/nodes/api/code_agent/code_act_agent.py
@@ -164,6 +164,26 @@ StateSchema = TypeVar("StateSchema", bound=CodeActState)
 StateSchemaType = Type[StateSchema]
 
 
+def _get_tool_args_json_schema(tool: StructuredTool) -> Optional[dict[str, Any]]:
+    """Return a JSON schema dict for a tool's arguments, when available."""
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is None:
+        return None
+
+    if isinstance(args_schema, dict):
+        return args_schema
+
+    model_json_schema = getattr(args_schema, "model_json_schema", None)
+    if callable(model_json_schema):
+        return model_json_schema()
+
+    schema = getattr(args_schema, "schema", None)
+    if callable(schema):
+        return schema()
+
+    return None
+
+
 def create_default_prompt(tools: list[StructuredTool], base_prompt: Optional[str] = None):
     """Create default prompt for the CodeAct agent."""
     tools = [t if isinstance(t, StructuredTool) else create_tool(t) for t in tools]
@@ -176,6 +196,14 @@ In addition to the Python Standard Library, you can use the following functions:
 """
 
     for tool in tools:
+        schema = _get_tool_args_json_schema(tool)
+        if schema:
+            schema_str = json.dumps(schema, indent=2)
+            prompt += f"""The arguments for `{tool.name}` should follow this JSON schema:
+```json
+{schema_str}
+```
+"""
         prompt += f'''
 def {tool.name}{str(inspect.signature(tool.func))}:
     """{tool.description}"""

--- a/src/cuga/backend/cuga_graph/nodes/api/code_agent/tests/test_code_act_agent.py
+++ b/src/cuga/backend/cuga_graph/nodes/api/code_agent/tests/test_code_act_agent.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict
+
+from langchain_core.tools import StructuredTool
+from pydantic import Field, create_model
+
+from cuga.backend.cuga_graph.nodes.api.code_agent.code_act_agent import create_default_prompt
+
+
+def create_test_tool_with_nested_schema():
+    """Creates a sample tool with a nested object schema for testing."""
+
+    WhenModel = create_model(
+        "WhenModel",
+        start=(str, Field(..., description="Start time in ISO 8601 format")),
+        end=(str, Field(..., description="End time in ISO 8601 format")),
+    )
+
+    EventModel = create_model(
+        "EventModel",
+        title=(str, Field(..., description="Title of the event")),
+        when=(WhenModel, Field(..., description="Timing of the event")),
+    )
+
+    InputModel = create_model(
+        "create_eventInput",
+        event=(EventModel, Field(..., description="The event to create")),
+    )
+
+    def create_event(event: Dict[str, Any]) -> str:
+        """
+        Creates a new calendar event.
+        """
+        return f"Event '{event.get('title')}' created."
+
+    tool = StructuredTool.from_function(
+        func=create_event,
+        name="create_event",
+        description="Creates a new calendar event.",
+        args_schema=InputModel,
+    )
+    return tool
+
+
+def test_create_default_prompt_includes_json_schema_for_nested_models():
+    """Test that create_default_prompt includes nested model schema details."""
+    tool = create_test_tool_with_nested_schema()
+    prompt = create_default_prompt(tools=[tool])
+
+    assert "The arguments for `create_event` should follow this JSON schema:" in prompt
+    assert "```json" in prompt
+    assert "EventModel" in prompt
+    assert "WhenModel" in prompt
+    assert '"event"' in prompt
+    assert '"title"' in prompt
+    assert '"when"' in prompt
+    assert '"start"' in prompt
+    assert '"end"' in prompt
+    assert "def create_event(event: Dict[str, Any]) -> str:" in prompt

--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -72,6 +72,7 @@ run_pytest ./src/cuga/backend/tools_env/registry/tests/
 run_pytest ./src/cuga/backend/tools_env/registry/mcp_manager/tests/
 run_pytest ./src/cuga/backend/cuga_graph/nodes/api/variables_manager/tests/
 run_pytest_with_e2b ./src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/
+run_pytest ./src/cuga/backend/cuga_graph/nodes/api/code_agent/tests/
 echo "Running memory tests..."
 run_pytest ./src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/memory/
 echo "Running knowledge tests..."


### PR DESCRIPTION
## Bug fix

Fixes #186

### Summary

- Include tool argument JSON schemas in the code-generation prompt so nested object parameters are visible to the model.
- Support Pydantic v2, Pydantic v1-style, and dict-based tool argument schemas.
- Add regression coverage for nested object tool parameter prompt rendering and include it in the standard test runner.

### Testing
- [x] Verified fix locally; tests pass

Validated with:
- `uv run ruff format src/cuga/backend/cuga_graph/nodes/api/code_agent/code_act_agent.py src/cuga/backend/cuga_graph/nodes/api/code_agent/tests/test_code_act_agent.py`
- `uv run ruff check src/cuga/backend/cuga_graph/nodes/api/code_agent/code_act_agent.py src/cuga/backend/cuga_graph/nodes/api/code_agent/tests/test_code_act_agent.py`
- `uv run pytest src/cuga/backend/cuga_graph/nodes/api/code_agent/tests/test_code_act_agent.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Code agent now includes detailed JSON-formatted schemas for available tools, clearly documenting parameter requirements and input structure for improved tool usage.

* **Tests**
  * Added comprehensive test coverage for tool argument schema generation in documentation, including validation of nested model specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cuga-project/cuga-agent/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->