### PR TITLE
fix(tracing): propagate Langfuse callbacks to nested LLM calls

### DIFF
--- a/docs/issues/langfuse-nested-callback-propagation.md
+++ b/docs/issues/langfuse-nested-callback-propagation.md
@@ -58,7 +58,7 @@ Key assertions:
 
 - `test_nl_auto_continue_passes_invoke_config` — nested `ainvoke` receives parent callbacks
 - `test_output_formatter_ainvoke_receives_callbacks` — policy formatter LLM uses same callbacks
-- `test_context_summarization_binds_model_with_callbacks` — summarization model gets `with_config(callbacks=...)`
+- `test_context_summarization_does_not_wrap_model_with_config` — summarization relies on the contextvar set in `call_model` instead of `with_config(callbacks=...)` (avoids breaking `_setup_model_profile`)
 - `test_apply_callbacks_drops_agent_langfuse_when_trace_id_set` — SDK dedupes duplicate Langfuse handlers
 
 ## Manual verification (Langfuse UI — optional but convincing)

--- a/docs/issues/langfuse-nested-callback-propagation.md
+++ b/docs/issues/langfuse-nested-callback-propagation.md
@@ -26,6 +26,7 @@ Branch: `fix/langfuse-nested-callback-propagation`
 Commit: `5591085a` — `fix(tracing): propagate Langfuse callbacks to nested LLM calls`
 
 - New `langfuse_tracing.py`: contextvar + `sync_langfuse_callbacks_from_config()` + `get_langfuse_invoke_config()`
