### PR TITLE
fix(cuga_lite): reset task_todos state on fresh conversation

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
@@ -70,6 +70,15 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
         Disable few-shots entirely via ``advanced_features.cuga_lite_enable_few_shots`` in settings.toml
         or ``cuga_lite_enable_few_shots`` in configurable (skips prefix chat few-shots).
         """
+        # The adapter's task_todos_ref is closure-scoped per compiled graph and
+        # outlives a single .invoke(); state.task_todos can also persist via a
+        # thread-keyed checkpointer. Reset both at the start of a new
+        # conversation so a previous task's plan doesn't leak into this one's
+        # turn-1 system prompt.
+        if len(state.chat_messages or []) <= 1:
+            adapter._task_todos_ref.clear()
+            state.task_todos = None
+
         configurable = config.get("configurable", {}) if config else {}
         enable_todos = (
             configurable.get("enable_todos")

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
@@ -70,12 +70,18 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
         Disable few-shots entirely via ``advanced_features.cuga_lite_enable_few_shots`` in settings.toml
         or ``cuga_lite_enable_few_shots`` in configurable (skips prefix chat few-shots).
         """
-        # The adapter's task_todos_ref is closure-scoped per compiled graph and
+        # Reset cross-task state at the start of a fresh conversation.
+        # adapter._task_todos_ref is closure-scoped per compiled graph and
         # outlives a single .invoke(); state.task_todos can also persist via a
-        # thread-keyed checkpointer. Reset both at the start of a new
-        # conversation so a previous task's plan doesn't leak into this one's
-        # turn-1 system prompt.
-        if len(state.chat_messages or []) <= 1:
+        # thread-keyed checkpointer. We detect "fresh conversation" by message
+        # count (<=1 means just the user's initial message).
+        # The closure ref is cleared in place; state.task_todos is propagated
+        # via every Command.update returned below because in-place state
+        # mutation does not persist through LangGraph.
+        # Note: this does not cover "new task as a follow-up turn on the same
+        # thread" (chat_messages > 1 with a topic change) — tracked separately.
+        is_fresh_conversation = len(state.chat_messages or []) <= 1
+        if is_fresh_conversation:
             adapter._task_todos_ref.clear()
             state.task_todos = None
 
@@ -117,6 +123,11 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
 
             # If policy returned a command (e.g., BLOCK_INTENT), execute it immediately
             if command:
+                # Propagate the task_todos reset through the policy-returned
+                # Command so LangGraph persists it; the in-place state mutation
+                # above does not survive the node return.
+                if is_fresh_conversation and isinstance(getattr(command, "update", None), dict):
+                    command.update.setdefault("task_todos", None)
                 return command
 
             # If policy returned metadata (e.g., playbook guidance), store it
@@ -627,19 +638,23 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
 
         reflection_apps_snapshot = format_apps_for_prompt(apps_for_prompt or [])
 
