### PR TITLE
fix(supervisor): handle pydantic model iteration in _agent_card_description

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
@@ -47,10 +47,19 @@ def _agent_card_description(agent_card: "AgentCard") -> str:
         parts.append(str(agent_card.description))
     caps = getattr(agent_card, "capabilities", None)
     if caps:
-        parts.append(f"Capabilities: {', '.join(caps)}")
+        # AgentCapabilities is a pydantic model; in pydantic v1 iterating it yields
+        # (field_name, value) tuples — extract only the enabled boolean flags.
+        try:
+            enabled = [k for k, v in caps if isinstance(v, bool) and v]
+            if enabled:
+                parts.append(f"Capabilities: {', '.join(enabled)}")
+        except TypeError:
+            pass
     skills = getattr(agent_card, "skills", None)
     if skills:
-        parts.append(f"Skills: {', '.join(skills)}")
+        # AgentSkill objects — use name or id, not the object repr.
+        skill_names = [getattr(s, "name", None) or getattr(s, "id", None) or str(s) for s in skills]
+        parts.append(f"Skills: {', '.join(skill_names)}")
     return " ".join(parts) if parts else "A2A agent"
 
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
@@ -46,18 +46,16 @@ def _agent_card_description(agent_card: "AgentCard") -> str:
     if getattr(agent_card, "description", None):
         parts.append(str(agent_card.description))
     caps = getattr(agent_card, "capabilities", None)
-    if caps:
-        # AgentCapabilities is a pydantic model; in pydantic v1 iterating it yields
-        # (field_name, value) tuples — extract only the enabled boolean flags.
-        try:
-            enabled = [k for k, v in caps if isinstance(v, bool) and v]
+    if caps is not None:
+        if hasattr(caps, "model_dump"):
+            d = caps.model_dump(exclude_none=True)
+            enabled = [k for k, v in d.items() if v is True]
             if enabled:
                 parts.append(f"Capabilities: {', '.join(enabled)}")
-        except TypeError:
-            pass
+        elif isinstance(caps, (list, tuple)):
+            parts.append(f"Capabilities: {', '.join(str(c) for c in caps)}")
     skills = getattr(agent_card, "skills", None)
     if skills:
-        # AgentSkill objects — use name or id, not the object repr.
         skill_names = [getattr(s, "name", None) or getattr(s, "id", None) or str(s) for s in skills]
         parts.append(f"Skills: {', '.join(skill_names)}")
     return " ".join(parts) if parts else "A2A agent"


### PR DESCRIPTION
## Bug fix

Fixes #307

### Summary

`_agent_card_description` in `a2a_protocol.py` called `str.join()` directly on `AgentCapabilities` and `AgentSkill` pydantic objects. In pydantic v1, iterating a model yields `(field_name, value)` tuples — not strings — causing `TypeError: sequence item 0: expected str instance, tuple found` on every supervisor invocation against an external A2A agent.

**Root cause:** Two incorrect assumptions in `_agent_card_description`:
1. `AgentCapabilities` is a plain string iterable — it is a pydantic model
2. `skills` is a list of strings — it is a list of `AgentSkill` objects

**Fix:**
- For capabilities: iterate as `(k, v)` tuples and collect only enabled boolean flags
- For skills: extract the `name` or `id` attribute from each `AgentSkill`

The bug was non-blocking (delegation still worked because `agent_card` is assigned before the error fires), but the supervisor LLM received a degraded description and a noisy warning on every call.

### Testing
- [x] Verified fix locally against a real A2A agent (LangGraph sub-agent with `AgentCapabilities()` and `AgentSkill` entries) — warning no longer appears
- [x] `_agent_card_description` returns correct name/description/skills string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made agent-card capability display more robust: now derives a clear, human-readable capabilities list and safely handles different capability formats.
  * Improved skills display reliability: builds a stable list of skill identifiers by preferring a skill’s name, then id, then fallback string, avoiding broken or inconsistent renderings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->