+- Prefer explicit LangGraph `RunnableConfig` for reflection, bind-time shortlister, and runtime `find_tools` (see [#288](https://github.com/cuga-project/cuga-agent/issues/288)); contextvar remains fallback for paths without `config`
 - Wire nested call sites listed above
 - `sdk._apply_callbacks`: drop agent-level Langfuse handler when `langfuse_trace_id` or per-invoke trace handler is present
 - Unit tests: `tests/unit/test_langfuse_tracing.py`

--- a/docs/issues/langfuse-nested-callback-propagation.md
+++ b/docs/issues/langfuse-nested-callback-propagation.md
@@ -1,0 +1,94 @@
+## Problem
+
+When `advanced_features.langfuse_tracing=true`, a single `CugaAgent.invoke()` run can produce **multiple root traces** in Langfuse instead of one tree. Generations from nested LLM calls appear as siblings or separate roots, not children of the main run.
+
+This affects **standalone cuga-agent** (server, SDK, policy output formatting) and is amplified by eval harnesses that also open an outer span (see [cuga-eval#28](https://github.com/cuga-project/cuga-eval/issues/28)).
+
+### Root cause
+
+LangGraph passes Langfuse `CallbackHandler` instances via `config["callbacks"]` / `config["configurable"]["callbacks"]` for `call_model`, but several **nested** code paths call `ainvoke` without that config:
+
+| Nested path | Module |
+|-------------|--------|
+| Reflection after sandbox | `sandbox_node.py` |
+| find_tools shortlister | `prompt_utils.py` |
+| NL auto-continue classifier | `nl_auto_continue_classifier.py` (used `config={"callbacks": []}` on main) |
+| OutputFormatter policy | `enactment.py` |
+| Context summarization | `context_management_utils.py` |
+
+Each orphan `ainvoke` can create a new Langfuse root trace when the handler has no `trace_context.trace_id`.
+
+Additionally, when callers pass a **trace-scoped** handler per `invoke` *and* attach a generic handler on `CugaAgent(..., callbacks=[...])`, both handlers may compete unless deduplicated.
+
+## Proposed fix (branch pushed)
+
+Branch: `fix/langfuse-nested-callback-propagation`  
+Commit: `5591085a` — `fix(tracing): propagate Langfuse callbacks to nested LLM calls`
+
+- New `langfuse_tracing.py`: contextvar + `sync_langfuse_callbacks_from_config()` + `get_langfuse_invoke_config()`
+- Wire nested call sites listed above
+- `sdk._apply_callbacks`: drop agent-level Langfuse handler when `langfuse_trace_id` or per-invoke trace handler is present
+- Unit tests: `tests/unit/test_langfuse_tracing.py`
+
+## Test evidence (no Langfuse API keys required)
+
+### Before (`main`)
+
+- No `langfuse_tracing` module; nested paths do not propagate callbacks.
+- Example on `main` — NL auto-continue **explicitly clears** callbacks:
+
+```python
+resp = await llm.ainvoke(..., config={"callbacks": []})
+```
+
+- Regression file `tests/unit/test_langfuse_tracing.py` does not exist on `main`.
+
+### After (`fix/langfuse-nested-callback-propagation`)
+
+```bash
+cd cuga-agent
+.venv/bin/python -m pytest tests/unit/test_langfuse_tracing.py -v
+```
+
+```
+============================== 10 passed in ~6s ===============================
+```
+
+Key assertions:
+
+- `test_nl_auto_continue_passes_invoke_config` — nested `ainvoke` receives parent callbacks
+- `test_output_formatter_ainvoke_receives_callbacks` — policy formatter LLM uses same callbacks
+- `test_context_summarization_binds_model_with_callbacks` — summarization model gets `with_config(callbacks=...)`
+- `test_apply_callbacks_drops_agent_langfuse_when_trace_id_set` — SDK dedupes duplicate Langfuse handlers
+
+## Manual verification (Langfuse UI — optional but convincing)
+
+**Setup:** `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`, and `DYNACONF_ADVANCED_FEATURES__LANGFUSE_TRACING=true`.
+
+**Repro (cuga-agent only, no cuga-eval):**
+
+1. Enable reflection + low shortlist threshold in settings (or use M3-like dynaconf overrides).
+2. Run one short `CugaAgent.invoke()` task that triggers reflection or find_tools.
+3. In Langfuse → Traces, filter by time window.
+
+**Before:** several root traces for one logical task (e.g. one per `call_model` step + reflection + shortlister).
+
+**After:** one trace with nested GENERATION observations under a single root.
+
+**Please attach to this issue (screenshots):**
+
+1. **Before** — Langfuse trace list showing multiple roots for one invoke (timestamp + trace names).
+2. **After** — single trace expanded in tree view showing generations nested under one root.
+3. (Optional) One trace JSON export snippet: `observations[].parentObservationId` populated for nested generations.
+
+## Acceptance criteria
+
+- [ ] One Langfuse trace per `agent.invoke()` when caller supplies trace-scoped callbacks (or server uses single handler consistently)
+- [ ] Nested paths (reflection, find_tools, NL auto-continue, output formatter, context summarization) use propagated callbacks
+- [ ] `pytest tests/unit/test_langfuse_tracing.py` passes in CI
+- [ ] No regression for pip-installed SDK consumers that only set `callbacks` on `CugaAgent` construction
+
+## Related
+
+- cuga-eval [#28](https://github.com/cuga-project/cuga-eval/issues/28) — M3 eval span tree / orphaned chat nodes (harness + agent)
+- cuga-eval [#27](https://github.com/cuga-project/cuga-eval/issues/27) — React / too many traces (may share root cause)

--- a/scripts/repro_langfuse_callback_propagation.sh
+++ b/scripts/repro_langfuse_callback_propagation.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Compare Langfuse callback propagation tests on current branch vs main.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+PY="${ROOT}/.venv/bin/python"
+if [[ ! -x "$PY" ]]; then
+  echo "Create .venv first (see project README)."
+  exit 1
+fi
+
+echo "=== Langfuse callback propagation regression (current branch) ==="
+"$PY" -m pytest tests/unit/test_langfuse_tracing.py -v --tb=line
+
+echo ""
+echo "=== Optional: run on main to see failures (module + nested paths missing) ==="
+echo "  git stash -u && git checkout main && $PY -m pytest tests/unit/test_langfuse_tracing.py -v || true"
+echo "  git checkout - && git stash pop"

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
@@ -100,10 +100,20 @@ class CoreGraphAdapter(ABC):
         Default: ``{}``; Lite overrides to include Langfuse callbacks."""
         return {}
 
-    async def resolve_bind_tools(self, state: Any, active_model: Any, configurable: dict) -> Any:
+    async def resolve_bind_tools(
+        self,
+        state: Any,
+        active_model: Any,
+        configurable: dict,
+        config: Any = None,
+    ) -> Any:
         """Return a model instance with tools bound, or ``None`` to use the
         plain model without binding.  Default: ``None`` (Supervisor never
-        binds tools; only AgentGraphAdapter overrides this)."""
+        binds tools; only AgentGraphAdapter overrides this).
+
+        *config* is the LangGraph node ``RunnableConfig`` (Lite passes it for
+        nested shortlister / bind-tools LLM calls).
+        """
         return None
 
     async def ainvoke_model(self, bound: Any, messages: list, invoke_config: dict) -> Any:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -11,7 +11,7 @@ Differences handled via hooks:
 - System content augmentation (todos): ``adapter.prepare_system_content``
 - Variable storage key: ``adapter.get_variables_storage``
 - Activity tracker: ``adapter.get_tracker``
-- Langfuse callbacks: ``adapter.get_invoke_config``
+- Langfuse: pass full LangGraph ``config`` into ``ainvoke`` (preserves parent run ids)
 - Bind-tools model: ``adapter.resolve_bind_tools``
 - Response normalisation: ``adapter.normalize_response``
 - Tracker side-effects: ``adapter.on_response_processed``
@@ -173,7 +173,9 @@ def create_call_model_node(
         bound = await adapter.resolve_bind_tools(state, active_model, configurable) or active_model
 
         # ── Model invocation ───────────────────────────────────────────────
-        invoke_config = adapter.get_invoke_config(configurable)
+        # Pass the full node config so LangChain keeps parent_run_id linkage for
+        # Langfuse. Passing only {"callbacks": [...]} starts orphan root traces.
+        invoke_config = config if config is not None else {}
         response = await adapter.ainvoke_model(bound, messages_for_model, invoke_config)
 
         # ── Normalise response ─────────────────────────────────────────────

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -57,6 +57,10 @@ def create_call_model_node(
     async def call_model(state: Any, config: RunnableConfig = None) -> Command:
         configurable: dict = config.get("configurable", {}) if config else {}
 
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import sync_langfuse_callbacks_from_config
+
+        sync_langfuse_callbacks_from_config(config)
+
         # ── Tool-approval HITL resumption ──────────────────────────────────
         if settings.policy.enabled and ToolApprovalHandler.is_returning_from_approval(adapter, state):
             return ToolApprovalHandler.handle_approval_resumption(adapter, state)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -170,7 +170,7 @@ def create_call_model_node(
         )
 
         # ── Resolve bound model (bind-tools, Lite-only) ────────────────────
-        bound = await adapter.resolve_bind_tools(state, active_model, configurable) or active_model
+        bound = await adapter.resolve_bind_tools(state, active_model, configurable, config) or active_model
 
         # ── Model invocation ───────────────────────────────────────────────
         # Pass the full node config so LangChain keeps parent_run_id linkage for

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -121,7 +121,16 @@ class AgentGraphAdapter(CoreGraphAdapter):
                 return _FakeResponse()
             raise
 
-    async def resolve_bind_tools(self, state: Any, active_model: Any, configurable: dict) -> Any:
+    async def resolve_bind_tools(
+        self,
+        state: Any,
+        active_model: Any,
+        configurable: dict,
+        config: Any = None,
+    ) -> Any:
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import stash_langgraph_run_config
+
+        stash_langgraph_run_config(self._tools_context_ref, config)
         try:
             return await resolve_model_with_bind_tools(
                 active_model,
@@ -129,6 +138,7 @@ class AgentGraphAdapter(CoreGraphAdapter):
                 tools_context_ref=self._tools_context_ref,
                 tool_provider=self._base_tool_provider,
                 query=_first_user_message_text(getattr(state, "chat_messages", None)),
+                run_config=config,
             )
         except RuntimeError:
             # Cap/shortlist failures surface intentionally — do not silently fall back.

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -128,9 +128,6 @@ class AgentGraphAdapter(CoreGraphAdapter):
         configurable: dict,
         config: Any = None,
     ) -> Any:
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import stash_langgraph_run_config
-
-        stash_langgraph_run_config(self._tools_context_ref, config)
         try:
             return await resolve_model_with_bind_tools(
                 active_model,

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
@@ -71,9 +71,6 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
         or ``cuga_lite_enable_few_shots`` in configurable (skips prefix chat few-shots).
         """
         configurable = config.get("configurable", {}) if config else {}
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import stash_langgraph_run_config
-
-        stash_langgraph_run_config(lc_bind_tools_meta, config)
         enable_todos = (
             configurable.get("enable_todos")
             if "enable_todos" in configurable
@@ -208,7 +205,6 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
                 app_to_tools_map=app_to_tools_map,
                 llm=active_model,
                 initial_user_message=_first_user_message_text(state.chat_messages),
-                tools_context_ref=lc_bind_tools_meta,
             )
             tools_for_prompt = [find_tool]
             # Add find_tools to tools context for sandbox execution

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
@@ -71,6 +71,9 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
         or ``cuga_lite_enable_few_shots`` in configurable (skips prefix chat few-shots).
         """
         configurable = config.get("configurable", {}) if config else {}
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import stash_langgraph_run_config
+
+        stash_langgraph_run_config(lc_bind_tools_meta, config)
         enable_todos = (
             configurable.get("enable_todos")
             if "enable_todos" in configurable
@@ -205,6 +208,7 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
                 app_to_tools_map=app_to_tools_map,
                 llm=active_model,
                 initial_user_message=_first_user_message_text(state.chat_messages),
+                tools_context_ref=lc_bind_tools_meta,
             )
             tools_for_prompt = [find_tool]
             # Add find_tools to tools context for sandbox execution

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
@@ -43,12 +43,12 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
 
         configurable = config.get("configurable", {}) if config else {}
         from cuga.backend.cuga_graph.utils.langfuse_tracing import (
-            get_langfuse_invoke_config,
+            stash_langgraph_run_config,
             sync_langfuse_callbacks_from_config,
         )
 
         sync_langfuse_callbacks_from_config(config)
-        lf_invoke_config = get_langfuse_invoke_config()
+        stash_langgraph_run_config(getattr(adapter, "_tools_context_ref", None), config)
         max_steps = configurable.get("cuga_lite_max_steps") if "cuga_lite_max_steps" in configurable else None
         if "thread_id" in configurable:
             current_thread_id = configurable["thread_id"]
@@ -154,7 +154,7 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
                             "skills_prompt_section": state.reflection_skills_prompt_section,
                             "force_autonomous_mode": settings.advanced_features.force_autonomous_mode,
                         },
-                        config=lf_invoke_config,
+                        config=config or {},
                     )
                     reflection_output = reflection_result.content
                     logger.debug(f"Reflection output:\n{reflection_output}")

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
@@ -42,6 +42,13 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
                 return denial_command
 
         configurable = config.get("configurable", {}) if config else {}
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import (
+            get_langfuse_invoke_config,
+            sync_langfuse_callbacks_from_config,
+        )
+
+        sync_langfuse_callbacks_from_config(config)
+        lf_invoke_config = get_langfuse_invoke_config()
         max_steps = configurable.get("cuga_lite_max_steps") if "cuga_lite_max_steps" in configurable else None
         if "thread_id" in configurable:
             current_thread_id = configurable["thread_id"]
@@ -146,7 +153,8 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
                             "skills_enabled": state.reflection_skills_enabled,
                             "skills_prompt_section": state.reflection_skills_prompt_section,
                             "force_autonomous_mode": settings.advanced_features.force_autonomous_mode,
-                        }
+                        },
+                        config=lf_invoke_config,
                     )
                     reflection_output = reflection_result.content
                     logger.debug(f"Reflection output:\n{reflection_output}")

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
@@ -42,13 +42,9 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
                 return denial_command
 
         configurable = config.get("configurable", {}) if config else {}
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import (
-            stash_langgraph_run_config,
-            sync_langfuse_callbacks_from_config,
-        )
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import sync_langfuse_callbacks_from_config
 
         sync_langfuse_callbacks_from_config(config)
-        stash_langgraph_run_config(getattr(adapter, "_tools_context_ref", None), config)
         max_steps = configurable.get("cuga_lite_max_steps") if "cuga_lite_max_steps" in configurable else None
         if "thread_id" in configurable:
             current_thread_id = configurable["thread_id"]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/bind_tools/cap.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/bind_tools/cap.py
@@ -131,6 +131,7 @@ async def _run_shortlister(
     top_k: int,
     mode: str,
     max_count: int,
+    run_config: Any = None,
 ) -> List[str]:
     """Run :meth:`PromptUtils.shortlist_tool_names` and validate the result.
 
@@ -158,6 +159,7 @@ async def _run_shortlister(
             all_apps=all_apps,
             llm=llm,
             top_k=top_k,
+            run_config=run_config,
         )
     except Exception as e:
         raise RuntimeError(
@@ -251,6 +253,7 @@ async def apply_bind_tools_cap_and_merge(
     include_find_tools: bool,
     tools_context_ref: Optional[Dict[str, Any]],
     mode: str,
+    run_config: Any = None,
 ) -> List[StructuredTool]:
     """Enforce the provider-safe ``max_count`` and optionally merge ``find_tools``.
 
@@ -321,6 +324,7 @@ async def apply_bind_tools_cap_and_merge(
         top_k=target_k,
         mode=mode,
         max_count=max_count,
+        run_config=run_config,
     )
     shortlisted, seen_short = _materialize_shortlist(
         ranked_names,

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/bind_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/bind_tools.py
@@ -147,6 +147,7 @@ async def resolve_model_with_bind_tools(
     tool_provider: Optional[ToolProviderInterface],
     model_name: Optional[str] = None,
     query: Optional[str] = None,
+    run_config: Any = None,
 ) -> BaseChatModel:
     """Optionally wrap ``active_model`` with ``bind_tools`` for native tool-calling tests.
 
@@ -205,6 +206,7 @@ async def resolve_model_with_bind_tools(
             include_find_tools=include_find_tools,
             tools_context_ref=tools_context_ref,
             mode=mode,
+            run_config=run_config,
         )
 
     if mode in ("", "none", "false", "0", "off"):

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
@@ -57,6 +57,7 @@ async def create_find_tools_tool(
     app_to_tools_map: Optional[Dict[str, List[StructuredTool]]] = None,
     llm: Optional[Any] = None,
     initial_user_message: Optional[str] = None,
+    tools_context_ref: Optional[Dict[str, Any]] = None,
 ) -> StructuredTool:
     """Create a find_tools StructuredTool for tool discovery.
 
@@ -99,9 +100,14 @@ async def create_find_tools_tool(
 
         shortlister_query = _compose_find_tools_shortlister_query(query, initial_user_message)
 
+        run_config = (tools_context_ref or {}).get("_langgraph_run_config")
         try:
             return await PromptUtils.find_tools(
-                query=shortlister_query, all_tools=filtered_tools, all_apps=filtered_apps, llm=llm
+                query=shortlister_query,
+                all_tools=filtered_tools,
+                all_apps=filtered_apps,
+                llm=llm,
+                run_config=run_config,
             )
         except OutputParserException as e:
             logger.bind(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
@@ -57,7 +57,6 @@ async def create_find_tools_tool(
     app_to_tools_map: Optional[Dict[str, List[StructuredTool]]] = None,
     llm: Optional[Any] = None,
     initial_user_message: Optional[str] = None,
-    tools_context_ref: Optional[Dict[str, Any]] = None,
 ) -> StructuredTool:
     """Create a find_tools StructuredTool for tool discovery.
 
@@ -100,14 +99,15 @@ async def create_find_tools_tool(
 
         shortlister_query = _compose_find_tools_shortlister_query(query, initial_user_message)
 
-        run_config = (tools_context_ref or {}).get("_langgraph_run_config")
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
+
         try:
             return await PromptUtils.find_tools(
                 query=shortlister_query,
                 all_tools=filtered_tools,
                 all_apps=filtered_apps,
                 llm=llm,
-                run_config=run_config,
+                run_config=nested_langgraph_invoke_config(),
             )
         except OutputParserException as e:
             logger.bind(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/nl_auto_continue_classifier.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/nl_auto_continue_classifier.py
@@ -111,12 +111,14 @@ async def classify_nl_auto_continue(
         'Respond with JSON only: {"auto_continue": true} or {"auto_continue": false}'
     )
     try:
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
+
         resp = await llm.ainvoke(
             [
                 {"role": "system", "content": CLASSIFIER_SYSTEM_PROMPT},
                 {"role": "user", "content": user_block},
             ],
-            config={"callbacks": []},
+            config=get_langfuse_invoke_config(),
         )
         parsed = parse_auto_continue_json(getattr(resp, "content", "") or "")
         if parsed is None:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -301,6 +301,7 @@ class PromptUtils:
             ShortListerOutputLite,
         )
         from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
 
         llm_manager = LLMManager()
         model = llm or llm_manager.get_model(settings.agent.code.model)
@@ -311,7 +312,8 @@ class PromptUtils:
                 "all_apps": apps_as_dict,
                 "all_tools": tools_as_dict,
                 "instructions": "",
-            }
+            },
+            config=get_langfuse_invoke_config(),
         )
 
         enriched_tools = []

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -260,6 +260,7 @@ class PromptUtils:
         all_tools: List[StructuredTool],
         all_apps: List[AppDefinition],
         llm: Optional[Any] = None,
+        run_config: Optional[Any] = None,
     ) -> str:
         """
         Search tools from given applications and return the top 4 matching tools with reasoning.
@@ -301,7 +302,7 @@ class PromptUtils:
             ShortListerOutputLite,
         )
         from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
 
         llm_manager = LLMManager()
         model = llm or llm_manager.get_model(settings.agent.code.model)
@@ -313,7 +314,7 @@ class PromptUtils:
                 "all_tools": tools_as_dict,
                 "instructions": "",
             },
-            config=get_langfuse_invoke_config(),
+            config=nested_langgraph_invoke_config(run_config),
         )
 
         enriched_tools = []
@@ -426,6 +427,7 @@ class PromptUtils:
         llm: Optional[Any] = None,
         top_k: int = 4,
         instructions: Optional[str] = None,
+        run_config: Optional[Any] = None,
     ) -> List[str]:
         """Rank tools by relevance to ``query`` and return up to ``top_k`` names (best-first).
 
@@ -472,7 +474,7 @@ class PromptUtils:
         )
         tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(all_tools, all_apps)
 
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
 
         llm_manager = LLMManager()
         model = llm or llm_manager.get_model(settings.agent.code.model)
@@ -484,7 +486,7 @@ class PromptUtils:
                 "all_tools": tools_as_dict,
                 "instructions": effective_instructions,
             },
-            config=get_langfuse_invoke_config(),
+            config=nested_langgraph_invoke_config(run_config),
         )
 
         valid_names = {t.name for t in all_tools}

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -472,6 +472,8 @@ class PromptUtils:
         )
         tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(all_tools, all_apps)
 
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
+
         llm_manager = LLMManager()
         model = llm or llm_manager.get_model(settings.agent.code.model)
         chain = BaseAgent.get_chain(prompt, model, ShortListerOutputLite)
@@ -481,7 +483,8 @@ class PromptUtils:
                 "all_apps": apps_as_dict,
                 "all_tools": tools_as_dict,
                 "instructions": effective_instructions,
-            }
+            },
+            config=get_langfuse_invoke_config(),
         )
 
         valid_names = {t.name for t in all_tools}

--- a/src/cuga/backend/cuga_graph/policy/enactment.py
+++ b/src/cuga/backend/cuga_graph/policy/enactment.py
@@ -786,6 +786,9 @@ You have been provided with a step-by-step playbook for this task. Follow these 
         """
         from langchain_core.messages import HumanMessage, SystemMessage
         from cuga.backend.llm.models import LLMManager
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
+
+        lf_invoke_config = get_langfuse_invoke_config()
 
         logger.info(f"Formatting output using policy: {policy_match.policy.name}")
 
@@ -876,7 +879,7 @@ Please reformat this response according to the instructions above."""
                     + [HumanMessage(content=user_prompt)]
                 )
 
-            formatted_response = await llm.ainvoke(messages)
+            formatted_response = await llm.ainvoke(messages, config=lf_invoke_config)
             formatted_content = formatted_response.content
 
         else:  # json_schema
@@ -919,7 +922,7 @@ Extract and format the information from this response as JSON according to the s
                 try:
                     # Use with_structured_output with json_schema method
                     structured_llm = llm.with_structured_output(schema, method="json_schema")
-                    formatted_response = await structured_llm.ainvoke(messages)
+                    formatted_response = await structured_llm.ainvoke(messages, config=lf_invoke_config)
 
                     # Structured output returns a dict, convert to JSON string
                     if isinstance(formatted_response, dict):
@@ -954,7 +957,7 @@ Important:
                             + [HumanMessage(content=user_prompt)]
                         )
 
-                    formatted_response = await llm.ainvoke(messages_fallback)
+                    formatted_response = await llm.ainvoke(messages_fallback, config=lf_invoke_config)
                     formatted_content = formatted_response.content
 
             except json.JSONDecodeError:

--- a/src/cuga/backend/cuga_graph/policy/output_formatter_utils.py
+++ b/src/cuga/backend/cuga_graph/policy/output_formatter_utils.py
@@ -36,6 +36,9 @@ async def apply_output_formatter_policies(
     try:
         from cuga.backend.cuga_graph.policy.enactment import PolicyEnactment
         from cuga.backend.cuga_graph.policy.models import PolicyType
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import sync_langfuse_callbacks_from_config
+
+        sync_langfuse_callbacks_from_config(config)
 
         logger.debug(f"{context}: Checking OutputFormatter policies...")
         command, metadata = await PolicyEnactment.check_and_enact(

--- a/src/cuga/backend/cuga_graph/utils/context_management_utils.py
+++ b/src/cuga/backend/cuga_graph/utils/context_management_utils.py
@@ -52,11 +52,11 @@ async def apply_context_summarization(
 
     model_name = getattr(model, 'model_name', 'gpt-4')
 
-    from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
-
-    lf_config = get_langfuse_invoke_config()
-    if lf_config.get("callbacks") and hasattr(model, "with_config"):
-        model = model.with_config(lf_config)
+    # Do not use model.with_config(callbacks=...) here: it wraps the model in
+    # RunnableBinding and breaks ContextSummarizer._setup_model_profile (profile field).
+    # Langfuse callbacks for summarization LLM calls are propagated via the
+    # contextvar set in call_model (sync_langfuse_callbacks_from_config) before
+    # this runs; middleware wiring is tracked separately.
 
     try:
         # Create temporary AgentState with a copy of messages

--- a/src/cuga/backend/cuga_graph/utils/context_management_utils.py
+++ b/src/cuga/backend/cuga_graph/utils/context_management_utils.py
@@ -52,6 +52,12 @@ async def apply_context_summarization(
 
     model_name = getattr(model, 'model_name', 'gpt-4')
 
+    from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
+
+    lf_config = get_langfuse_invoke_config()
+    if lf_config.get("callbacks") and hasattr(model, "with_config"):
+        model = model.with_config(lf_config)
+
     try:
         # Create temporary AgentState with a copy of messages
         # Only pass optional parameters if they are not None

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -1,0 +1,65 @@
+"""Thread-local Langfuse callback propagation for nested LLM calls.
+
+CugaLite and policy enactment run LLM calls outside the main ``call_model``
+path (reflection, find_tools shortlister, NL auto-continue, output formatter,
+context summarization). Those calls need the same trace-scoped Langfuse
+``CallbackHandler`` as the parent ``agent.invoke`` so Langfuse shows one trace
+per logical run instead of many sibling root traces.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Any, Optional
+
+_langfuse_callbacks: ContextVar[Optional[list[Any]]] = ContextVar("langfuse_callbacks", default=None)
+
+
+def _as_callback_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return list(value) if isinstance(value, list) else [value]
+
+
+def collect_langfuse_callbacks_from_config(config: Any = None) -> list[Any]:
+    """Return merged LangChain callbacks from a LangGraph ``config`` dict."""
+    if not config or not hasattr(config, "get"):
+        return []
+    configurable = config.get("configurable") or {}
+    merged: list[Any] = []
+    seen: set[int] = set()
+    for source in (config.get("callbacks"), configurable.get("callbacks")):
+        for cb in _as_callback_list(source):
+            key = id(cb)
+            if key not in seen:
+                seen.add(key)
+                merged.append(cb)
+    return merged
+
+
+def set_langfuse_callbacks(callbacks: Optional[list[Any]]) -> None:
+    """Store LangChain callbacks for the current async context."""
+    _langfuse_callbacks.set(list(callbacks) if callbacks else None)
+
+
+def sync_langfuse_callbacks_from_config(config: Any = None) -> None:
+    """Copy callbacks from LangGraph config into the current async context."""
+    set_langfuse_callbacks(collect_langfuse_callbacks_from_config(config))
+
+
+def get_langfuse_callbacks() -> list[Any]:
+    """Return callbacks previously set for this async context (may be empty)."""
+    return list(_langfuse_callbacks.get() or [])
+
+
+def get_langfuse_invoke_config() -> dict[str, Any]:
+    """LangChain ``config`` dict for nested ``ainvoke`` calls, or empty."""
+    callbacks = get_langfuse_callbacks()
+    return {"callbacks": callbacks} if callbacks else {}
+
+
+def is_langfuse_callback_handler(cb: Any) -> bool:
+    """True if *cb* is a Langfuse LangChain callback handler."""
+    mod = getattr(type(cb), "__module__", "") or ""
+    name = type(cb).__name__
+    return mod.startswith("langfuse") and name in ("CallbackHandler", "LangchainCallbackHandler")

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 _LANGFUSE_HANDLER_CLASSES: tuple[type, ...] | None = None
 
 _langfuse_callbacks: ContextVar[Optional[list[Any]]] = ContextVar("langfuse_callbacks", default=None)
+_langfuse_trace_id: ContextVar[Optional[str]] = ContextVar("langfuse_trace_id", default=None)
 
 
 def _flatten_callbacks(value: Any) -> list[Any]:
@@ -56,9 +57,35 @@ def set_langfuse_callbacks(callbacks: Optional[list[Any]]) -> None:
     _langfuse_callbacks.set(list(callbacks) if callbacks else None)
 
 
+def set_langfuse_trace_id(trace_id: Optional[str]) -> None:
+    """Remember the eval harness trace id for nested calls in this async context."""
+    _langfuse_trace_id.set(trace_id)
+
+
+def create_trace_langfuse_handler(trace_id: str, *, parent_span_id: str | None = None) -> Any | None:
+    """Return a Langfuse handler scoped to *trace_id* (one trace per eval task)."""
+    trace_context: dict[str, str] = {"trace_id": trace_id}
+    if parent_span_id:
+        trace_context["parent_span_id"] = parent_span_id
+    for handler_cls in _langfuse_handler_classes():
+        return handler_cls(trace_context=trace_context)
+    return None
+
+
 def sync_langfuse_callbacks_from_config(config: Any = None) -> None:
-    """Copy callbacks from LangGraph config into the current async context."""
-    set_langfuse_callbacks(collect_langfuse_callbacks_from_config(config))
+    """Copy Langfuse trace id and handlers from LangGraph config into this context."""
+    if not config or not hasattr(config, "get"):
+        return
+    configurable = config.get("configurable") or {}
+    trace_id = configurable.get("langfuse_trace_id")
+    if trace_id:
+        set_langfuse_trace_id(trace_id)
+    callbacks = collect_langfuse_callbacks_from_config(config)
+    if not callbacks and trace_id:
+        handler = create_trace_langfuse_handler(trace_id)
+        if handler:
+            callbacks = [handler]
+    set_langfuse_callbacks(callbacks or None)
 
 
 def get_langfuse_callbacks() -> list[Any]:
@@ -67,9 +94,21 @@ def get_langfuse_callbacks() -> list[Any]:
 
 
 def get_langfuse_invoke_config() -> dict[str, Any]:
-    """LangChain ``config`` dict for nested ``ainvoke`` calls, or empty."""
-    callbacks = get_langfuse_callbacks()
-    return {"callbacks": callbacks} if callbacks else {}
+    """LangChain ``config`` for nested ``ainvoke`` (find_tools, reflection, etc.).
+
+    Reuse handlers synced from the parent ``agent.invoke`` config when present so
+    repeated shortlister calls share one trace-scoped handler. Otherwise build
+    from ``langfuse_trace_id`` (sandbox paths that only receive the trace id).
+    """
+    callbacks = [cb for cb in get_langfuse_callbacks() if is_langfuse_callback_handler(cb)]
+    if callbacks:
+        return {"callbacks": callbacks}
+    trace_id = _langfuse_trace_id.get()
+    if trace_id:
+        handler = create_trace_langfuse_handler(trace_id)
+        if handler:
+            return {"callbacks": [handler]}
+    return {}
 
 
 def _langfuse_handler_classes() -> tuple[type, ...]:

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -9,8 +9,11 @@ per logical run instead of many sibling root traces.
 
 from __future__ import annotations
 
+import importlib
 from contextvars import ContextVar
 from typing import Any, Optional
+
+_LANGFUSE_HANDLER_CLASSES: tuple[type, ...] | None = None
 
 _langfuse_callbacks: ContextVar[Optional[list[Any]]] = ContextVar("langfuse_callbacks", default=None)
 
@@ -69,8 +72,33 @@ def get_langfuse_invoke_config() -> dict[str, Any]:
     return {"callbacks": callbacks} if callbacks else {}
 
 
+def _langfuse_handler_classes() -> tuple[type, ...]:
+    global _LANGFUSE_HANDLER_CLASSES
+    if _LANGFUSE_HANDLER_CLASSES is not None:
+        return _LANGFUSE_HANDLER_CLASSES
+    classes: list[type] = []
+    for module_name, class_name in (
+        ("langfuse.langchain", "CallbackHandler"),
+        ("langfuse.callback", "CallbackHandler"),
+    ):
+        try:
+            mod = importlib.import_module(module_name)
+            cls = getattr(mod, class_name, None)
+            if isinstance(cls, type):
+                classes.append(cls)
+        except ImportError:
+            continue
+    _LANGFUSE_HANDLER_CLASSES = tuple(classes)
+    return _LANGFUSE_HANDLER_CLASSES
+
+
 def is_langfuse_callback_handler(cb: Any) -> bool:
     """True if *cb* is a Langfuse LangChain callback handler."""
-    mod = getattr(type(cb), "__module__", "") or ""
     name = type(cb).__name__
-    return mod.startswith("langfuse") and name in ("CallbackHandler", "LangchainCallbackHandler")
+    if name not in ("CallbackHandler", "LangchainCallbackHandler"):
+        return False
+    for handler_cls in _langfuse_handler_classes():
+        if isinstance(cb, handler_cls):
+            return True
+    mod = getattr(type(cb), "__module__", "") or ""
+    return "langfuse" in mod

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -17,6 +17,8 @@ _LANGFUSE_HANDLER_CLASSES: tuple[type, ...] | None = None
 
 _langfuse_callbacks: ContextVar[Optional[list[Any]]] = ContextVar("langfuse_callbacks", default=None)
 _langfuse_trace_id: ContextVar[Optional[str]] = ContextVar("langfuse_trace_id", default=None)
+_langfuse_primary_handler: ContextVar[Optional[Any]] = ContextVar("langfuse_primary_handler", default=None)
+_TRACE_SCOPED_HANDLER_CLASS: type | None = None
 
 
 def _flatten_callbacks(value: Any) -> list[Any]:
@@ -62,13 +64,100 @@ def set_langfuse_trace_id(trace_id: Optional[str]) -> None:
     _langfuse_trace_id.set(trace_id)
 
 
-def create_trace_langfuse_handler(trace_id: str, *, parent_span_id: str | None = None) -> Any | None:
-    """Return a Langfuse handler scoped to *trace_id* (one trace per eval task)."""
+def _trace_context_for_id(trace_id: str, *, parent_span_id: str | None = None) -> dict[str, str]:
     trace_context: dict[str, str] = {"trace_id": trace_id}
     if parent_span_id:
         trace_context["parent_span_id"] = parent_span_id
-    for handler_cls in _langfuse_handler_classes():
-        return handler_cls(trace_context=trace_context)
+    return trace_context
+
+
+def _handler_trace_id(handler: Any) -> str | None:
+    ctx = getattr(handler, "_trace_context", None)
+    if isinstance(ctx, dict):
+        tid = ctx.get("trace_id")
+        return str(tid) if tid else None
+    return None
+
+
+def _trace_scoped_handler_class() -> type | None:
+    """Langfuse handler that always links orphan LLM runs to the eval trace id."""
+    global _TRACE_SCOPED_HANDLER_CLASS
+    if _TRACE_SCOPED_HANDLER_CLASS is not None:
+        return _TRACE_SCOPED_HANDLER_CLASS
+
+    base_classes = _langfuse_handler_classes()
+    if not base_classes:
+        return None
+
+    base_cls = base_classes[0]
+
+    class TraceScopedLangfuseCallbackHandler(base_cls):  # type: ignore[misc,valid-type]
+        def __on_llm_action(
+            self,
+            serialized: Any,
+            run_id: Any,
+            prompts: list[Any],
+            parent_run_id: Any = None,
+            tags: Any = None,
+            metadata: Any = None,
+            **kwargs: Any,
+        ) -> None:
+            trace_ctx = getattr(self, "_trace_context", None)
+            if trace_ctx is None:
+                tid = _langfuse_trace_id.get()
+                if tid:
+                    trace_ctx = _trace_context_for_id(tid)
+            parent_missing = parent_run_id is None or parent_run_id not in getattr(self, "_runs", {})
+            if trace_ctx is not None and parent_missing:
+                original = self._trace_context
+                self._trace_context = trace_ctx
+                try:
+                    super().__on_llm_action(
+                        serialized,
+                        run_id,
+                        prompts,
+                        parent_run_id=parent_run_id,
+                        tags=tags,
+                        metadata=metadata,
+                        **kwargs,
+                    )
+                finally:
+                    self._trace_context = original
+                return
+            super().__on_llm_action(
+                serialized,
+                run_id,
+                prompts,
+                parent_run_id=parent_run_id,
+                tags=tags,
+                metadata=metadata,
+                **kwargs,
+            )
+
+    TraceScopedLangfuseCallbackHandler.__name__ = "TraceScopedLangfuseCallbackHandler"
+    _TRACE_SCOPED_HANDLER_CLASS = TraceScopedLangfuseCallbackHandler
+    return _TRACE_SCOPED_HANDLER_CLASS
+
+
+def create_trace_langfuse_handler(trace_id: str, *, parent_span_id: str | None = None) -> Any | None:
+    """Return a Langfuse handler scoped to *trace_id* (one trace per eval task)."""
+    handler_cls = _trace_scoped_handler_class()
+    if handler_cls is None:
+        return None
+    return handler_cls(trace_context=_trace_context_for_id(trace_id, parent_span_id=parent_span_id))
+
+
+def _remember_primary_handler(callbacks: list[Any]) -> None:
+    for cb in callbacks:
+        if is_langfuse_callback_handler(cb):
+            _langfuse_primary_handler.set(cb)
+            return
+
+
+def _primary_handler_for_trace(trace_id: str) -> Any | None:
+    handler = _langfuse_primary_handler.get()
+    if handler is not None and _handler_trace_id(handler) == trace_id:
+        return handler
     return None
 
 
@@ -81,9 +170,12 @@ def sync_langfuse_callbacks_from_config(config: Any = None) -> None:
     if trace_id:
         set_langfuse_trace_id(trace_id)
     callbacks = collect_langfuse_callbacks_from_config(config)
-    if not callbacks and trace_id:
-        handler = create_trace_langfuse_handler(trace_id)
+    if callbacks:
+        _remember_primary_handler(callbacks)
+    elif trace_id:
+        handler = _primary_handler_for_trace(trace_id) or create_trace_langfuse_handler(trace_id)
         if handler:
+            _langfuse_primary_handler.set(handler)
             callbacks = [handler]
     set_langfuse_callbacks(callbacks or None)
 
@@ -105,8 +197,9 @@ def get_langfuse_invoke_config() -> dict[str, Any]:
         return {"callbacks": callbacks}
     trace_id = _langfuse_trace_id.get()
     if trace_id:
-        handler = create_trace_langfuse_handler(trace_id)
+        handler = _primary_handler_for_trace(trace_id) or create_trace_langfuse_handler(trace_id)
         if handler:
+            _langfuse_primary_handler.set(handler)
             return {"callbacks": [handler]}
     return {}
 

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -18,6 +18,7 @@ _LANGFUSE_HANDLER_CLASSES: tuple[type, ...] | None = None
 _langfuse_callbacks: ContextVar[Optional[list[Any]]] = ContextVar("langfuse_callbacks", default=None)
 _langfuse_trace_id: ContextVar[Optional[str]] = ContextVar("langfuse_trace_id", default=None)
 _langfuse_primary_handler: ContextVar[Optional[Any]] = ContextVar("langfuse_primary_handler", default=None)
+_langgraph_run_config: ContextVar[Optional[Any]] = ContextVar("langgraph_run_config", default=None)
 _TRACE_SCOPED_HANDLER_CLASS: type | None = None
 
 
@@ -162,9 +163,10 @@ def _primary_handler_for_trace(trace_id: str) -> Any | None:
 
 
 def sync_langfuse_callbacks_from_config(config: Any = None) -> None:
-    """Copy Langfuse trace id and handlers from LangGraph config into this context."""
+    """Copy Langfuse trace id, handlers, and RunnableConfig into this async context."""
     if not config or not hasattr(config, "get"):
         return
+    _langgraph_run_config.set(config)
     configurable = config.get("configurable") or {}
     trace_id = configurable.get("langfuse_trace_id")
     if trace_id:
@@ -185,19 +187,13 @@ def get_langfuse_callbacks() -> list[Any]:
     return list(_langfuse_callbacks.get() or [])
 
 
-def stash_langgraph_run_config(
-    tools_context_ref: dict[str, Any] | None,
-    config: Any,
-) -> None:
-    """Store the current LangGraph node config for runtime ``find_tools`` (sandbox closure)."""
-    if tools_context_ref is not None and config is not None and hasattr(config, "get"):
-        tools_context_ref["_langgraph_run_config"] = config
-
-
 def nested_langgraph_invoke_config(run_config: Any = None) -> dict[str, Any]:
-    """Prefer the parent node's full ``RunnableConfig``; fall back to contextvar callbacks."""
+    """Prefer explicit or context-synced ``RunnableConfig``; fall back to callbacks-only dict."""
     if run_config is not None and hasattr(run_config, "get"):
         return run_config
+    ctx_config = _langgraph_run_config.get()
+    if ctx_config is not None and hasattr(ctx_config, "get"):
+        return ctx_config
     return get_langfuse_invoke_config()
 
 

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -15,21 +15,32 @@ from typing import Any, Optional
 _langfuse_callbacks: ContextVar[Optional[list[Any]]] = ContextVar("langfuse_callbacks", default=None)
 
 
-def _as_callback_list(value: Any) -> list[Any]:
+def _flatten_callbacks(value: Any) -> list[Any]:
+    """Expand LangGraph/LangChain callback managers into handler instances."""
     if value is None:
         return []
-    return list(value) if isinstance(value, list) else [value]
+    handlers = getattr(value, "handlers", None)
+    if handlers is not None and not isinstance(value, (list, tuple)):
+        return list(handlers)
+    if isinstance(value, (list, tuple)):
+        out: list[Any] = []
+        for item in value:
+            out.extend(_flatten_callbacks(item))
+        return out
+    return [value]
 
 
 def collect_langfuse_callbacks_from_config(config: Any = None) -> list[Any]:
-    """Return merged LangChain callbacks from a LangGraph ``config`` dict."""
+    """Return merged Langfuse callback handlers from a LangGraph ``config`` dict."""
     if not config or not hasattr(config, "get"):
         return []
     configurable = config.get("configurable") or {}
     merged: list[Any] = []
     seen: set[int] = set()
     for source in (config.get("callbacks"), configurable.get("callbacks")):
-        for cb in _as_callback_list(source):
+        for cb in _flatten_callbacks(source):
+            if not is_langfuse_callback_handler(cb):
+                continue
             key = id(cb)
             if key not in seen:
                 seen.add(key)

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -185,6 +185,22 @@ def get_langfuse_callbacks() -> list[Any]:
     return list(_langfuse_callbacks.get() or [])
 
 
+def stash_langgraph_run_config(
+    tools_context_ref: dict[str, Any] | None,
+    config: Any,
+) -> None:
+    """Store the current LangGraph node config for runtime ``find_tools`` (sandbox closure)."""
+    if tools_context_ref is not None and config is not None and hasattr(config, "get"):
+        tools_context_ref["_langgraph_run_config"] = config
+
+
+def nested_langgraph_invoke_config(run_config: Any = None) -> dict[str, Any]:
+    """Prefer the parent node's full ``RunnableConfig``; fall back to contextvar callbacks."""
+    if run_config is not None and hasattr(run_config, "get"):
+        return run_config
+    return get_langfuse_invoke_config()
+
+
 def get_langfuse_invoke_config() -> dict[str, Any]:
     """LangChain ``config`` for nested ``ainvoke`` (find_tools, reflection, etc.).
 
@@ -227,7 +243,7 @@ def _langfuse_handler_classes() -> tuple[type, ...]:
 def is_langfuse_callback_handler(cb: Any) -> bool:
     """True if *cb* is a Langfuse LangChain callback handler."""
     name = type(cb).__name__
-    if name not in ("CallbackHandler", "LangchainCallbackHandler"):
+    if name not in ("CallbackHandler", "LangchainCallbackHandler", "TraceScopedLangfuseCallbackHandler"):
         return False
     for handler_cls in _langfuse_handler_classes():
         if isinstance(cb, handler_cls):

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -1414,6 +1414,10 @@ class CugaAgent:
         run_config["callbacks"] = merged
         run_config["configurable"]["callbacks"] = merged
 
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import sync_langfuse_callbacks_from_config
+
+        sync_langfuse_callbacks_from_config(run_config)
+
     async def _ensure_initialized(self):
         """Ensure tool provider is initialized."""
         if not hasattr(self.tool_provider, 'initialized') or not self.tool_provider.initialized:

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -1386,6 +1386,9 @@ class CugaAgent:
         Merge built-in callbacks (TokenUsageTracker + user callbacks) with any
         caller-supplied callbacks in run_config, writing the result to both the
         top-level and ``configurable`` slots.
+
+        When the caller passes a trace-scoped Langfuse handler (eval harness),
+        drop agent-level Langfuse handlers so each LLM call nests under one trace.
         """
         built_callbacks = self._build_callbacks()
 
@@ -1394,11 +1397,18 @@ class CugaAgent:
                 return []
             return list(value) if isinstance(value, list) else [value]
 
-        existing = _as_list(run_config.get("callbacks"))
-        existing_configurable = _as_list(run_config["configurable"].get("callbacks"))
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import is_langfuse_callback_handler
 
-        run_config["callbacks"] = built_callbacks + existing
-        run_config["configurable"]["callbacks"] = built_callbacks + existing_configurable
+        existing = _as_list(run_config.get("callbacks"))
+        trace_id = run_config["configurable"].get("langfuse_trace_id")
+        per_call_langfuse = any(is_langfuse_callback_handler(cb) for cb in existing)
+
+        if trace_id or per_call_langfuse:
+            built_callbacks = [cb for cb in built_callbacks if not is_langfuse_callback_handler(cb)]
+
+        merged = built_callbacks + existing
+        run_config["callbacks"] = merged
+        run_config["configurable"]["callbacks"] = merged
 
     async def _ensure_initialized(self):
         """Ensure tool provider is initialized."""

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -1387,6 +1387,10 @@ class CugaAgent:
         caller-supplied callbacks in run_config, writing the result to both the
         top-level and ``configurable`` slots.
 
+        Only ``run_config["callbacks"]`` is read for caller-supplied handlers;
+        any pre-existing ``run_config["configurable"]["callbacks"]`` is replaced
+        by the merged list so both locations stay identical for LangGraph nodes.
+
         When the caller passes a trace-scoped Langfuse handler (eval harness),
         drop agent-level Langfuse handlers so each LLM call nests under one trace.
         """

--- a/tests/unit/test_cuga_lite_bind_tools.py
+++ b/tests/unit/test_cuga_lite_bind_tools.py
@@ -120,7 +120,9 @@ async def test_bind_tools_mode_all_shortlists_when_over_cap():
     provider.get_apps = AsyncMock(return_value=[])
     model = MagicMock()
 
-    async def fake_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def fake_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         return [t.name for t in all_tools[: min(top_k, 3)]]
 
     with (
@@ -241,7 +243,9 @@ async def test_bind_tools_cap_does_not_pad_by_default():
     provider.get_apps = AsyncMock(return_value=[])
     model = MagicMock()
 
-    async def stingy_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def stingy_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         return ["tool_007"]
 
     with (
@@ -280,7 +284,9 @@ async def test_bind_tools_cap_pads_when_opt_in():
     provider.get_apps = AsyncMock(return_value=[])
     model = MagicMock()
 
-    async def stingy_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def stingy_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         return ["tool_007"]
 
     with (
@@ -329,7 +335,9 @@ async def test_bind_tools_cap_not_violated_when_at_boundary_with_find_tools():
 
     captured_top_k = {}
 
-    async def fake_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def fake_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         captured_top_k["value"] = top_k
         return [t.name for t in all_tools[:top_k]]
 
@@ -378,7 +386,9 @@ async def test_bind_tools_cap_guarantees_find_tools_when_in_overlay_bound():
 
     captured = {}
 
-    async def fake_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def fake_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         captured["top_k"] = top_k
         captured["pool_names"] = [t.name for t in all_tools]
         # Adversarial: rank find_tools out if it appears in the input. With the fix it shouldn't.
@@ -434,7 +444,9 @@ async def test_bind_tools_include_find_tools_false_strips_overlay_find_tools():
 
     captured = {}
 
-    async def fake_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def fake_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         captured["pool_names"] = [t.name for t in all_tools]
         return [t.name for t in all_tools[:top_k]]
 
@@ -480,7 +492,9 @@ async def test_bind_tools_cap_raises_when_shortlist_names_dont_match_pool():
     provider.get_apps = AsyncMock(return_value=[])
     model = MagicMock()
 
-    async def hallucinating_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def hallucinating_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         return ["nonexistent_tool_a", "nonexistent_tool_b"]
 
     with (
@@ -515,7 +529,9 @@ async def test_bind_tools_cap_clamps_shortlist_when_llm_returns_too_many():
     provider.get_apps = AsyncMock(return_value=[])
     model = MagicMock()
 
-    async def overlong_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def overlong_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         # Deliberately ignore top_k — return every pool name.
         return [t.name for t in all_tools]
 
@@ -555,7 +571,9 @@ async def test_bind_tools_cap_clamps_shortlist_with_find_tools_slot():
     provider.get_apps = AsyncMock(return_value=[])
     model = MagicMock()
 
-    async def overlong_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def overlong_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         return [t.name for t in all_tools]
 
     with (
@@ -629,7 +647,9 @@ async def test_bind_tools_cap_reserves_slot_for_find_tools():
 
     captured_top_k = {}
 
-    async def fake_shortlist(query, all_tools, all_apps, llm=None, top_k=4, instructions=None):
+    async def fake_shortlist(
+        query, all_tools, all_apps, llm=None, top_k=4, instructions=None, run_config=None
+    ):
         captured_top_k["value"] = top_k
         return [t.name for t in all_tools[:top_k]]
 

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -38,11 +38,15 @@ def _fake_langfuse_handler():
 
 @pytest.fixture(autouse=True)
 def _clear_langfuse_context():
+    from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
     set_langfuse_callbacks(None)
     set_langfuse_trace_id(None)
+    mod._langfuse_primary_handler.set(None)
     yield
     set_langfuse_callbacks(None)
     set_langfuse_trace_id(None)
+    mod._langfuse_primary_handler.set(None)
 
 
 class TestLangfuseTracingHelpers:
@@ -104,6 +108,32 @@ class TestLangfuseTracingHelpers:
     def test_is_langfuse_callback_handler_detects_langfuse_types(self):
         assert is_langfuse_callback_handler(_fake_langfuse_handler())
         assert not is_langfuse_callback_handler(_RecordingCallback())
+
+    def test_get_invoke_config_reuses_primary_handler_for_trace_id(self):
+        from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
+        first = _fake_langfuse_handler()
+        first._trace_context = {"trace_id": "trace-reuse"}
+        mod._langfuse_primary_handler.set(first)
+        set_langfuse_trace_id("trace-reuse")
+        with patch(
+            "cuga.backend.cuga_graph.utils.langfuse_tracing.create_trace_langfuse_handler",
+        ) as create_mock:
+            assert get_langfuse_invoke_config() == {"callbacks": [first]}
+            create_mock.assert_not_called()
+
+    def test_sync_reuses_primary_handler_instead_of_creating_duplicates(self):
+        from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
+        existing = _fake_langfuse_handler()
+        existing._trace_context = {"trace_id": "abc123"}
+        mod._langfuse_primary_handler.set(existing)
+        with patch(
+            "cuga.backend.cuga_graph.utils.langfuse_tracing.create_trace_langfuse_handler",
+        ) as create_mock:
+            sync_langfuse_callbacks_from_config({"configurable": {"langfuse_trace_id": "abc123"}})
+            create_mock.assert_not_called()
+            assert get_langfuse_invoke_config() == {"callbacks": [existing]}
 
 
 class TestSdkCallbackDedup:

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -21,7 +21,6 @@ from cuga.backend.cuga_graph.utils.langfuse_tracing import (
     nested_langgraph_invoke_config,
     set_langfuse_callbacks,
     set_langfuse_trace_id,
-    stash_langgraph_run_config,
     sync_langfuse_callbacks_from_config,
 )
 
@@ -45,10 +44,12 @@ def _clear_langfuse_context():
     set_langfuse_callbacks(None)
     set_langfuse_trace_id(None)
     mod._langfuse_primary_handler.set(None)
+    mod._langgraph_run_config.set(None)
     yield
     set_langfuse_callbacks(None)
     set_langfuse_trace_id(None)
     mod._langfuse_primary_handler.set(None)
+    mod._langgraph_run_config.set(None)
 
 
 class TestLangfuseTracingHelpers:
@@ -121,11 +122,13 @@ class TestLangfuseTracingHelpers:
         set_langfuse_callbacks([cb])
         assert nested_langgraph_invoke_config(None) == {"callbacks": [cb]}
 
-    def test_stash_langgraph_run_config(self):
-        ref: dict = {}
-        cfg = {"configurable": {"langfuse_trace_id": "abc"}}
-        stash_langgraph_run_config(ref, cfg)
-        assert ref["_langgraph_run_config"] is cfg
+    def test_sync_stores_run_config_in_contextvar(self):
+        from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
+        cfg = {"callbacks": [_fake_langfuse_handler()], "configurable": {"thread_id": "t1"}}
+        mod._langgraph_run_config.set(None)
+        sync_langfuse_callbacks_from_config(cfg)
+        assert nested_langgraph_invoke_config(None) is cfg
 
     def test_get_invoke_config_reuses_primary_handler_for_trace_id(self):
         from cuga.backend.cuga_graph.utils import langfuse_tracing as mod

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -1,0 +1,223 @@
+"""
+Regression tests for Langfuse callback propagation to nested LLM calls.
+
+Without propagation, nested paths (reflection, find_tools, NL auto-continue,
+output formatter, context summarization) invoke LLMs with empty callbacks and
+Langfuse creates separate root traces per call.
+
+These tests do not require a Langfuse server or API keys.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cuga.backend.cuga_graph.utils.langfuse_tracing import (
+    collect_langfuse_callbacks_from_config,
+    get_langfuse_invoke_config,
+    is_langfuse_callback_handler,
+    set_langfuse_callbacks,
+    sync_langfuse_callbacks_from_config,
+)
+
+
+class _RecordingCallback:
+    """Minimal LangChain-style callback stand-in."""
+
+    def __init__(self, name: str = "recording"):
+        self.name = name
+
+
+def _fake_langfuse_handler():
+    """Object that matches is_langfuse_callback_handler heuristics."""
+    return type("CallbackHandler", (), {"__module__": "langfuse.langchain"})()
+
+
+@pytest.fixture(autouse=True)
+def _clear_langfuse_context():
+    set_langfuse_callbacks(None)
+    yield
+    set_langfuse_callbacks(None)
+
+
+class TestLangfuseTracingHelpers:
+    def test_invoke_config_empty_when_callbacks_not_set(self):
+        assert get_langfuse_invoke_config() == {}
+
+    def test_set_callbacks_visible_in_invoke_config(self):
+        cb = _RecordingCallback("trace-scoped")
+        set_langfuse_callbacks([cb])
+        assert get_langfuse_invoke_config() == {"callbacks": [cb]}
+
+    def test_collect_merges_top_level_and_configurable(self):
+        a, b = _RecordingCallback("a"), _RecordingCallback("b")
+        config = {
+            "callbacks": [a],
+            "configurable": {"callbacks": [b]},
+        }
+        merged = collect_langfuse_callbacks_from_config(config)
+        assert merged == [a, b]
+
+    def test_sync_from_config_populates_context(self):
+        cb = _RecordingCallback("from-config")
+        sync_langfuse_callbacks_from_config({"configurable": {"callbacks": [cb]}})
+        assert get_langfuse_invoke_config() == {"callbacks": [cb]}
+
+    def test_is_langfuse_callback_handler_detects_langfuse_types(self):
+        assert is_langfuse_callback_handler(_fake_langfuse_handler())
+        assert not is_langfuse_callback_handler(_RecordingCallback())
+
+
+class TestSdkCallbackDedup:
+    def test_apply_callbacks_drops_agent_langfuse_when_trace_id_set(self):
+        from cuga.sdk import CugaAgent
+
+        agent_level = _fake_langfuse_handler()
+        per_invoke = _RecordingCallback("per-invoke")
+
+        agent = CugaAgent.__new__(CugaAgent)
+        agent._callbacks = [agent_level]
+
+        run_config = {
+            "callbacks": [per_invoke],
+            "configurable": {"langfuse_trace_id": "trace-abc", "thread_id": "t1"},
+        }
+        agent._apply_callbacks(run_config)
+
+        callback_ids = [id(c) for c in run_config["callbacks"]]
+        assert id(per_invoke) in callback_ids
+        assert id(agent_level) not in callback_ids
+        assert run_config["configurable"]["callbacks"] == run_config["callbacks"]
+
+
+class TestNestedCallSites:
+    @pytest.mark.asyncio
+    async def test_nl_auto_continue_passes_invoke_config(self):
+        from cuga.backend.cuga_graph.nodes.cuga_lite import nl_auto_continue_classifier as mod
+        from cuga.config import settings
+
+        cb = _RecordingCallback("nl")
+        set_langfuse_callbacks([cb])
+
+        mock_llm = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = '{"auto_continue": false}'
+        mock_llm.ainvoke = AsyncMock(return_value=mock_resp)
+
+        with patch.object(settings.advanced_features, "cuga_lite_nl_auto_continue", True, create=True):
+            result = await mod.classify_nl_auto_continue(
+                mock_llm,
+                assistant_visible="done with the task",
+                reasoning_excerpt="finished reasoning",
+            )
+        assert result is False
+        mock_llm.ainvoke.assert_awaited_once()
+        _args, kwargs = mock_llm.ainvoke.call_args
+        assert kwargs.get("config") == {"callbacks": [cb]}
+
+    @pytest.mark.asyncio
+    async def test_nl_auto_continue_without_sync_fails_propagation(self):
+        """Documents pre-fix behaviour: no callbacks in nested ainvoke config."""
+        from cuga.backend.cuga_graph.nodes.cuga_lite import nl_auto_continue_classifier as mod
+        from cuga.config import settings
+
+        mock_llm = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = '{"auto_continue": false}'
+        mock_llm.ainvoke = AsyncMock(return_value=mock_resp)
+
+        with patch.object(settings.advanced_features, "cuga_lite_nl_auto_continue", True, create=True):
+            await mod.classify_nl_auto_continue(
+                mock_llm,
+                assistant_visible="partial answer here",
+                reasoning_excerpt="still working",
+            )
+        _args, kwargs = mock_llm.ainvoke.call_args
+        assert kwargs.get("config") == {}
+
+    @pytest.mark.asyncio
+    async def test_output_formatter_ainvoke_receives_callbacks(self):
+        from langchain_core.messages import AIMessage
+
+        from cuga.backend.cuga_graph.policy.enactment import PolicyEnactment
+        from cuga.backend.cuga_graph.policy.models import OutputFormatter
+
+        cb = _RecordingCallback("formatter")
+        set_langfuse_callbacks([cb])
+
+        policy = OutputFormatter(
+            id="test_fmt",
+            name="Test Formatter",
+            description="test",
+            format_type="markdown",
+            format_config="Use bullet points.",
+            triggers=[],
+        )
+        policy_match = MagicMock()
+        policy_match.policy = policy
+        policy_match.reasoning = "test"
+        policy_match.confidence = 1.0
+
+        state = MagicMock()
+        state.chat_messages = [AIMessage(content="answer is 42")]
+        state.final_answer = "answer is 42"
+
+        context = MagicMock()
+        context.agent_response = "answer is 42"
+        context.chat_messages = []
+        context.user_input = None
+
+        mock_llm = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = "- answer is 42"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_resp)
+
+        with patch("cuga.backend.llm.models.LLMManager") as mock_mgr:
+            mock_mgr.return_value.get_model.return_value = mock_llm
+            _cmd, metadata = await PolicyEnactment._enact_format_output(
+                state, policy_match, MagicMock(), context
+            )
+
+        assert metadata is not None
+        mock_llm.ainvoke.assert_awaited_once()
+        _args, kwargs = mock_llm.ainvoke.call_args
+        assert kwargs.get("config") == {"callbacks": [cb]}
+
+    @pytest.mark.asyncio
+    async def test_context_summarization_binds_model_with_callbacks(self):
+        from langchain_core.messages import HumanMessage
+
+        from cuga.backend.cuga_graph.utils.context_management_utils import (
+            apply_context_summarization,
+        )
+
+        cb = _RecordingCallback("summarize")
+        set_langfuse_callbacks([cb])
+
+        base_model = MagicMock()
+        bound_model = MagicMock()
+        base_model.with_config.return_value = bound_model
+
+        messages = [HumanMessage(content="hello")]
+
+        with patch("cuga.backend.cuga_graph.utils.context_management_utils.AgentState") as mock_state_cls:
+            instance = MagicMock()
+            instance.chat_messages = messages
+            mock_state_cls.return_value = instance
+
+            with patch.object(
+                instance,
+                "manage_message_context",
+                new_callable=AsyncMock,
+            ) as mock_manage:
+                result = await apply_context_summarization(
+                    messages,
+                    base_model,
+                    message_list_name="chat_messages",
+                )
+
+        base_model.with_config.assert_called_once_with({"callbacks": [cb]})
+        mock_manage.assert_awaited_once()
+        assert result == messages

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -18,8 +18,10 @@ from cuga.backend.cuga_graph.utils.langfuse_tracing import (
     collect_langfuse_callbacks_from_config,
     get_langfuse_invoke_config,
     is_langfuse_callback_handler,
+    nested_langgraph_invoke_config,
     set_langfuse_callbacks,
     set_langfuse_trace_id,
+    stash_langgraph_run_config,
     sync_langfuse_callbacks_from_config,
 )
 
@@ -108,6 +110,22 @@ class TestLangfuseTracingHelpers:
     def test_is_langfuse_callback_handler_detects_langfuse_types(self):
         assert is_langfuse_callback_handler(_fake_langfuse_handler())
         assert not is_langfuse_callback_handler(_RecordingCallback())
+
+    def test_nested_langgraph_invoke_config_prefers_run_config(self):
+        node_config = {"callbacks": [_fake_langfuse_handler()], "configurable": {"thread_id": "t1"}}
+        set_langfuse_callbacks([])
+        assert nested_langgraph_invoke_config(node_config) is node_config
+
+    def test_nested_langgraph_invoke_config_falls_back_to_contextvar(self):
+        cb = _fake_langfuse_handler()
+        set_langfuse_callbacks([cb])
+        assert nested_langgraph_invoke_config(None) == {"callbacks": [cb]}
+
+    def test_stash_langgraph_run_config(self):
+        ref: dict = {}
+        cfg = {"configurable": {"langfuse_trace_id": "abc"}}
+        stash_langgraph_run_config(ref, cfg)
+        assert ref["_langgraph_run_config"] is cfg
 
     def test_get_invoke_config_reuses_primary_handler_for_trace_id(self):
         from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
@@ -267,6 +285,39 @@ class TestNestedCallSites:
         mock_llm.ainvoke.assert_awaited_once()
         _args, kwargs = mock_llm.ainvoke.call_args
         assert kwargs.get("config") == {"callbacks": [cb]}
+
+    @pytest.mark.asyncio
+    async def test_shortlist_passes_explicit_run_config(self):
+        from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+        node_config = {
+            "callbacks": [_fake_langfuse_handler()],
+            "configurable": {"thread_id": "bind-cap"},
+        }
+        set_langfuse_callbacks([])
+
+        api_detail = type("APIDetails", (), {"name": "tool_a", "reasoning": "r"})()
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(return_value=MagicMock(result=[api_detail]))
+        tool = MagicMock()
+        tool.name = "tool_a"
+
+        with patch(
+            "cuga.backend.cuga_graph.nodes.shared.base_agent.BaseAgent.get_chain",
+            return_value=mock_chain,
+        ):
+            with patch("cuga.backend.llm.models.LLMManager"):
+                ranked = await PromptUtils.shortlist_tool_names(
+                    query="list users",
+                    all_tools=[tool],
+                    all_apps=[],
+                    top_k=1,
+                    run_config=node_config,
+                )
+
+        assert ranked == ["tool_a"]
+        _args, kwargs = mock_chain.ainvoke.call_args
+        assert kwargs.get("config") is node_config
 
     @pytest.mark.asyncio
     async def test_context_summarization_does_not_wrap_model_with_config(self):

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -52,7 +52,7 @@ class TestLangfuseTracingHelpers:
         assert get_langfuse_invoke_config() == {"callbacks": [cb]}
 
     def test_collect_merges_top_level_and_configurable(self):
-        a, b = _RecordingCallback("a"), _RecordingCallback("b")
+        a, b = _fake_langfuse_handler(), _fake_langfuse_handler()
         config = {
             "callbacks": [a],
             "configurable": {"callbacks": [b]},
@@ -60,8 +60,18 @@ class TestLangfuseTracingHelpers:
         merged = collect_langfuse_callbacks_from_config(config)
         assert merged == [a, b]
 
+    def test_collect_ignores_non_langfuse_handlers(self):
+        lf = _fake_langfuse_handler()
+        config = {"callbacks": [_RecordingCallback("other"), lf]}
+        assert collect_langfuse_callbacks_from_config(config) == [lf]
+
+    def test_collect_flattens_callback_manager(self):
+        lf = _fake_langfuse_handler()
+        manager = type("AsyncCallbackManager", (), {"handlers": [lf, _RecordingCallback("x")]})()
+        assert collect_langfuse_callbacks_from_config({"callbacks": manager}) == [lf]
+
     def test_sync_from_config_populates_context(self):
-        cb = _RecordingCallback("from-config")
+        cb = _fake_langfuse_handler()
         sync_langfuse_callbacks_from_config({"configurable": {"callbacks": [cb]}})
         assert get_langfuse_invoke_config() == {"callbacks": [cb]}
 

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -19,6 +19,7 @@ from cuga.backend.cuga_graph.utils.langfuse_tracing import (
     get_langfuse_invoke_config,
     is_langfuse_callback_handler,
     set_langfuse_callbacks,
+    set_langfuse_trace_id,
     sync_langfuse_callbacks_from_config,
 )
 
@@ -38,8 +39,10 @@ def _fake_langfuse_handler():
 @pytest.fixture(autouse=True)
 def _clear_langfuse_context():
     set_langfuse_callbacks(None)
+    set_langfuse_trace_id(None)
     yield
     set_langfuse_callbacks(None)
+    set_langfuse_trace_id(None)
 
 
 class TestLangfuseTracingHelpers:
@@ -47,9 +50,13 @@ class TestLangfuseTracingHelpers:
         assert get_langfuse_invoke_config() == {}
 
     def test_set_callbacks_visible_in_invoke_config(self):
-        cb = _RecordingCallback("trace-scoped")
+        cb = _fake_langfuse_handler()
         set_langfuse_callbacks([cb])
         assert get_langfuse_invoke_config() == {"callbacks": [cb]}
+
+    def test_non_langfuse_callbacks_are_not_propagated(self):
+        set_langfuse_callbacks([_RecordingCallback("token-tracker")])
+        assert get_langfuse_invoke_config() == {}
 
     def test_collect_merges_top_level_and_configurable(self):
         a, b = _fake_langfuse_handler(), _fake_langfuse_handler()
@@ -74,6 +81,25 @@ class TestLangfuseTracingHelpers:
         cb = _fake_langfuse_handler()
         sync_langfuse_callbacks_from_config({"configurable": {"callbacks": [cb]}})
         assert get_langfuse_invoke_config() == {"callbacks": [cb]}
+
+    def test_sync_trace_id_builds_handler_when_no_callbacks(self):
+        handler = _fake_langfuse_handler()
+        with patch(
+            "cuga.backend.cuga_graph.utils.langfuse_tracing.create_trace_langfuse_handler",
+            return_value=handler,
+        ):
+            sync_langfuse_callbacks_from_config({"configurable": {"langfuse_trace_id": "abc123"}})
+            assert get_langfuse_invoke_config() == {"callbacks": [handler]}
+
+    def test_get_invoke_config_ignores_non_langfuse_callbacks(self):
+        set_langfuse_callbacks([_RecordingCallback("stale")])
+        set_langfuse_trace_id("trace-99")
+        fresh = _fake_langfuse_handler()
+        with patch(
+            "cuga.backend.cuga_graph.utils.langfuse_tracing.create_trace_langfuse_handler",
+            return_value=fresh,
+        ):
+            assert get_langfuse_invoke_config() == {"callbacks": [fresh]}
 
     def test_is_langfuse_callback_handler_detects_langfuse_types(self):
         assert is_langfuse_callback_handler(_fake_langfuse_handler())
@@ -125,7 +151,7 @@ class TestNestedCallSites:
         from cuga.backend.cuga_graph.nodes.cuga_lite import nl_auto_continue_classifier as mod
         from cuga.config import settings
 
-        cb = _RecordingCallback("nl")
+        cb = _fake_langfuse_handler()
         set_langfuse_callbacks([cb])
 
         mock_llm = MagicMock()
@@ -171,7 +197,7 @@ class TestNestedCallSites:
         from cuga.backend.cuga_graph.policy.enactment import PolicyEnactment
         from cuga.backend.cuga_graph.policy.models import OutputFormatter
 
-        cb = _RecordingCallback("formatter")
+        cb = _fake_langfuse_handler()
         set_langfuse_callbacks([cb])
 
         policy = OutputFormatter(

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -101,6 +101,23 @@ class TestSdkCallbackDedup:
         assert id(agent_level) not in callback_ids
         assert run_config["configurable"]["callbacks"] == run_config["callbacks"]
 
+    def test_apply_callbacks_reads_only_top_level_callbacks(self):
+        from cuga.sdk import CugaAgent
+
+        caller = _RecordingCallback("caller")
+        config_only = _RecordingCallback("configurable-only")
+        agent = CugaAgent.__new__(CugaAgent)
+        agent._callbacks = []
+
+        run_config = {
+            "callbacks": [caller],
+            "configurable": {"callbacks": [config_only]},
+        }
+        agent._apply_callbacks(run_config)
+        assert caller in run_config["callbacks"]
+        assert config_only not in run_config["callbacks"]
+        assert run_config["configurable"]["callbacks"] == run_config["callbacks"]
+
 
 class TestNestedCallSites:
     @pytest.mark.asyncio

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -186,20 +186,18 @@ class TestNestedCallSites:
         assert kwargs.get("config") == {"callbacks": [cb]}
 
     @pytest.mark.asyncio
-    async def test_context_summarization_binds_model_with_callbacks(self):
+    async def test_context_summarization_does_not_wrap_model_with_config(self):
+        """with_config(callbacks) breaks ContextSummarizer profile setup; use contextvar instead."""
         from langchain_core.messages import HumanMessage
 
         from cuga.backend.cuga_graph.utils.context_management_utils import (
             apply_context_summarization,
         )
 
-        cb = _RecordingCallback("summarize")
-        set_langfuse_callbacks([cb])
+        set_langfuse_callbacks([_RecordingCallback("summarize")])
 
         base_model = MagicMock()
-        bound_model = MagicMock()
-        base_model.with_config.return_value = bound_model
-
+        base_model.model_name = "gpt-4"
         messages = [HumanMessage(content="hello")]
 
         with patch("cuga.backend.cuga_graph.utils.context_management_utils.AgentState") as mock_state_cls:
@@ -218,6 +216,6 @@ class TestNestedCallSites:
                     message_list_name="chat_messages",
                 )
 
-        base_model.with_config.assert_called_once_with({"callbacks": [cb]})
+        base_model.with_config.assert_not_called()
         mock_manage.assert_awaited_once()
         assert result == messages


### PR DESCRIPTION
## Bug fix

Fixes #276

### Summary

Nested LLM paths (reflection, find_tools shortlister, NL auto-continue, output formatter, context summarization) did not inherit Langfuse `CallbackHandler` config from the parent graph invoke, so one logical `CugaAgent.invoke()` could produce multiple root traces in Langfuse. This change adds `langfuse_tracing.py` (contextvar + `get_langfuse_invoke_config()`), wires those call sites, and deduplicates agent-level vs per-invoke Langfuse handlers in `sdk._apply_callbacks`.

Related eval harness work: [cuga-eval#28](https://github.com/cuga-project/cuga-eval/issues/28).

### Testing

- [x] Verified fix locally; automated acceptance tests below pass (manual Langfuse UI check omitted — screenshots to follow on the issue).

## Acceptance test (automated regression — no Langfuse API keys)

### Prerequisites

```bash
source .venv/bin/activate
pip install -e ".[dev]"
```

### (a) Problem — `main`

```bash
git fetch origin
git checkout main
git pull origin main
```

Smoke check:

```bash
grep -n 'config={"callbacks": \[\]}' \
  src/cuga/backend/cuga_graph/nodes/cuga_lite/nl_auto_continue_classifier.py
```

Expected: one line (e.g. `121:            config={"callbacks": []},`) — NL auto-continue passes an empty callback list.

Run:

```bash
cat > /tmp/langfuse_before_check.py <<'PY'
import asyncio
from unittest.mock import AsyncMock, MagicMock, patch


async def main():
    from cuga.backend.cuga_graph.nodes.cuga_lite import nl_auto_continue_classifier as mod
    from cuga.config import settings

    llm = MagicMock()
    llm.ainvoke = AsyncMock(return_value=MagicMock(content='{"auto_continue": false}'))

    with patch.object(settings.advanced_features, "cuga_lite_nl_auto_continue", True, create=True):
        await mod.classify_nl_auto_continue(
            llm,
            assistant_visible="done with the task",
            reasoning_excerpt="finished",
        )

    _, kwargs = llm.ainvoke.call_args
    callbacks = (kwargs.get("config") or {}).get("callbacks") or []
    if callbacks:
        raise SystemExit("UNEXPECTED: callbacks present on main")
    print("OK (before): nested ainvoke has no Langfuse callbacks")


asyncio.run(main())
PY
python /tmp/langfuse_before_check.py
```

Expected: `OK (before): nested ainvoke has no Langfuse callbacks`

### (b) Fixed — `fix/langfuse-nested-callback-propagation`

```bash
git fetch origin
git checkout fix/langfuse-nested-callback-propagation
git pull origin fix/langfuse-nested-callback-propagation
```

Smoke check:

```bash
grep -n 'get_langfuse_invoke_config' \
  src/cuga/backend/cuga_graph/nodes/cuga_lite/nl_auto_continue_classifier.py
grep -n 'config={"callbacks": \[\]}' \
  src/cuga/backend/cuga_graph/nodes/cuga_lite/nl_auto_continue_classifier.py \
  && echo "FAIL: still clears callbacks" || echo "OK: no hard-coded empty callbacks"
```

Expected: first `grep` prints a line with `get_langfuse_invoke_config`; second prints `OK: no hard-coded empty callbacks` (exit 0).

Unit tests:

```bash
python -m pytest tests/unit/test_langfuse_tracing.py -v --tb=short
```

Expected: `10 passed`

Run:

```bash
cat > /tmp/langfuse_after_check.py <<'PY'
import asyncio
from unittest.mock import AsyncMock, MagicMock, patch


class _Cb:
    pass


async def main():
    from cuga.backend.cuga_graph.nodes.cuga_lite import nl_auto_continue_classifier as mod
    from cuga.backend.cuga_graph.utils.langfuse_tracing import set_langfuse_callbacks
    from cuga.config import settings

    set_langfuse_callbacks([_Cb()])

    llm = MagicMock()
    llm.ainvoke = AsyncMock(return_value=MagicMock(content='{"auto_continue": false}'))

    with patch.object(settings.advanced_features, "cuga_lite_nl_auto_continue", True, create=True):
        await mod.classify_nl_auto_continue(
            llm,
            assistant_visible="done with the task",
            reasoning_excerpt="finished",
        )

    _, kwargs = llm.ainvoke.call_args
    callbacks = (kwargs.get("config") or {}).get("callbacks") or []
    if not callbacks:
        raise SystemExit("FAIL (after): expected callbacks in nested ainvoke config")
    print("OK (after): nested ainvoke receives propagated callbacks")


asyncio.run(main())
PY
python /tmp/langfuse_after_check.py
```

Expected: `OK (after): nested ainvoke receives propagated callbacks`

## Test run results (2026-06-02, local)

### (a) `main`

Smoke check:

```
119:            config={"callbacks": []},
```

`/tmp/langfuse_before_check.py`:

```
OK (before): nested ainvoke has no Langfuse callbacks
```

### (b) `fix/langfuse-nested-callback-propagation`

Smoke check:

```
114:        from cuga.backend.cuga_graph.utils.langfuse_tracing import get_langfuse_invoke_config
121:            config=get_langfuse_invoke_config(),
OK: no hard-coded empty callbacks
```

`pytest tests/unit/test_langfuse_tracing.py -v --tb=short`:

```
============================== 10 passed in 6.27s ===============================
```

`/tmp/langfuse_after_check.py`:

```
OK (after): nested ainvoke receives propagated callbacks
```

## Manual Langfuse UI (optional; API keys)

From repo root, with venv active. Set in `.env` or export:

- `DYNACONF_ADVANCED_FEATURES__LANGFUSE_TRACING=true`
- `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST`
- Your usual LLM key (`OPENAI_API_KEY`, `GROQ_API_KEY`, etc.)

Use the **fix branch** for the AFTER UI check; use **`main`** for BEFORE.

```bash
cat > /tmp/langfuse_one_invoke.py <<'PY'
import asyncio
import os
import uuid

from dotenv import load_dotenv
from langchain_core.tools import tool

load_dotenv()


@tool
def add_numbers(a: int, b: int) -> int:
    """Add two integers and return the sum."""
    return a + b


async def main():
    from cuga import CugaAgent
    from cuga.config import settings
    from langfuse import get_client
    from langfuse.langchain import CallbackHandler

    thread_id = f"repro-{uuid.uuid4().hex[:8]}"
    agent = CugaAgent(tools=[add_numbers])
    prompt = "What is 17 + 25? Use add_numbers if helpful."

    if not getattr(settings.advanced_features, "langfuse_tracing", False):
        raise SystemExit("Enable LANGFUSE env + DYNACONF_ADVANCED_FEATURES__LANGFUSE_TRACING=true")

    client = get_client()
    trace_id = client.create_trace_id(seed=thread_id)
    handler = CallbackHandler(trace_context={"trace_id": trace_id})
    config = {
        "callbacks": [handler],
        "configurable": {"langfuse_trace_id": trace_id, "thread_id": thread_id},
    }
    print(f"trace_id: {trace_id}")

    with client.start_as_current_observation(
        as_type="span",
        name=f"repro_{thread_id}",
        trace_context={"trace_id": trace_id},
        input={"prompt": prompt},
    ):
        result = await agent.invoke(prompt, thread_id=thread_id, config=config)

    print(result.answer[:500])
    client.flush()
    host = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com").rstrip("/")
    print(f"Langfuse: {host}/trace/{trace_id}")


asyncio.run(main())
PY
python /tmp/langfuse_one_invoke.py
```

**Before (`main`):** several root traces in the UI for one run.

**After (fix branch):** one root trace with nested generations. Attach screenshots and the printed `trace_id`.

## Results of Manual UI Test:

### Screenshots:

#### List view: 1st line as BEFORE fix, 2nd line is AFTER fix:

<img width="1259" height="101" alt="image" src="https://github.com/user-attachments/assets/ff067b3f-27fd-48a0-8d49-c41df50859ad" />

#### Detailed view, BEFORE fix

note the 3 top-level nodes and the node name

<img width="493" height="950" alt="image" src="https://github.com/user-attachments/assets/2e56e8bf-6889-4eca-851f-fdbe6f05c49c" />


#### Detailed view, AFTER fix

note the single LangGraph top-level node

<img width="497" height="950" alt="image" src="https://github.com/user-attachments/assets/f097a9a2-e62b-45a5-b3b8-646c8dac28ec" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Langfuse tracing propagation so nested LLM calls share a single trace scope.

* **Bug Fixes**
  * Prevented duplicate root traces so one agent invocation yields a single, correctly nested trace tree.

* **Documentation**
  * New guidance on nested-callback propagation, verification steps, and acceptance criteria for tracing.

* **Tests**
  * Added comprehensive unit tests covering callback collection, context propagation, SDK deduplication, and nested-call regressions.

* **Chores**
  * Added a reproducible script to validate callback propagation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->