-        return Command(
-            goto="call_model",
-            update={
-                "tools_prepared": True,
-                "prepared_prompt": dynamic_prompt,
-                "step_count": 0,
-                "cuga_lite_metadata": state.cuga_lite_metadata,
-                "reflection_apps": reflection_apps_snapshot,
-                "reflection_enable_find_tools": enable_find_tools,
-                "reflection_skills_enabled": skills_enabled,
-                "reflection_skills_prompt_section": skills_prompt_section,
-                "mcp_few_shot_messages": few_shot_examples,
-            },
-        )
+        update_payload: dict[str, Any] = {
+            "tools_prepared": True,
+            "prepared_prompt": dynamic_prompt,
+            "step_count": 0,
+            "cuga_lite_metadata": state.cuga_lite_metadata,
+            "reflection_apps": reflection_apps_snapshot,
+            "reflection_enable_find_tools": enable_find_tools,
+            "reflection_skills_enabled": skills_enabled,
+            "reflection_skills_prompt_section": skills_prompt_section,
+            "mcp_few_shot_messages": few_shot_examples,
+        }
+        if is_fresh_conversation:
+            # Carry the task_todos reset through LangGraph state so the
+            # state.task_todos fallback path in prepare_system_content sees an
+            # empty value on the next turn.
+            update_payload["task_todos"] = None
+
+        return Command(goto="call_model", update=update_payload)
 
     return prepare_tools_and_apps

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_task_todos_reset.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_task_todos_reset.py
@@ -1,0 +1,147 @@
+"""Regression test for issue #314 — task_todos reset on fresh conversation.
+
+Verifies that prepare_tools_and_apps:
+1. Clears the closure-scoped adapter._task_todos_ref in place when a
+   conversation starts (chat_messages <= 1)
+2. Propagates the reset through the returned Command.update so LangGraph
+   persists state.task_todos = None — the failure mode flagged in the
+   review of PR #315 where the in-place state mutation was a no-op
+3. Does NOT touch either field on a continuing conversation (HITL resume
+   or follow-up turn)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+def _build_mock_adapter(stale_ref: list[dict]) -> MagicMock:
+    adapter = MagicMock()
+    adapter._task_todos_ref = list(stale_ref)
+    adapter._tools_context = {}
+    adapter._instructions = ""
+    adapter._special_instructions = None
+    adapter._static_prompt = None
+    adapter._thread_id = "test-thread"
+    adapter._model = MagicMock()
+    adapter.set_metadata = MagicMock()
+
+    # Tool provider: no tools, no apps (lets the node finish without I/O)
+    adapter._base_tool_provider = MagicMock()
+    adapter._base_tool_provider.get_all_tools = AsyncMock(return_value=[])
+    adapter._base_tool_provider.get_apps = AsyncMock(return_value=[])
+    adapter._base_tool_provider.get_tools = AsyncMock(return_value=[])
+
+    # Prompt template renders to empty string (we don't assert on the prompt body)
+    rendered = MagicMock()
+    rendered.to_string = MagicMock(return_value="")
+    adapter._prompt_template = MagicMock()
+    adapter._prompt_template.invoke = MagicMock(return_value=rendered)
+    return adapter
+
+
+def _make_state(*, chat_messages: list, task_todos):
+    return SimpleNamespace(
+        chat_messages=chat_messages,
+        task_todos=task_todos,
+        sub_task=None,
+        sub_task_app=None,
+        api_intent_relevant_apps=None,
+        cuga_lite_metadata=None,
+        thread_id="test-thread",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fresh_conversation_clears_ref_and_propagates_through_command_update():
+    """Stale ref + stale state.task_todos on a fresh-invoke first turn:
+    closure ref is cleared in place AND Command.update carries task_todos=None
+    so LangGraph persists the reset (closes the state-fallback leak path that
+    the review of PR #315 flagged as still open).
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
+        create_prepare_tools_and_apps_node,
+    )
+
+    stale_ref = [{"text": "stale Gmail plan", "status": "pending"}]
+    stale_state = [{"text": "stale checkpointed plan", "status": "in_progress"}]
+
+    adapter = _build_mock_adapter(stale_ref)
+    state = _make_state(
+        chat_messages=[HumanMessage(content="new HR task")],
+        task_todos=list(stale_state),
+    )
+
+    # Override only the prepare-node-level config via configurable; let the
+    # real settings module handle deeper layers (filesystem / shell backends
+    # validated by pydantic).
+    configurable = {
+        "enable_todos": False,
+        "shortlisting_tool_threshold": 35,
+    }
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
+        new=False,
+    ):
+        node = create_prepare_tools_and_apps_node(adapter, lc_bind_tools_meta={})
+        result = await node(state, config={"configurable": configurable})
+
+    # 1. Closure-scoped ref cleared in place
+    assert adapter._task_todos_ref == [], (
+        f"_task_todos_ref should be cleared on fresh conversation; got {adapter._task_todos_ref!r}"
+    )
+    # 2. Command.update carries the reset so LangGraph persists state.task_todos = None
+    assert isinstance(result.update, dict), "prepare_tools_and_apps must return Command with an update dict"
+    assert "task_todos" in result.update, (
+        "Command.update must include task_todos to propagate the reset through "
+        "LangGraph state; the in-place state.task_todos = None mutation is a "
+        "no-op (see PR #315 review)"
+    )
+    assert result.update["task_todos"] is None
+
+
+@pytest.mark.asyncio
+async def test_continuing_conversation_preserves_ref_and_omits_task_todos_in_update():
+    """When chat_messages > 1 (multi-turn / HITL resume):
+    closure ref is preserved (in-flight plan still visible to call_model)
+    AND Command.update does NOT contain task_todos (no spurious reset).
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
+        create_prepare_tools_and_apps_node,
+    )
+
+    in_flight_ref = [{"text": "fetch unread email", "status": "in_progress"}]
+
+    adapter = _build_mock_adapter(in_flight_ref)
+    state = _make_state(
+        chat_messages=[
+            HumanMessage(content="original task"),
+            AIMessage(content="assistant turn 1"),
+            HumanMessage(content="continue"),
+        ],
+        task_todos=list(in_flight_ref),
+    )
+
+    configurable = {
+        "enable_todos": False,
+        "shortlisting_tool_threshold": 35,
+    }
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
+        new=False,
+    ):
+        node = create_prepare_tools_and_apps_node(adapter, lc_bind_tools_meta={})
+        result = await node(state, config={"configurable": configurable})
+
+    # 1. In-flight ref preserved
+    assert adapter._task_todos_ref == in_flight_ref, (
+        f"_task_todos_ref must NOT be cleared on a continuing turn; got {adapter._task_todos_ref!r}"
+    )
+    # 2. No spurious task_todos reset in the update
+    assert "task_todos" not in result.update, (
+        "Command.update should not include task_todos on a continuing turn (would erase the in-flight plan)"
+    )


### PR DESCRIPTION
## Bug fix

Fixes #314.

### Summary

When `advanced_features.enable_todos=true`, the closure-scoped `task_todos_ref` (plus the parallel `state.task_todos` checkpointer field) outlived a single `agent.invoke()`. From the second task onward, the previous task's plan leaked into the new task's turn-1 system prompt as `## Current task todos`, biasing the model's first reasoning step before it had any chance to call `create_update_todos` for the new task.

**Root cause:** `CugaAgent._create_graph` memoizes on `self._graph` and only resets in `add_tool()` ([sdk.py:2224](https://github.com/cuga-project/cuga-agent/blob/main/src/cuga/sdk.py#L2224)), so every `.invoke()` reuses the same compiled graph and the same closure-captured list created in `create_cuga_lite_graph` ([cuga_lite_graph.py:180](https://github.com/cuga-project/cuga-agent/blob/main/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_graph.py#L180)). The tool body in [todos.py:123-126](https://github.com/cuga-project/cuga-agent/blob/main/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/todos.py#L123-L126) only does `clear() + extend(new)` — it never resets on a new task. Nothing in the SDK, agent loop, or framework cleared these between invocations.

### Scope

This PR fixes the leak **on a fresh conversation** — detected by `len(state.chat_messages) <= 1`, i.e. an invoke where the only message present is the user's first turn. That covers the production failure mode in the AppWorld harness (one `agent.invoke()` per task, fresh state) and the SDK direct-invoke pattern.

**Out of scope** (will be filed as a separate follow-up issue):
- *New task as a follow-up turn on the same thread.* If a multi-turn conversation has `chat_messages > 1` but the user has changed topic, this PR's guard is false and the leak shape can recur. Detecting a topic change requires more than a message count — a follow-up.
- *Thread-scoped todos for concurrency.* The closure-shared `_task_todos_ref` is a process-global singleton; `.clear()` races across concurrent threads. Pre-existing (the `create_update_todos` tool already mutates the shared ref), but worth a follow-up.

### Fix

At the top of `prepare_tools_and_apps` ([prepare_node.py](https://github.com/cuga-project/cuga-agent/blob/main/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py)):

```python
is_fresh_conversation = len(state.chat_messages or []) <= 1
if is_fresh_conversation:
    adapter._task_todos_ref.clear()      # closure-scoped, mutated in place
    state.task_todos = None               # local consistency only — see below
```

`state.task_todos = None` alone is a no-op because LangGraph reduces state only from the returned `Command.update`. The reset is therefore also propagated through **both** return paths of this node:

- **Policy early-return path** (`BLOCK_INTENT` / playbook / tool-guide): if `is_fresh_conversation`, defensively `setdefault("task_todos", None)` on the policy-returned `Command.update` dict so the reset survives.
- **Main return path** (`goto="call_model"`): build `update_payload` as a local dict and include `"task_todos": None` when `is_fresh_conversation`, then construct the `Command`.

The guard preserves HITL resume (turn 2+ keeps the in-flight plan).

### Verification

Reproduced and verified on a 43-task AppWorld eval bundle (gpt-4.1, `enable_todos=true`):

| Metric | Before fix | After fix |
|---|---:|---:|
| Traces with `## Current task todos` in **turn-1 system prompt** | **42 / 43** | **0 / 43** |
| Traces with `## Current Plan` in turn-1 (state path) | — | 0 / 43 |
| Mean fraction of LLM turns spent on todo-only blocks | 7.1% | 5.6% |

(AppWorld doesn't exercise the state-path checkpointer fallback, so the original commit's no-op for that path didn't show up in the eval; the must-fix commit closes the path nevertheless. See review comment by @sami-marreed.)

Concrete example from the pre-fix bundle — task asking about HR/candidates/`report_template.md` opens with a stale Gmail plan injected as authoritative:

```
## Current task todos
1. **[pending]** Fetch all unread email threads from Gmail inbox (handle pagination)
2. **[pending]** Filter threads for priority-1
3. **[pending]** Count the number of priority-1 unread threads
4. **[pending]** Return the count to the user
```

After the fix, every one of the 43 traces starts turn 1 with a clean system prompt.

### Commits in this PR

- `1780408` fix(cuga_lite): reset task_todos state between invocations (initial fix — closes the closure-ref path)
- `8aaace2` fix(cuga_lite): propagate task_todos reset through Command.update (must-fix from review — closes the state-path checkpointer fallback)

### Testing
- [x] Verified fix locally; tests pass
- [x] Re-ran 43-task AppWorld eval with `enable_todos=true`: leak signature dropped from 42/43 to 0/43
- [x] Existing unit tests under `cuga_lite/tests/test_agent_graph_adapter.py` exercise `prepare_system_content` directly (not `prepare_tools_and_apps`), so they're unaffected by the new clear logic
- [ ] A regression test that seeds stale `_task_todos_ref` + a checkpointed `task_todos` and asserts both are cleared after a fresh-conversation invoke — drafted, to be added in a follow-up commit per the review thread.