### PR TITLE
feat(a2a): expose CUGA over A2A v0.3 + working two-CUGA demo

### DIFF
--- a/docs/examples/a2a_two_cuga/README.md
+++ b/docs/examples/a2a_two_cuga/README.md
@@ -8,7 +8,7 @@ returns the answer.
 
 ## Architecture
 
-```
+```text
        ┌──────────────────────────┐                  ┌──────────────────────────┐
  user  │  CUGA-1 (consumer)       │   A2A v0.3       │  CUGA-2 (provider)       │
  ──→   │  http://localhost:7860/  │  ─JSON-RPC──→    │  http://localhost:8002/  │

--- a/docs/examples/a2a_two_cuga/README.md
+++ b/docs/examples/a2a_two_cuga/README.md
@@ -1,0 +1,108 @@
+# Two CUGAs over A2A
+
+Stand up two CUGA processes that talk to each other over the A2A v0.3
+protocol. **CUGA-1 (consumer)** has no local tools. **CUGA-2 (provider)**
+fronts the `digital_sales` toolset and exposes it over A2A. When you
+chat with CUGA-1, it delegates every task across the wire to CUGA-2 and
+returns the answer.
+
+## Architecture
+
+```
+       ┌──────────────────────────┐                  ┌──────────────────────────┐
+ user  │  CUGA-1 (consumer)       │   A2A v0.3       │  CUGA-2 (provider)       │
+ ──→   │  http://localhost:7860/  │  ─JSON-RPC──→    │  http://localhost:8002/  │
+ chat  │  no local tools          │  /a2a            │  digital_sales toolset   │
+       │  supervisor: 1 ext agent │                  │  A2A inbound enabled     │
+       └──────────────────────────┘                  └──────────────────────────┘
+                       ▲                                          ▲
+                       │ shared                                   │
+                       └─── http://localhost:8001 (registry) ─────┘
+```
+
+## Prerequisites
+
+- An OpenAI key (or another LLM configured) — same as any CUGA run.
+- `uv` available on `PATH`.
+
+## Run
+
+Open three terminals:
+
+**Terminal 1 — registry**
+```bash
+cuga start registry
+```
+This serves the digital_sales OpenAPI tool catalog on `http://localhost:8001`.
+
+**Terminal 2 — provider CUGA (port 8002)**
+```bash
+./docs/examples/a2a_two_cuga/run_provider.sh
+```
+Once it's up, sanity-check the A2A surface:
+```bash
+curl -s http://localhost:8002/.well-known/agent.json | jq .name
+# → "cuga-provider"
+
+curl -s -X POST http://localhost:8002/a2a \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"message/send",
+       "params":{"message":{"role":"user",
+                            "parts":[{"kind":"text","text":"list my territory accounts"}],
+                            "messageId":"m1"}}}' \
+  | jq .result.status.state
+# → "completed"
+```
+
+**Terminal 3 — consumer CUGA (port 7860)**
+```bash
+./docs/examples/a2a_two_cuga/run_consumer.sh
+```
+
+Now open **<http://localhost:7860/>** in a browser and chat:
+
+> *List my top accounts by revenue*
+
+The consumer has no tools of its own, so it routes the question through
+its sole external agent (`provider`) over A2A. The provider's supervisor
+runs `digital_sales` against the registry and the answer flows back to
+the consumer chat UI.
+
+## URLs
+
+- **Chat UI (consumer):** http://localhost:7860/
+- **Provider AgentCard:** http://localhost:8002/.well-known/agent.json
+- **Provider A2A endpoint:** http://localhost:8002/a2a
+- **Registry:** http://localhost:8001/
+
+## How it works
+
+- **`provider.supervisor.yaml`** — declares one internal agent
+  (`digital_sales`) that pulls tools from the registry's `digital_sales`
+  app. The provider CUGA is launched with `DYNACONF_A2A__ENABLED=true`
+  and `DYNACONF_A2A__SUPERVISOR_CONFIG_PATH` pointing at this YAML, so
+  inbound A2A requests are routed through this supervisor.
+
+- **`consumer.supervisor.yaml`** — declares one external agent
+  (`provider`) with `a2a_protocol.transport=http` and
+  `endpoint=http://localhost:8002`. CUGA's existing supervisor flow
+  fetches the provider's AgentCard at startup, surfaces it as a tool to
+  the consumer, and uses `delegate_task_via_a2a_sdk` to POST each
+  delegation as JSON-RPC to the provider's `/a2a`.
+
+- **No auth** — both CUGAs run with `auth_required=false`. The
+  auth-token forwarding test in the integration suite is `xfail` until
+  v1.
+
+## Troubleshooting
+
+- **`HAS_A2A_SDK` is False** — you're on a stale checkout. Run
+  `git pull && uv sync`. The fix to support `a2a-sdk==1.0.2` is in this
+  same commit.
+- **Provider returns "endpoint reached, but … is not yet wired"** —
+  `DYNACONF_A2A__SUPERVISOR_CONFIG_PATH` was not set. Re-run
+  `run_provider.sh`; it sets that env var.
+- **Consumer can't find provider** — check the order: registry first,
+  then provider, then consumer. The consumer's supervisor fetches the
+  provider's AgentCard at startup; if the provider isn't running the
+  consumer logs a warning and falls back to its YAML description.

--- a/docs/examples/a2a_two_cuga/_preflight.py
+++ b/docs/examples/a2a_two_cuga/_preflight.py
@@ -33,6 +33,13 @@ COLUMN = "config_json"
 
 
 def _load_dotenv_into_environ() -> None:
+    """Load ``.env`` keys into ``os.environ`` without overriding the shell.
+
+    Bash does not auto-source ``.env`` for child processes; the run
+    scripts already do, but we also do it here so the preflight works
+    when invoked directly. Existing exported values win — we never
+    clobber what the operator set in their shell.
+    """
     env_file = REPO_ROOT / ".env"
     if not env_file.exists():
         return
@@ -48,6 +55,14 @@ def _load_dotenv_into_environ() -> None:
 
 
 def _patch_saved_llm_model(model_name: str) -> None:
+    """Rewrite every saved ``llm.model`` in cuga.db to ``model_name``.
+
+    Workaround for cuga-project/cuga-agent#322: at lifespan startup,
+    ``_apply_published_config`` calls ``os.environ.pop('MODEL_NAME')``
+    when the saved row's ``llm.model`` is empty, wiping the operator's
+    configured model. By writing ``model_name`` into the saved row we
+    keep the env var alive. Idempotent — running twice is a no-op.
+    """
     if not DB_PATH.exists():
         print(f"[preflight] no cuga.db at {DB_PATH} — nothing to patch")
         return
@@ -80,6 +95,7 @@ def _patch_saved_llm_model(model_name: str) -> None:
 
 
 def main() -> int:
+    """Run the .env load + DB patch and report what was done."""
     _load_dotenv_into_environ()
     model_name = os.environ.get("MODEL_NAME") or os.environ.get("OPENAI_MODEL") or ""
     if not model_name:

--- a/docs/examples/a2a_two_cuga/_preflight.py
+++ b/docs/examples/a2a_two_cuga/_preflight.py
@@ -1,0 +1,97 @@
+"""Preflight for the A2A two-CUGA demo.
+
+Two things this fixes that would otherwise break the demo on a stock
+checkout:
+
+1. ``.env`` — bash run scripts don't auto-load it, so we forward MODEL_NAME
+   and OPENAI_API_KEY to the child process via env. We also surface them
+   in this script's own output so the run scripts can see them.
+
+2. ``cuga.db`` saved config — at lifespan startup, ``_apply_published_config``
+   reads the saved row in the ``agent_configs`` table and, if its
+   ``llm.model`` is empty, calls ``os.environ.pop("MODEL_NAME", None)``.
+   That deletes the value the user just set. We patch the saved row's
+   ``llm.model`` to MODEL_NAME so force_env writes it back instead of
+   nuking it.
+
+Run with: ``uv run python docs/examples/a2a_two_cuga/_preflight.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DB_PATH = REPO_ROOT / "src" / "cuga" / "dbs" / "cuga.db"
+
+TABLE = "agent_configs"
+COLUMN = "config_json"
+
+
+def _load_dotenv_into_environ() -> None:
+    env_file = REPO_ROOT / ".env"
+    if not env_file.exists():
+        return
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        # Don't override anything the user already exported.
+        os.environ.setdefault(key, val)
+
+
+def _patch_saved_llm_model(model_name: str) -> None:
+    if not DB_PATH.exists():
+        print(f"[preflight] no cuga.db at {DB_PATH} — nothing to patch")
+        return
+    conn = sqlite3.connect(str(DB_PATH))
+    try:
+        cur = conn.cursor()
+        cur.execute(f"SELECT rowid, {COLUMN} FROM {TABLE}")
+        rows = cur.fetchall()
+        patched = 0
+        for rowid, raw in rows:
+            try:
+                cfg = json.loads(raw)
+            except Exception:
+                continue
+            llm = cfg.get("llm")
+            if not isinstance(llm, dict):
+                continue
+            if (llm.get("model") or "") == model_name:
+                continue
+            llm["model"] = model_name
+            cur.execute(
+                f"UPDATE {TABLE} SET {COLUMN} = ? WHERE rowid = ?",
+                (json.dumps(cfg), rowid),
+            )
+            patched += 1
+        conn.commit()
+        print(f"[preflight] patched {patched} saved row(s) in {TABLE} with model={model_name!r}")
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    _load_dotenv_into_environ()
+    model_name = os.environ.get("MODEL_NAME") or os.environ.get("OPENAI_MODEL") or ""
+    if not model_name:
+        print("[preflight] WARNING: MODEL_NAME is unset and .env did not provide one.", file=sys.stderr)
+        print("[preflight] Set MODEL_NAME (e.g. 'Azure/gpt-4.1') and re-run.", file=sys.stderr)
+        return 1
+    print(f"[preflight] MODEL_NAME = {model_name}")
+    _patch_saved_llm_model(model_name)
+    if "OPENAI_BASE_URL" in os.environ:
+        print(f"[preflight] OPENAI_BASE_URL = {os.environ['OPENAI_BASE_URL']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/examples/a2a_two_cuga/_preflight.py
+++ b/docs/examples/a2a_two_cuga/_preflight.py
@@ -75,7 +75,11 @@ def _patch_saved_llm_model(model_name: str) -> None:
         for rowid, raw in rows:
             try:
                 cfg = json.loads(raw)
-            except Exception:
+            except json.JSONDecodeError as exc:
+                print(
+                    f"[preflight] skipped rowid={rowid}: invalid JSON ({exc})",
+                    file=sys.stderr,
+                )
                 continue
             llm = cfg.get("llm")
             if not isinstance(llm, dict):

--- a/docs/examples/a2a_two_cuga/consumer.supervisor.yaml
+++ b/docs/examples/a2a_two_cuga/consumer.supervisor.yaml
@@ -1,0 +1,26 @@
+# Consumer CUGA — has no local tools, delegates everything to the
+# provider over A2A.
+#
+# The supervisor here knows about exactly one agent: `provider`, declared
+# as type `external` with an A2A HTTP endpoint pointing at the second
+# CUGA process (default http://localhost:8002). On startup, the supervisor
+# fetches the provider's AgentCard from /.well-known/agent.json and uses
+# it to populate the prompt; at delegation time it POSTs JSON-RPC to the
+# provider's /a2a endpoint via delegate_task_via_a2a_sdk.
+
+supervisor:
+  description: "Consumer CUGA — owns no tools; delegates to a remote provider over A2A."
+  special_instructions: |
+    You have NO local tools. For every user request, delegate to the
+    `provider` agent. The provider is a remote CUGA exposing sales/CRM
+    tooling over A2A. Use `delegate_to_provider("...")` and return the
+    provider's answer to the user without further reasoning.
+
+agents:
+  - name: provider
+    description: "Remote CUGA on http://localhost:8002 fronting the digital_sales toolset over A2A."
+    a2a_protocol:
+      enabled: true
+      transport: http
+      endpoint: "http://localhost:8002"
+      timeout: 30

--- a/docs/examples/a2a_two_cuga/provider.supervisor.yaml
+++ b/docs/examples/a2a_two_cuga/provider.supervisor.yaml
@@ -1,0 +1,26 @@
+# Provider CUGA — exposes the digital_sales toolset over A2A.
+#
+# This supervisor handles inbound A2A requests on the provider side. The
+# A2A router (mounted by main.py when settings.a2a.enabled is true) routes
+# incoming message/send and message/stream calls through this supervisor's
+# `invoke()` method. The supervisor in turn delegates to the digital_sales
+# internal agent, which calls into the digital_sales registry app.
+
+supervisor:
+  description: "Provider CUGA — fronts the digital_sales toolset for remote A2A clients."
+  special_instructions: |
+    You front a single internal agent, `digital_sales`, that has access to
+    the digital sales CRM tools (territory accounts, TPP client info, job
+    role management, contact sync). For ANY user request that resembles a
+    sales / CRM / customer / account / territory query, delegate to
+    `digital_sales`. Do not refuse simple questions — the goal of this
+    deployment is to expose those tools to remote agents over A2A.
+
+agents:
+  - name: digital_sales
+    description: "Sales / CRM operations: territory accounts, client info, contact sync."
+    apps:
+      - name: digital_sales
+    special_instructions: |
+      Use the digital_sales API tools to answer the user's request directly.
+      Return concise, data-grounded answers. Do not narrate steps.

--- a/docs/examples/a2a_two_cuga/run_consumer.sh
+++ b/docs/examples/a2a_two_cuga/run_consumer.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Consumer CUGA — listens on :7860 (the standard CUGA chat-UI port) and
+# delegates EVERY task to the provider on :8002 via A2A. Has no local
+# tools.
+#
+# Prereqs:
+#   1. Registry running on :8001:           cuga start registry
+#   2. Provider CUGA running on :8002:      docs/examples/a2a_two_cuga/run_provider.sh
+#
+# Once running, open the chat UI:
+#   http://localhost:7860/
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+# Load .env (MODEL_NAME, OPENAI_API_KEY, OPENAI_BASE_URL, …). Bash doesn't
+# do this automatically; the Python startup also reads .env, but the saved
+# DB config can later wipe MODEL_NAME from os.environ — see _preflight.py.
+if [[ -f .env ]]; then
+  set -a; source .env; set +a
+fi
+
+# Patch the saved cuga.db row so force_env doesn't pop MODEL_NAME at
+# startup. Idempotent — safe to run on every launch.
+uv run --no-sync python docs/examples/a2a_two_cuga/_preflight.py
+
+CONSUMER_PORT="${CONSUMER_PORT:-7860}"
+REGISTRY_PORT="${REGISTRY_PORT:-8001}"
+
+# The consumer is just a regular CUGA backend whose supervisor is wired
+# to a single external A2A agent. We do NOT enable the A2A inbound
+# endpoint here — the consumer is purely a client.
+#
+# Both flags are required: ENABLED=true flips DynamicAgentGraph into
+# supervisor mode; CONFIG_PATH selects the YAML that declares the
+# external A2A agent.
+export DYNACONF_A2A__ENABLED=false
+export DYNACONF_SUPERVISOR__ENABLED=true
+export DYNACONF_SUPERVISOR__CONFIG_PATH="docs/examples/a2a_two_cuga/consumer.supervisor.yaml"
+export DYNACONF_SERVER_PORTS__DEMO="${CONSUMER_PORT}"
+export DYNACONF_SERVER_PORTS__REGISTRY="${REGISTRY_PORT}"
+
+echo "Consumer CUGA starting on http://localhost:${CONSUMER_PORT}"
+echo "  Open this in a browser to chat:  http://localhost:${CONSUMER_PORT}/"
+echo "  Delegating to provider at:       http://localhost:8002"
+echo
+exec uv run --no-sync uvicorn cuga.backend.server.main:app \
+  --host 127.0.0.1 \
+  --port "${CONSUMER_PORT}"

--- a/docs/examples/a2a_two_cuga/run_provider.sh
+++ b/docs/examples/a2a_two_cuga/run_provider.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Provider CUGA — listens on :8002 and exposes the digital_sales toolset
+# over A2A. The A2A inbound endpoint routes through the supervisor defined
+# in provider.supervisor.yaml.
+#
+# Prereq: a registry must be running on :8001. Start one in another
+# terminal with:  cuga start registry
+#
+# Once running:
+#   curl http://localhost:8002/.well-known/agent.json | jq .name
+#   # → "cuga-provider"
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+# Load .env and patch the saved cuga.db config — same shape as the
+# consumer script. See _preflight.py for the rationale.
+if [[ -f .env ]]; then
+  set -a; source .env; set +a
+fi
+uv run --no-sync python docs/examples/a2a_two_cuga/_preflight.py
+
+PROVIDER_PORT="${PROVIDER_PORT:-8002}"
+REGISTRY_PORT="${REGISTRY_PORT:-8001}"
+
+export DYNACONF_A2A__ENABLED=true
+export DYNACONF_A2A__AGENT_NAME="cuga-provider"
+export DYNACONF_A2A__AGENT_DESCRIPTION="CUGA exposing digital_sales tools over A2A."
+export DYNACONF_A2A__AGENT_URL="http://localhost:${PROVIDER_PORT}"
+export DYNACONF_A2A__SUPERVISOR_CONFIG_PATH="docs/examples/a2a_two_cuga/provider.supervisor.yaml"
+export DYNACONF_A2A__SKILL_IDS='["digital_sales"]'
+
+# Also enable the supervisor for the LOCAL chat flow on this same process.
+# Even if you only ever hit the provider via /a2a, the LLM-mode toggle and
+# graph-build path expect supervisor.enabled to be true alongside config_path.
+export DYNACONF_SUPERVISOR__ENABLED=true
+export DYNACONF_SUPERVISOR__CONFIG_PATH="docs/examples/a2a_two_cuga/provider.supervisor.yaml"
+export DYNACONF_SERVER_PORTS__DEMO="${PROVIDER_PORT}"
+export DYNACONF_SERVER_PORTS__REGISTRY="${REGISTRY_PORT}"
+
+echo "Provider CUGA starting on http://localhost:${PROVIDER_PORT}"
+echo "  AgentCard:    http://localhost:${PROVIDER_PORT}/.well-known/agent.json"
+echo "  A2A endpoint: http://localhost:${PROVIDER_PORT}/a2a"
+echo
+exec uv run --no-sync uvicorn cuga.backend.server.main:app \
+  --host 127.0.0.1 \
+  --port "${PROVIDER_PORT}"

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
@@ -136,20 +136,42 @@ async def fetch_agent_card(
 def _agent_card_rpc_url(agent_card: "AgentCard", fallback_base: Optional[str] = None) -> str:
     """Pick the JSON-RPC endpoint to POST to.
 
-    The v0.3 AgentCard's ``url`` field points at the agent's RPC endpoint.
-    Some servers advertise the base host instead; in that case we append
-    ``/a2a`` (the convention used by CUGA's own router). If neither is
-    usable, fall back to the caller-supplied base.
+    Two AgentCard shapes are in play depending on which class the caller
+    hands us:
+
+    - v0.3 pydantic (``a2a.compat.v0_3.types.AgentCard``) — has a
+      top-level ``url`` field pointing at the agent's RPC endpoint.
+    - v1.0 protobuf (``a2a.types.a2a_pb2.AgentCard``) — what
+      ``A2ACardResolver.get_agent_card`` actually returns on SDK 1.x.
+      No top-level ``url``; the URL lives in
+      ``supported_interfaces[0].url`` along with a ``protocol_binding``
+      ("JSONRPC", "GRPC", …) and ``protocol_version``.
+
+    We try both shapes, prefer a JSONRPC-bound interface when there are
+    multiple, and fall back to ``fallback_base`` if neither yields a URL.
+    Once we have a base, we append ``/a2a`` unless the URL already ends
+    in a recognized transport path.
     """
-    url = (getattr(agent_card, "url", None) or fallback_base or "").rstrip("/")
+    url = (getattr(agent_card, "url", None) or "").strip()
+
+    if not url:
+        for iface in getattr(agent_card, "supported_interfaces", None) or []:
+            iface_url = (getattr(iface, "url", None) or "").strip()
+            binding = (getattr(iface, "protocol_binding", None) or "").upper()
+            if not iface_url:
+                continue
+            if binding == "JSONRPC":
+                url = iface_url
+                break
+            if not url:
+                url = iface_url  # remember first interface; keep looking for JSONRPC
+
+    url = (url or fallback_base or "").rstrip("/")
     if not url:
         raise RuntimeError("Agent card carries no URL and no fallback was supplied.")
-    if url.endswith("/a2a"):
+    if any(url.endswith(p) for p in ("/a2a", "/jsonrpc", "/rpc")):
         return url
-    # Heuristic: an agent card usually points at the agent's chat URL,
-    # not the JSON-RPC endpoint. Append /a2a if it doesn't already end in
-    # one of the standard transport paths.
-    return url if any(url.endswith(p) for p in ("/jsonrpc", "/rpc")) else f"{url}/a2a"
+    return f"{url}/a2a"
 
 
 async def delegate_task_via_a2a_sdk(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
@@ -58,6 +58,7 @@ def _extract_text_from_task(task_dict: Dict[str, Any]) -> str:
 
 
 def _agent_card_description(agent_card: "AgentCard") -> str:
+    """Render a one-line summary of an AgentCard for prompt embedding."""
     parts = []
     if getattr(agent_card, "name", None):
         parts.append(str(agent_card.name))
@@ -116,6 +117,12 @@ async def fetch_agent_card(
     auth: Optional[Dict[str, str]] = None,
     timeout: float = 30.0,
 ) -> "AgentCard":
+    """Fetch the peer's AgentCard from its well-known path.
+
+    Uses the SDK's ``A2ACardResolver`` (still works on a2a-sdk 1.x), so
+    the returned card is a protobuf instance whose URL lives in
+    ``supported_interfaces`` rather than as a top-level ``url`` attribute.
+    """
     if not HAS_A2A_SDK:
         raise ImportError("a2a-sdk is required for A2A HTTP. Install with: uv add a2a-sdk")
     headers = {}
@@ -246,6 +253,7 @@ class A2AProtocol:
         auth: Optional[Dict[str, str]] = None,
         timeout: int = 30,
     ):
+        """Configure the legacy protocol client; no I/O until ``connect()``."""
         self.endpoint = endpoint
         self.transport = transport.lower()
         self.auth = auth or {}
@@ -255,6 +263,7 @@ class A2AProtocol:
         self._ws = None
 
     async def connect(self) -> None:
+        """Open the underlying transport (http session, sse, websocket, …)."""
         if self.transport == "http":
             try:
                 import aiohttp
@@ -288,6 +297,7 @@ class A2AProtocol:
             raise ValueError(f"Unsupported transport type: {self.transport}")
 
     async def disconnect(self) -> None:
+        """Close the transport opened by ``connect()``; safe to call twice."""
         if self.transport == "http" and self._session:
             await self._session.close()
             self._session = None
@@ -302,6 +312,7 @@ class A2AProtocol:
             logger.info("Closed WebSocket connection")
 
     def _get_auth_headers(self) -> Dict[str, str]:
+        """Build the ``Authorization`` header dict for the configured auth."""
         headers = {}
         if self.auth.get("type") == "bearer" and self.auth.get("token"):
             headers["Authorization"] = f"Bearer {self.auth['token']}"
@@ -314,6 +325,7 @@ class A2AProtocol:
         context: Dict[str, Any],
         variables: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
+        """Send a ``task_delegation`` message and return the peer's response."""
         message = {
             "protocol_version": "1.0",
             "message_type": "task_delegation",
@@ -363,6 +375,7 @@ class A2AProtocol:
         variables: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
+        """Push a ``result_sharing`` message to ``target_agent`` (fire-and-forget)."""
         message = {
             "protocol_version": "1.0",
             "message_type": "result_sharing",
@@ -393,6 +406,7 @@ class A2AProtocol:
             logger.warning("STDIO transport for result sharing not fully implemented")
 
     async def discover_capabilities(self, agent_name: str) -> List[str]:
+        """Ask ``agent_name`` for its supported capabilities; ``[]`` on failure."""
         message = {
             "protocol_version": "1.0",
             "message_type": "capability_query",
@@ -430,6 +444,7 @@ class A2AProtocol:
             return []
 
     async def get_agent_status(self, agent_name: str) -> Dict[str, Any]:
+        """Probe ``agent_name`` for liveness/status; ``{'status': 'unknown'}`` on failure."""
         message = {
             "protocol_version": "1.0",
             "message_type": "status_query",

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
@@ -162,6 +162,11 @@ def _agent_card_rpc_url(agent_card: "AgentCard", fallback_base: Optional[str] = 
     url = (getattr(agent_card, "url", None) or "").strip()
 
     if not url:
+        # Pick the first JSONRPC interface; if none, fall back to the first
+        # *HTTP(S)* interface so we never POST to a grpc:// (or otherwise
+        # unsupported) URL — that would fail confusingly downstream in
+        # httpx.
+        http_fallback = ""
         for iface in getattr(agent_card, "supported_interfaces", None) or []:
             iface_url = (getattr(iface, "url", None) or "").strip()
             binding = (getattr(iface, "protocol_binding", None) or "").upper()
@@ -170,8 +175,10 @@ def _agent_card_rpc_url(agent_card: "AgentCard", fallback_base: Optional[str] = 
             if binding == "JSONRPC":
                 url = iface_url
                 break
-            if not url:
-                url = iface_url  # remember first interface; keep looking for JSONRPC
+            if not http_fallback and iface_url.lower().startswith(("http://", "https://")):
+                http_fallback = iface_url
+        if not url:
+            url = http_fallback
 
     url = (url or fallback_base or "").rstrip("/")
     if not url:
@@ -234,10 +241,18 @@ async def delegate_task_via_a2a_sdk(
 
     result_obj = body.get("result") if isinstance(body, dict) else None
     if not isinstance(result_obj, dict):
-        return {"result": "", "variables": {}, "status": "success"}
+        # The peer answered 200 but with no recognizable Task envelope —
+        # treat as a transport-level failure rather than silently flattening.
+        raise RuntimeError("A2A response is missing a valid `result` task envelope")
 
     text = _extract_text_from_task(result_obj)
-    return {"result": text, "variables": {}, "status": "success"}
+    state = str(((result_obj.get("status") or {}).get("state") or "")).lower()
+    # Map peer's TaskState to caller-visible status. Anything that smells like
+    # failure becomes status="failed" so upstream callers can distinguish a
+    # successful delegation from one whose remote execution actually errored.
+    normalized_status = "failed" if ("fail" in state or "error" in state) else "success"
+    out_vars = (result_obj.get("metadata") or {}).get("variables") or {}
+    return {"result": text, "variables": out_vars, "status": normalized_status}
 
 
 class A2AProtocol:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py
@@ -1,9 +1,12 @@
 """
 A2A Protocol - Agent-to-Agent communication.
 
-HTTP transport uses a2a-sdk (A2ACardResolver, A2AClient): fetch agent card from
-well-known path, send message with task only (no variables). Other transports
-use legacy A2AProtocol.
+HTTP transport speaks A2A v0.3 JSON-RPC directly to the peer's ``/a2a``
+endpoint. We pull pydantic types from ``a2a.compat.v0_3.types`` (the
+installed ``a2a-sdk`` 1.x ships v0.3 wire shapes there) and use the
+SDK's ``A2ACardResolver`` for the well-known agent-card lookup. Other
+transports (sse/websocket/stdio) still use the legacy ``A2AProtocol``
+class below.
 """
 
 from __future__ import annotations
@@ -16,27 +19,42 @@ from loguru import logger
 
 try:
     import httpx
-    from a2a.client import A2ACardResolver, A2AClient
-    from a2a.types import (
+    from a2a.client import A2ACardResolver
+    from a2a.compat.v0_3.types import (
         AgentCard,
-        JSONRPCErrorResponse,
-        Message,
-        MessageSendParams,
-        Part,
-        Role,
-        SendMessageRequest,
         Task,
-        TextPart,
     )
     from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
-    from a2a.utils.message import get_message_text
 
     HAS_A2A_SDK = True
 except ImportError:
     HAS_A2A_SDK = False
     AgentCard = None
     Task = None
-    JSONRPCErrorResponse = None
+
+
+def _extract_text_from_task(task_dict: Dict[str, Any]) -> str:
+    """Pull human-readable text from a v0.3 Task envelope.
+
+    Prefers the most recent agent message in ``history`` since A2A returns
+    the full conversation; falls back to the status message, then to the
+    raw JSON if all else fails.
+    """
+    history = task_dict.get("history") or []
+    for msg in reversed(history):
+        if msg.get("role") != "agent":
+            continue
+        for part in msg.get("parts") or []:
+            text = part.get("text") if isinstance(part, dict) else None
+            if isinstance(text, str) and text:
+                return text
+    status = task_dict.get("status") or {}
+    status_msg = status.get("message") or {}
+    for part in status_msg.get("parts") or []:
+        text = part.get("text") if isinstance(part, dict) else None
+        if isinstance(text, str) and text:
+            return text
+    return ""
 
 
 def _agent_card_description(agent_card: "AgentCard") -> str:
@@ -115,51 +133,82 @@ async def fetch_agent_card(
     return card
 
 
+def _agent_card_rpc_url(agent_card: "AgentCard", fallback_base: Optional[str] = None) -> str:
+    """Pick the JSON-RPC endpoint to POST to.
+
+    The v0.3 AgentCard's ``url`` field points at the agent's RPC endpoint.
+    Some servers advertise the base host instead; in that case we append
+    ``/a2a`` (the convention used by CUGA's own router). If neither is
+    usable, fall back to the caller-supplied base.
+    """
+    url = (getattr(agent_card, "url", None) or fallback_base or "").rstrip("/")
+    if not url:
+        raise RuntimeError("Agent card carries no URL and no fallback was supplied.")
+    if url.endswith("/a2a"):
+        return url
+    # Heuristic: an agent card usually points at the agent's chat URL,
+    # not the JSON-RPC endpoint. Append /a2a if it doesn't already end in
+    # one of the standard transport paths.
+    return url if any(url.endswith(p) for p in ("/jsonrpc", "/rpc")) else f"{url}/a2a"
+
+
 async def delegate_task_via_a2a_sdk(
     agent_card: "AgentCard",
     task: str,
     auth: Optional[Dict[str, str]] = None,
     timeout: float = 30.0,
     variables: Optional[Dict[str, Any]] = None,
+    rpc_url: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """
-    Delegate by sending a user message. Optionally pass variables in request metadata (extension).
-    Returns dict with keys: result (str), variables (dict), status (str).
+    """Delegate a task to a remote A2A agent over v0.3 JSON-RPC.
+
+    Returns dict with keys: ``result`` (str), ``variables`` (dict),
+    ``status`` (str). When ``variables`` is provided, it is forwarded in
+    request metadata as the A2A ``variables`` extension.
+
+    ``rpc_url`` overrides the URL discovered from the agent card; mostly
+    useful when callers already know the endpoint and want to skip the
+    inference step.
     """
     if not HAS_A2A_SDK:
         raise ImportError("a2a-sdk is required. Install with: uv add a2a-sdk")
-    headers = {}
+
+    target_url = rpc_url or _agent_card_rpc_url(agent_card)
+
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
     if auth and auth.get("type") == "bearer" and auth.get("token"):
         headers["Authorization"] = f"Bearer {auth['token']}"
-    message_id = uuid4().hex
-    user_msg = Message(
-        role=Role.user,
-        parts=[Part(root=TextPart(text=task))],
-        message_id=message_id,
-    )
-    metadata = {"variables": variables} if variables else None
-    params = MessageSendParams(message=user_msg, metadata=metadata)
-    request = SendMessageRequest(id=str(uuid4()), params=params)
-    async with httpx.AsyncClient(timeout=timeout) as httpx_client:
-        client = A2AClient(httpx_client=httpx_client, agent_card=agent_card)
-        response = await client.send_message(
-            request,
-            http_kwargs={"headers": headers} if headers else None,
-        )
-    root = getattr(response, "root", response)
-    if isinstance(root, JSONRPCErrorResponse) and getattr(root, "error", None):
-        raise RuntimeError(f"A2A send_message failed: {root.error}")
-    result_obj = getattr(root, "result", None)
-    if result_obj is None:
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid4()),
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": task}],
+                "messageId": uuid4().hex,
+            }
+        },
+    }
+    if variables:
+        payload["params"]["metadata"] = {"variables": variables}
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.post(target_url, json=payload, headers=headers)
+        resp.raise_for_status()
+        body = resp.json()
+
+    err = body.get("error") if isinstance(body, dict) else None
+    if err:
+        raise RuntimeError(f"A2A send_message failed: {err}")
+
+    result_obj = body.get("result") if isinstance(body, dict) else None
+    if not isinstance(result_obj, dict):
         return {"result": "", "variables": {}, "status": "success"}
-    if isinstance(result_obj, Message):
-        text = get_message_text(result_obj)
-    elif isinstance(result_obj, Task) and result_obj.history:
-        texts = [get_message_text(m) for m in result_obj.history if isinstance(m, Message)]
-        text = "\n".join(texts) if texts else ""
-    else:
-        text = str(result_obj) if result_obj else ""
-    return {"result": text or "", "variables": {}, "status": "success"}
+
+    text = _extract_text_from_task(result_obj)
+    return {"result": text, "variables": {}, "status": "success"}
 
 
 class A2AProtocol:

--- a/src/cuga/backend/server/a2a/__init__.py
+++ b/src/cuga/backend/server/a2a/__init__.py
@@ -1,0 +1,13 @@
+"""A2A server module — exposes CUGA as an A2A-compatible agent.
+
+This package is mounted only when ``settings.a2a.enabled`` is true. When
+disabled, importing this package costs nothing beyond Python's module-load
+overhead, and the rest of the server is byte-identical to a build without
+this feature.
+"""
+
+from cuga.backend.server.a2a.agent_card import build_agent_card
+from cuga.backend.server.a2a.router import build_router
+from cuga.backend.server.a2a.task_adapter import stream_events_to_a2a
+
+__all__ = ["build_agent_card", "build_router", "stream_events_to_a2a"]

--- a/src/cuga/backend/server/a2a/_a2a_types.py
+++ b/src/cuga/backend/server/a2a/_a2a_types.py
@@ -1,0 +1,46 @@
+"""Single import site for the A2A pydantic types we use.
+
+The installed ``a2a-sdk`` (1.x) re-exports protobuf classes from
+``a2a.types``; the pydantic models that support ``model_validate`` /
+``model_dump`` live under ``a2a.compat.v0_3.types``. We import from there
+once so the rest of the package — and the tests — stay agnostic to the
+SDK's layout.
+"""
+
+from __future__ import annotations
+
+from a2a.compat.v0_3.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    HTTPAuthSecurityScheme,
+    Message,
+    MessageSendParams,
+    Part,
+    Role,
+    SecurityScheme,
+    SendMessageRequest,
+    Task,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+    TextPart,
+)
+
+__all__ = [
+    "AgentCapabilities",
+    "AgentCard",
+    "AgentSkill",
+    "HTTPAuthSecurityScheme",
+    "Message",
+    "MessageSendParams",
+    "Part",
+    "Role",
+    "SecurityScheme",
+    "SendMessageRequest",
+    "Task",
+    "TaskState",
+    "TaskStatus",
+    "TaskStatusUpdateEvent",
+    "TextPart",
+]

--- a/src/cuga/backend/server/a2a/agent_card.py
+++ b/src/cuga/backend/server/a2a/agent_card.py
@@ -18,6 +18,13 @@ from cuga.backend.server.a2a._a2a_types import (
 
 
 def _coerce_skill(spec: Mapping[str, Any]) -> AgentSkill:
+    """Build an ``AgentSkill`` from a loose mapping.
+
+    Accepts whatever the caller has lying around (config dict, registry
+    entry, hand-written test fixture) and produces a valid SDK skill.
+    Falls back to the skill id for any missing display fields so the
+    output round-trips through the SDK's pydantic model.
+    """
     skill_id = spec["id"]
     return AgentSkill(
         id=skill_id,

--- a/src/cuga/backend/server/a2a/agent_card.py
+++ b/src/cuga/backend/server/a2a/agent_card.py
@@ -1,0 +1,62 @@
+"""Build an AgentCard from CUGA settings + a list of skill descriptors.
+
+Pure function; no I/O. The output is the JSON served at
+``/.well-known/agent.json`` and consumed by any A2A client.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from cuga.backend.server.a2a._a2a_types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    HTTPAuthSecurityScheme,
+    SecurityScheme,
+)
+
+
+def _coerce_skill(spec: Mapping[str, Any]) -> AgentSkill:
+    skill_id = spec["id"]
+    return AgentSkill(
+        id=skill_id,
+        name=spec.get("name") or skill_id,
+        description=spec.get("description") or spec.get("name") or skill_id,
+        tags=list(spec.get("tags") or []),
+        examples=list(spec.get("examples") or []) or None,
+        input_modes=list(spec.get("input_modes") or []) or None,
+        output_modes=list(spec.get("output_modes") or []) or None,
+    )
+
+
+def build_agent_card(
+    settings: Mapping[str, Any],
+    skills: Sequence[Mapping[str, Any]],
+) -> AgentCard:
+    """Construct an A2A AgentCard from a settings dict and skill specs."""
+    agent_skills = [_coerce_skill(s) for s in skills]
+
+    security_schemes: dict[str, SecurityScheme] | None = None
+    if settings.get("auth_required"):
+        security_schemes = {
+            "bearer": SecurityScheme(
+                root=HTTPAuthSecurityScheme(
+                    scheme="bearer",
+                    bearer_format="JWT",
+                    description="Bearer token used by CUGA's existing chat-access dependency.",
+                )
+            )
+        }
+
+    return AgentCard(
+        name=settings.get("agent_name") or "cuga",
+        description=settings.get("agent_description") or "CUGA agent exposed over A2A.",
+        version=settings.get("agent_version") or "0.0.0",
+        url=settings.get("agent_url") or "http://localhost",
+        capabilities=AgentCapabilities(streaming=True),
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        skills=agent_skills,
+        security_schemes=security_schemes,
+    )

--- a/src/cuga/backend/server/a2a/router.py
+++ b/src/cuga/backend/server/a2a/router.py
@@ -16,6 +16,7 @@ area.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from typing import Any, AsyncIterator, Mapping, Protocol
 
@@ -32,6 +33,8 @@ from cuga.backend.server.a2a._a2a_types import (
 )
 from cuga.backend.server.a2a.agent_card import build_agent_card
 from cuga.backend.server.a2a.task_adapter import stream_events_to_a2a
+
+logger = logging.getLogger(__name__)
 
 
 class GraphRunner(Protocol):
@@ -136,14 +139,24 @@ def build_router(*, runner: GraphRunner, settings: Mapping[str, Any], **_kwargs:
     async def _sse_stream(
         message_text: str, context_id: str, task_id: str, rpc_id: Any
     ) -> AsyncIterator[dict]:
-        """Yield SSE frames carrying JSON-RPC envelopes per task update."""
-        agen = runner.run(message_text, context_id)
-        events = []
-        async for ev in agen:
-            events.append(ev)
-        for upd in stream_events_to_a2a(events, task_id=task_id, context_id=context_id):
-            frame = _rpc_result(rpc_id, upd.model_dump(mode="json", exclude_none=True, by_alias=True))
-            yield {"data": json.dumps(frame)}
+        """Yield SSE frames carrying JSON-RPC envelopes per task update.
+
+        If the runner or adapter raises, we still emit one final JSON-RPC
+        error frame before closing — otherwise clients see a half-open
+        stream and can't distinguish a network drop from a server bug.
+        """
+        try:
+            agen = runner.run(message_text, context_id)
+            events = []
+            async for ev in agen:
+                events.append(ev)
+            for upd in stream_events_to_a2a(events, task_id=task_id, context_id=context_id):
+                frame = _rpc_result(rpc_id, upd.model_dump(mode="json", exclude_none=True, by_alias=True))
+                yield {"data": json.dumps(frame)}
+        except Exception as exc:
+            logger.exception("A2A SSE stream failed for task %s", task_id)
+            err_frame = _rpc_error(rpc_id, _INTERNAL_ERROR, f"Internal error: {type(exc).__name__}")
+            yield {"data": json.dumps(err_frame)}
 
     @router.post("/a2a")
     async def jsonrpc_endpoint(request: Request):
@@ -182,7 +195,13 @@ def build_router(*, runner: GraphRunner, settings: Mapping[str, Any], **_kwargs:
             try:
                 task = await _run_and_collect(message_text, context_id, task_id)
             except Exception as exc:  # graph blew up
-                return JSONResponse(_rpc_error(rpc_id, _INTERNAL_ERROR, "Internal error", str(exc)))
+                # Don't echo raw exception text across the wire (paths,
+                # config, etc.). Keep details in server logs; tell the
+                # caller only the exception class so they can route it.
+                logger.exception("A2A message/send graph run failed for task %s", task_id)
+                return JSONResponse(
+                    _rpc_error(rpc_id, _INTERNAL_ERROR, f"Internal error: {type(exc).__name__}")
+                )
             return JSONResponse(
                 _rpc_result(rpc_id, task.model_dump(mode="json", exclude_none=True, by_alias=True))
             )

--- a/src/cuga/backend/server/a2a/router.py
+++ b/src/cuga/backend/server/a2a/router.py
@@ -1,0 +1,182 @@
+"""FastAPI router exposing CUGA over A2A.
+
+Wire shape (v0.3 compat):
+
+  GET  /.well-known/agent.json   — AgentCard JSON
+  POST /a2a                      — JSON-RPC 2.0
+                                   - method=message/send   → JSON envelope
+                                   - method=message/stream → SSE stream of frames
+
+The router is created on demand by the application factory and is only
+mounted when ``settings.a2a.enabled`` is true; that opt-in lives in
+``main.py`` so importing this package does not change CUGA's surface
+area.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, AsyncIterator, Mapping, Protocol
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from sse_starlette.sse import EventSourceResponse
+
+from cuga.backend.server.a2a._a2a_types import (
+    Message,
+    MessageSendParams,
+    Task,
+    TaskState,
+    TaskStatus,
+)
+from cuga.backend.server.a2a.agent_card import build_agent_card
+from cuga.backend.server.a2a.task_adapter import stream_events_to_a2a
+
+
+class GraphRunner(Protocol):
+    """Minimal contract a graph runner must satisfy.
+
+    Anything async that yields events with ``name`` / ``data`` / optional
+    ``final`` is acceptable. We don't import CUGA's graph types here.
+    """
+
+    def run(self, message: str, context_id: str | None = None) -> AsyncIterator[Any]:  # pragma: no cover
+        ...
+
+
+# JSON-RPC error codes we use.
+_PARSE_ERROR = -32700
+_INVALID_REQUEST = -32600
+_METHOD_NOT_FOUND = -32601
+_INVALID_PARAMS = -32602
+_INTERNAL_ERROR = -32603
+
+
+def _rpc_error(rid: Any, code: int, message: str, data: Any | None = None) -> dict[str, Any]:
+    err: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": rid, "error": err}
+
+
+def _rpc_result(rid: Any, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": rid, "result": result}
+
+
+def _extract_message_text(params: MessageSendParams) -> str:
+    parts = []
+    for p in params.message.parts:
+        root = getattr(p, "root", p)
+        text = getattr(root, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _ensure_context_id(params: MessageSendParams) -> str:
+    return params.message.context_id or uuid.uuid4().hex
+
+
+def build_router(*, runner: GraphRunner, settings: Mapping[str, Any], **_kwargs: Any) -> APIRouter:
+    """Build the A2A FastAPI router bound to a specific graph runner.
+
+    The runner is captured by closure so callers can plug in any CUGA
+    graph instance (production or scripted) without the router having to
+    know how the graph is constructed.
+    """
+
+    router = APIRouter()
+    skill_specs = list(settings.get("skill_ids") or [])
+    skills = [{"id": s, "name": s, "description": s} for s in skill_specs]
+
+    async def _agent_card_response() -> JSONResponse:
+        card = build_agent_card(settings, skills)
+        return JSONResponse(card.model_dump(mode="json", exclude_none=True, by_alias=True))
+
+    # Both paths are served: /.well-known/agent.json is the original A2A
+    # well-known path; /.well-known/agent-card.json is what the 1.x SDK
+    # resolver fetches. Older clients keep working, newer clients work too.
+    @router.get("/.well-known/agent.json")
+    async def agent_card_endpoint_legacy() -> JSONResponse:
+        return await _agent_card_response()
+
+    @router.get("/.well-known/agent-card.json")
+    async def agent_card_endpoint() -> JSONResponse:
+        return await _agent_card_response()
+
+    async def _run_and_collect(message_text: str, context_id: str, task_id: str) -> Task:
+        agen = runner.run(message_text, context_id)
+        events = []
+        async for ev in agen:
+            events.append(ev)
+        history: list[Message] = []
+        last_state: TaskState = TaskState.completed
+        for upd in stream_events_to_a2a(events, task_id=task_id, context_id=context_id):
+            if upd.status and upd.status.message:
+                history.append(upd.status.message)
+            if upd.status and upd.status.state:
+                last_state = upd.status.state
+        return Task(
+            id=task_id,
+            context_id=context_id,
+            status=TaskStatus(state=last_state),
+            history=history,
+        )
+
+    async def _sse_stream(message_text: str, context_id: str, task_id: str, rpc_id: Any) -> AsyncIterator[dict]:
+        agen = runner.run(message_text, context_id)
+        events = []
+        async for ev in agen:
+            events.append(ev)
+        for upd in stream_events_to_a2a(events, task_id=task_id, context_id=context_id):
+            frame = _rpc_result(rpc_id, upd.model_dump(mode="json", exclude_none=True, by_alias=True))
+            yield {"data": json.dumps(frame)}
+
+    @router.post("/a2a")
+    async def jsonrpc_endpoint(request: Request):
+        raw = await request.body()
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            return JSONResponse(_rpc_error(None, _PARSE_ERROR, "Parse error", str(exc)))
+
+        if not isinstance(payload, dict):
+            return JSONResponse(_rpc_error(None, _INVALID_REQUEST, "Invalid Request"))
+
+        rpc_id = payload.get("id")
+        if payload.get("jsonrpc") != "2.0" or not isinstance(payload.get("method"), str):
+            return JSONResponse(_rpc_error(rpc_id, _INVALID_REQUEST, "Invalid Request"))
+
+        method = payload["method"]
+        params_dict = payload.get("params") or {}
+
+        if method == "message/send":
+            try:
+                params = MessageSendParams.model_validate(params_dict)
+            except Exception as exc:
+                return JSONResponse(_rpc_error(rpc_id, _INVALID_PARAMS, "Invalid params", str(exc)))
+            message_text = _extract_message_text(params)
+            context_id = _ensure_context_id(params)
+            task_id = uuid.uuid4().hex
+            try:
+                task = await _run_and_collect(message_text, context_id, task_id)
+            except Exception as exc:  # graph blew up
+                return JSONResponse(_rpc_error(rpc_id, _INTERNAL_ERROR, "Internal error", str(exc)))
+            return JSONResponse(
+                _rpc_result(rpc_id, task.model_dump(mode="json", exclude_none=True, by_alias=True))
+            )
+
+        if method == "message/stream":
+            try:
+                params = MessageSendParams.model_validate(params_dict)
+            except Exception as exc:
+                return JSONResponse(_rpc_error(rpc_id, _INVALID_PARAMS, "Invalid params", str(exc)))
+            message_text = _extract_message_text(params)
+            context_id = _ensure_context_id(params)
+            task_id = uuid.uuid4().hex
+            return EventSourceResponse(_sse_stream(message_text, context_id, task_id, rpc_id))
+
+        return JSONResponse(_rpc_error(rpc_id, _METHOD_NOT_FOUND, "Method not found"))
+
+    return router

--- a/src/cuga/backend/server/a2a/router.py
+++ b/src/cuga/backend/server/a2a/router.py
@@ -42,6 +42,7 @@ class GraphRunner(Protocol):
     """
 
     def run(self, message: str, context_id: str | None = None) -> AsyncIterator[Any]:  # pragma: no cover
+        """Yield graph events for ``message`` on the given thread."""
         ...
 
 
@@ -54,6 +55,7 @@ _INTERNAL_ERROR = -32603
 
 
 def _rpc_error(rid: Any, code: int, message: str, data: Any | None = None) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 error envelope echoing the request id."""
     err: dict[str, Any] = {"code": code, "message": message}
     if data is not None:
         err["data"] = data
@@ -61,10 +63,12 @@ def _rpc_error(rid: Any, code: int, message: str, data: Any | None = None) -> di
 
 
 def _rpc_result(rid: Any, result: Any) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 success envelope echoing the request id."""
     return {"jsonrpc": "2.0", "id": rid, "result": result}
 
 
 def _extract_message_text(params: MessageSendParams) -> str:
+    """Concatenate every text part of the inbound message in order."""
     parts = []
     for p in params.message.parts:
         root = getattr(p, "root", p)
@@ -75,6 +79,7 @@ def _extract_message_text(params: MessageSendParams) -> str:
 
 
 def _ensure_context_id(params: MessageSendParams) -> str:
+    """Return the caller-supplied contextId, or mint a fresh one."""
     return params.message.context_id or uuid.uuid4().hex
 
 
@@ -91,6 +96,7 @@ def build_router(*, runner: GraphRunner, settings: Mapping[str, Any], **_kwargs:
     skills = [{"id": s, "name": s, "description": s} for s in skill_specs]
 
     async def _agent_card_response() -> JSONResponse:
+        """Serialize the AgentCard with camelCase aliases for SDK clients."""
         card = build_agent_card(settings, skills)
         return JSONResponse(card.model_dump(mode="json", exclude_none=True, by_alias=True))
 
@@ -99,13 +105,16 @@ def build_router(*, runner: GraphRunner, settings: Mapping[str, Any], **_kwargs:
     # resolver fetches. Older clients keep working, newer clients work too.
     @router.get("/.well-known/agent.json")
     async def agent_card_endpoint_legacy() -> JSONResponse:
+        """Serve the AgentCard at the v0.3 well-known path."""
         return await _agent_card_response()
 
     @router.get("/.well-known/agent-card.json")
     async def agent_card_endpoint() -> JSONResponse:
+        """Serve the AgentCard at the path the 1.x SDK resolver fetches."""
         return await _agent_card_response()
 
     async def _run_and_collect(message_text: str, context_id: str, task_id: str) -> Task:
+        """Drive the runner to completion and fold the events into a Task."""
         agen = runner.run(message_text, context_id)
         events = []
         async for ev in agen:
@@ -124,7 +133,10 @@ def build_router(*, runner: GraphRunner, settings: Mapping[str, Any], **_kwargs:
             history=history,
         )
 
-    async def _sse_stream(message_text: str, context_id: str, task_id: str, rpc_id: Any) -> AsyncIterator[dict]:
+    async def _sse_stream(
+        message_text: str, context_id: str, task_id: str, rpc_id: Any
+    ) -> AsyncIterator[dict]:
+        """Yield SSE frames carrying JSON-RPC envelopes per task update."""
         agen = runner.run(message_text, context_id)
         events = []
         async for ev in agen:
@@ -135,6 +147,14 @@ def build_router(*, runner: GraphRunner, settings: Mapping[str, Any], **_kwargs:
 
     @router.post("/a2a")
     async def jsonrpc_endpoint(request: Request):
+        """Dispatch a JSON-RPC 2.0 request to the right A2A method.
+
+        Returns a JSON envelope for ``message/send`` and an SSE stream
+        for ``message/stream``. Malformed JSON, non-object payloads, and
+        unknown methods are mapped to standard JSON-RPC error codes
+        (-32700 / -32600 / -32601 / -32602) rather than HTTP 5xx, so
+        SDK clients can parse the failure mode.
+        """
         raw = await request.body()
         try:
             payload = json.loads(raw)

--- a/src/cuga/backend/server/a2a/runner.py
+++ b/src/cuga/backend/server/a2a/runner.py
@@ -1,0 +1,156 @@
+"""Production-side A2A runner glue and the opt-in mount helper.
+
+Lives separate from ``router.py`` so the router stays a pure
+contract-implementation (FastAPI + JSON-RPC) and can be reused with any
+``GraphRunner`` Protocol implementation. This module is what wires CUGA
+itself behind that protocol and provides the one entry point ``main.py``
+calls at startup.
+
+The router only depends on ``runner.GraphRunner`` (a duck-typed Protocol
+in ``router.py``); none of these classes leak back the other way.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, AsyncIterator, Mapping, Optional
+
+from fastapi import APIRouter
+
+from cuga.backend.server.a2a.router import build_router
+
+logger = logging.getLogger(__name__)
+
+
+class A2AStreamEvent:
+    """Duck-typed event the A2A task adapter consumes.
+
+    Only three attributes (``name``, ``data``, ``final``) are read by
+    ``stream_events_to_a2a``; this is the smallest type that satisfies
+    that contract without dragging in CUGA's graph state types.
+    """
+
+    __slots__ = ("data", "final", "name")
+
+    def __init__(self, name: str, data: Optional[Mapping[str, Any]] = None, final: bool = False):
+        """Capture an event name + payload + terminal-flag triple."""
+        self.name = name
+        self.data = data
+        self.final = final
+
+
+class SupervisorA2ARunner:
+    """Run inbound A2A messages through a lazily-created CugaSupervisor.
+
+    The supervisor is built on first request rather than during lifespan
+    startup, so deployments that enable A2A but never receive a request
+    pay no init cost. The instance is cached on
+    ``app_state.a2a_supervisor`` afterward; concurrent first-requests
+    are serialized by an ``asyncio.Lock`` (double-checked) so we don't
+    build two supervisors in parallel.
+    """
+
+    def __init__(self, app_state_ref: Any, supervisor_config_path: str):
+        """Stash the app_state and YAML path; no I/O until ``run()``."""
+        self._app_state = app_state_ref
+        self._yaml_path = supervisor_config_path
+        self._lock = asyncio.Lock()
+
+    async def _ensure_supervisor(self) -> Any:
+        """Return the cached supervisor or build one under a lock (double-checked)."""
+        existing = getattr(self._app_state, "a2a_supervisor", None)
+        if existing is not None:
+            return existing
+        async with self._lock:
+            existing = getattr(self._app_state, "a2a_supervisor", None)
+            if existing is not None:
+                return existing
+            # Imported lazily so test harnesses that don't go through this
+            # path don't pay the import cost of the SDK supervisor.
+            from cuga.sdk import CugaSupervisor
+
+            supervisor = await CugaSupervisor.from_yaml(self._yaml_path)
+            self._app_state.a2a_supervisor = supervisor
+            return supervisor
+
+    async def run(self, message: str, context_id: Optional[str] = None) -> AsyncIterator[A2AStreamEvent]:
+        """Invoke the supervisor and emit one terminal event with its answer.
+
+        Errors during graph execution are caught and surfaced as a
+        terminal ``error`` event with only the exception class name on
+        the wire — the full traceback is logged via ``logger.exception``
+        so operators can debug without leaking config to the caller.
+        """
+        try:
+            supervisor = await self._ensure_supervisor()
+            result = await supervisor.invoke(message, thread_id=context_id)
+            answer = getattr(result, "answer", None) or str(result)
+            error = getattr(result, "error", None)
+            if error:
+                # The supervisor's own `error` field is graph-internal text
+                # already shaped for our UI — safe to relay; it carries no
+                # stack frames or env state.
+                yield A2AStreamEvent("error", {"text": f"Supervisor error: {error}"}, final=True)
+                return
+            yield A2AStreamEvent("final_answer", {"text": answer}, final=True)
+        except Exception as exc:
+            logger.exception("A2A inbound delegation failed")
+            yield A2AStreamEvent(
+                "error",
+                {"text": f"A2A handler error: {type(exc).__name__}"},
+                final=True,
+            )
+
+
+class PlaceholderA2ARunner:
+    """Used when ``settings.a2a.supervisor_config_path`` is unset.
+
+    Returns a clear "endpoint reached but unconfigured" terminal event
+    so callers get a well-formed Task envelope instead of an HTTP 5xx.
+    """
+
+    async def run(self, message: str, context_id: Optional[str] = None) -> AsyncIterator[A2AStreamEvent]:
+        """Yield a single terminal event explaining the missing config."""
+        yield A2AStreamEvent(
+            "final_answer",
+            {"text": "A2A inbound endpoint reached, but settings.a2a.supervisor_config_path is not set."},
+            final=True,
+        )
+
+
+def _settings_to_card_dict(a2a_settings: Any) -> dict[str, Any]:
+    """Project a Dynaconf ``settings.a2a`` block into a plain dict.
+
+    Defensive defaults match the documented schema in ``settings.toml``;
+    we accept loose mappings (test fixtures, alt loaders) by going through
+    ``getattr`` rather than dotted attribute access.
+    """
+    return {
+        "agent_name": getattr(a2a_settings, "agent_name", "cuga"),
+        "agent_description": getattr(a2a_settings, "agent_description", "CUGA agent exposed over A2A."),
+        "agent_version": getattr(a2a_settings, "agent_version", "0.0.0"),
+        "agent_url": getattr(a2a_settings, "agent_url", "http://localhost:8000"),
+        "auth_required": getattr(a2a_settings, "auth_required", False),
+        "skill_ids": list(getattr(a2a_settings, "skill_ids", []) or []),
+    }
+
+
+def build_a2a_router_for_settings(a2a_settings: Any, app_state: Any) -> APIRouter:
+    """Build the A2A FastAPI router bound to a runner picked by settings.
+
+    If ``a2a_settings.supervisor_config_path`` is set we lazily front the
+    real CUGA supervisor; otherwise we mount a placeholder so the
+    endpoints at least respond with a well-formed Task envelope.
+    Returns a router ready for ``app.include_router(...)``.
+    """
+    supervisor_path = getattr(a2a_settings, "supervisor_config_path", "") or ""
+    if supervisor_path:
+        runner: Any = SupervisorA2ARunner(app_state, supervisor_path)
+        logger.info("A2A inbound: routing requests through supervisor at %s", supervisor_path)
+    else:
+        runner = PlaceholderA2ARunner()
+        logger.warning(
+            "A2A inbound enabled but settings.a2a.supervisor_config_path is empty; using placeholder runner."
+        )
+    return build_router(runner=runner, settings=_settings_to_card_dict(a2a_settings))

--- a/src/cuga/backend/server/a2a/task_adapter.py
+++ b/src/cuga/backend/server/a2a/task_adapter.py
@@ -1,0 +1,131 @@
+"""Map CUGA StreamEvents to A2A task lifecycle events.
+
+The adapter keeps the protocol surface narrow: it accepts whatever the
+CUGA graph yields (just a duck-typed object exposing ``name``, optional
+``data``, and an optional ``final`` flag) and emits A2A
+``TaskStatusUpdateEvent`` instances. We don't import CUGA's internal
+event types here — that would couple the A2A layer to graph internals.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Iterator
+
+from cuga.backend.server.a2a._a2a_types import (
+    Message,
+    Part,
+    Role,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+    TextPart,
+)
+
+# Event names CUGA already uses (or is likely to use) that signal a HITL
+# interrupt. Matching is substring-based so we forward-compat new variants.
+_HITL_HINTS = ("approval", "input_required", "user_input", "interrupt", "hitl")
+
+
+def _is_hitl(event: Any) -> bool:
+    name = str(getattr(event, "name", "") or "").lower()
+    return any(hint in name for hint in _HITL_HINTS)
+
+
+def _is_final(event: Any) -> bool:
+    if bool(getattr(event, "final", False)):
+        return True
+    name = str(getattr(event, "name", "") or "").lower()
+    return name in {"final_answer", "task_complete", "completed", "done"}
+
+
+def _event_text(event: Any) -> str:
+    data = getattr(event, "data", None)
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict):
+        for key in ("text", "message", "prompt", "content"):
+            v = data.get(key)
+            if isinstance(v, str):
+                return v
+    return str(getattr(event, "name", "") or "")
+
+
+def _message(text: str, message_id: str, context_id: str) -> Message:
+    return Message(
+        role=Role.agent,
+        parts=[Part(root=TextPart(text=text))],
+        message_id=message_id,
+        context_id=context_id,
+    )
+
+
+def stream_events_to_a2a(
+    events: Iterable[Any],
+    *,
+    task_id: str,
+    context_id: str,
+) -> Iterator[TaskStatusUpdateEvent]:
+    """Translate a stream of CUGA events into A2A TaskStatusUpdateEvents.
+
+    Guarantees:
+    - At least one terminal event is always emitted (completed or failed),
+      so an A2A client never hangs on an open task.
+    - Unknown event names are coerced into a ``working`` update rather
+      than raising — protocol forward-compatibility.
+    - ``context_id`` round-trips verbatim onto every emitted event.
+    """
+    saw_terminal = False
+    counter = 0
+
+    for ev in events:
+        counter += 1
+        if _is_hitl(ev):
+            yield TaskStatusUpdateEvent(
+                task_id=task_id,
+                context_id=context_id,
+                final=False,
+                status=TaskStatus(
+                    state=TaskState.input_required,
+                    message=_message(
+                        _event_text(ev) or "Input required",
+                        f"{task_id}-msg-{counter}",
+                        context_id,
+                    ),
+                ),
+            )
+            continue
+
+        if _is_final(ev):
+            saw_terminal = True
+            yield TaskStatusUpdateEvent(
+                task_id=task_id,
+                context_id=context_id,
+                final=True,
+                status=TaskStatus(
+                    state=TaskState.completed,
+                    message=_message(_event_text(ev) or "", f"{task_id}-final", context_id),
+                ),
+            )
+            continue
+
+        # Default: any other (named or unknown) event is in-flight progress.
+        yield TaskStatusUpdateEvent(
+            task_id=task_id,
+            context_id=context_id,
+            final=False,
+            status=TaskStatus(
+                state=TaskState.working,
+                message=_message(_event_text(ev), f"{task_id}-msg-{counter}", context_id),
+            ),
+        )
+
+    if not saw_terminal:
+        yield TaskStatusUpdateEvent(
+            task_id=task_id,
+            context_id=context_id,
+            final=True,
+            status=TaskStatus(
+                state=TaskState.completed,
+                message=_message("", f"{task_id}-final", context_id),
+            ),
+        )

--- a/src/cuga/backend/server/a2a/task_adapter.py
+++ b/src/cuga/backend/server/a2a/task_adapter.py
@@ -27,11 +27,13 @@ _HITL_HINTS = ("approval", "input_required", "user_input", "interrupt", "hitl")
 
 
 def _is_hitl(event: Any) -> bool:
+    """Return True when ``event.name`` looks like a human-in-the-loop interrupt."""
     name = str(getattr(event, "name", "") or "").lower()
     return any(hint in name for hint in _HITL_HINTS)
 
 
 def _is_final(event: Any) -> bool:
+    """Return True when ``event`` should close the A2A task."""
     if bool(getattr(event, "final", False)):
         return True
     name = str(getattr(event, "name", "") or "").lower()
@@ -39,6 +41,12 @@ def _is_final(event: Any) -> bool:
 
 
 def _event_text(event: Any) -> str:
+    """Best-effort extract the user-visible text payload from an event.
+
+    Probes the common shapes CUGA's graph emits (a raw string, or a dict
+    with one of ``text``/``message``/``prompt``/``content``), falling
+    back to the event name so the A2A frame is never empty.
+    """
     data = getattr(event, "data", None)
     if isinstance(data, str):
         return data
@@ -51,6 +59,7 @@ def _event_text(event: Any) -> str:
 
 
 def _message(text: str, message_id: str, context_id: str) -> Message:
+    """Build an agent-role A2A Message wrapping ``text`` as a single TextPart."""
     return Message(
         role=Role.agent,
         parts=[Part(root=TextPart(text=text))],

--- a/src/cuga/backend/server/a2a/task_adapter.py
+++ b/src/cuga/backend/server/a2a/task_adapter.py
@@ -37,7 +37,18 @@ def _is_final(event: Any) -> bool:
     if bool(getattr(event, "final", False)):
         return True
     name = str(getattr(event, "name", "") or "").lower()
-    return name in {"final_answer", "task_complete", "completed", "done"}
+    return name in {"final_answer", "task_complete", "completed", "done"} or _is_error(event)
+
+
+def _is_error(event: Any) -> bool:
+    """Return True when ``event`` represents a terminal failure.
+
+    Used by ``_is_final`` to recognize the event AND by the dispatch
+    branch to distinguish ``TaskState.failed`` from ``TaskState.completed``
+    — without this, error terminals were silently mapped to success.
+    """
+    name = str(getattr(event, "name", "") or "").lower()
+    return name in {"error", "failed", "failure", "exception"}
 
 
 def _event_text(event: Any) -> str:
@@ -106,12 +117,13 @@ def stream_events_to_a2a(
 
         if _is_final(ev):
             saw_terminal = True
+            terminal_state = TaskState.failed if _is_error(ev) else TaskState.completed
             yield TaskStatusUpdateEvent(
                 task_id=task_id,
                 context_id=context_id,
                 final=True,
                 status=TaskStatus(
-                    state=TaskState.completed,
+                    state=terminal_state,
                     message=_message(_event_text(ev) or "", f"{task_id}-final", context_id),
                 ),
             )

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -1634,23 +1634,69 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
     # so disabled deployments pay no import-time cost for it.
     from cuga.backend.server.a2a import build_router as _build_a2a_router  # noqa: E402
 
-    class _PlaceholderA2ARunner:
-        """Minimal runner used until production graph wiring lands.
+    class _A2AStreamEvent:
+        """Duck-typed event the A2A task adapter consumes."""
 
-        Yields a single placeholder event so an A2A client gets a clean
-        lifecycle (working → completed) instead of a hung task.
+        __slots__ = ("name", "data", "final")
+
+        def __init__(self, name, data=None, final=False):
+            self.name = name
+            self.data = data
+            self.final = final
+
+    class _SupervisorA2ARunner:
+        """Run inbound A2A messages through a lazily-created CugaSupervisor.
+
+        We instantiate the supervisor on first use rather than during
+        lifespan startup so deployments that enable A2A but never receive
+        a request pay no init cost. The supervisor is cached on
+        ``app_state.a2a_supervisor`` afterward.
+        """
+
+        def __init__(self, app_state_ref, supervisor_config_path: str):
+            self._app_state = app_state_ref
+            self._yaml_path = supervisor_config_path
+            self._lock = asyncio.Lock()
+
+        async def _ensure_supervisor(self):
+            existing = getattr(self._app_state, "a2a_supervisor", None)
+            if existing is not None:
+                return existing
+            async with self._lock:
+                existing = getattr(self._app_state, "a2a_supervisor", None)
+                if existing is not None:
+                    return existing
+                from cuga.sdk import CugaSupervisor
+
+                supervisor = await CugaSupervisor.from_yaml(self._yaml_path)
+                self._app_state.a2a_supervisor = supervisor
+                return supervisor
+
+        async def run(self, message, context_id=None):
+            try:
+                supervisor = await self._ensure_supervisor()
+                result = await supervisor.invoke(message, thread_id=context_id)
+                answer = getattr(result, "answer", None) or str(result)
+                error = getattr(result, "error", None)
+                if error:
+                    yield _A2AStreamEvent("error", {"text": f"Supervisor error: {error}"}, final=True)
+                    return
+                yield _A2AStreamEvent("final_answer", {"text": answer}, final=True)
+            except Exception as exc:  # surface failures across the wire
+                logger.exception("A2A inbound delegation failed")
+                yield _A2AStreamEvent("error", {"text": f"A2A handler error: {exc}"}, final=True)
+
+    class _PlaceholderA2ARunner:
+        """Used when ``a2a.supervisor_config_path`` is unset.
+
+        Returns a clear "endpoint reached but unconfigured" terminal event
+        so callers get a well-formed Task envelope instead of a 5xx.
         """
 
         async def run(self, message, context_id=None):
-            class _Ev:
-                def __init__(self, name, data, final=False):
-                    self.name = name
-                    self.data = data
-                    self.final = final
-
-            yield _Ev(
+            yield _A2AStreamEvent(
                 "final_answer",
-                {"text": "A2A inbound endpoint reached, but graph runner is not yet wired."},
+                {"text": "A2A inbound endpoint reached, but settings.a2a.supervisor_config_path is not set."},
                 final=True,
             )
 
@@ -1662,7 +1708,14 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
         "auth_required": getattr(settings.a2a, "auth_required", False),
         "skill_ids": list(getattr(settings.a2a, "skill_ids", []) or []),
     }
-    app.include_router(_build_a2a_router(runner=_PlaceholderA2ARunner(), settings=_a2a_settings_dict))
+    _a2a_supervisor_cfg = getattr(settings.a2a, "supervisor_config_path", "") or ""
+    if _a2a_supervisor_cfg:
+        _a2a_runner: Any = _SupervisorA2ARunner(app_state, _a2a_supervisor_cfg)
+        logger.info(f"A2A inbound: routing requests through supervisor at {_a2a_supervisor_cfg}")
+    else:
+        _a2a_runner = _PlaceholderA2ARunner()
+        logger.warning("A2A inbound enabled but settings.a2a.supervisor_config_path is empty; using placeholder runner.")
+    app.include_router(_build_a2a_router(runner=_a2a_runner, settings=_a2a_settings_dict))
 
 
 @app.get("/health")

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -1687,8 +1687,16 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
                     return
                 yield _A2AStreamEvent("final_answer", {"text": answer}, final=True)
             except Exception as exc:  # surface failures across the wire
+                # Don't expose raw exception text (paths, config, runtime
+                # state) to the remote caller. Class name is enough to
+                # triage; the full traceback is captured server-side by
+                # logger.exception.
                 logger.exception("A2A inbound delegation failed")
-                yield _A2AStreamEvent("error", {"text": f"A2A handler error: {exc}"}, final=True)
+                yield _A2AStreamEvent(
+                    "error",
+                    {"text": f"A2A handler error: {type(exc).__name__}"},
+                    final=True,
+                )
 
     class _PlaceholderA2ARunner:
         """Used when ``a2a.supervisor_config_path`` is unset.

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -1629,6 +1629,42 @@ app.include_router(manage_routes.router)
 app.include_router(secrets_routes.router)
 
 
+if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
+    # The A2A package is only imported when explicitly enabled in settings,
+    # so disabled deployments pay no import-time cost for it.
+    from cuga.backend.server.a2a import build_router as _build_a2a_router  # noqa: E402
+
+    class _PlaceholderA2ARunner:
+        """Minimal runner used until production graph wiring lands.
+
+        Yields a single placeholder event so an A2A client gets a clean
+        lifecycle (working → completed) instead of a hung task.
+        """
+
+        async def run(self, message, context_id=None):
+            class _Ev:
+                def __init__(self, name, data, final=False):
+                    self.name = name
+                    self.data = data
+                    self.final = final
+
+            yield _Ev(
+                "final_answer",
+                {"text": "A2A inbound endpoint reached, but graph runner is not yet wired."},
+                final=True,
+            )
+
+    _a2a_settings_dict = {
+        "agent_name": getattr(settings.a2a, "agent_name", "cuga"),
+        "agent_description": getattr(settings.a2a, "agent_description", "CUGA agent exposed over A2A."),
+        "agent_version": getattr(settings.a2a, "agent_version", "0.0.0"),
+        "agent_url": getattr(settings.a2a, "agent_url", "http://localhost:8000"),
+        "auth_required": getattr(settings.a2a, "auth_required", False),
+        "skill_ids": list(getattr(settings.a2a, "skill_ids", []) or []),
+    }
+    app.include_router(_build_a2a_router(runner=_PlaceholderA2ARunner(), settings=_a2a_settings_dict))
+
+
 @app.get("/health")
 async def health():
     return JSONResponse({"status": "ok", "subsystems": app_state.get_subsystem_statuses()})

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -1640,6 +1640,7 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
         __slots__ = ("name", "data", "final")
 
         def __init__(self, name, data=None, final=False):
+            """Capture an event name + payload + terminal-flag triple."""
             self.name = name
             self.data = data
             self.final = final
@@ -1654,11 +1655,13 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
         """
 
         def __init__(self, app_state_ref, supervisor_config_path: str):
+            """Stash the app_state and YAML path; no I/O until ``run()``."""
             self._app_state = app_state_ref
             self._yaml_path = supervisor_config_path
             self._lock = asyncio.Lock()
 
         async def _ensure_supervisor(self):
+            """Return the cached supervisor or build one under a lock (double-checked)."""
             existing = getattr(self._app_state, "a2a_supervisor", None)
             if existing is not None:
                 return existing
@@ -1673,6 +1676,7 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
                 return supervisor
 
         async def run(self, message, context_id=None):
+            """Invoke the supervisor and emit one terminal event with its answer."""
             try:
                 supervisor = await self._ensure_supervisor()
                 result = await supervisor.invoke(message, thread_id=context_id)
@@ -1694,6 +1698,7 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
         """
 
         async def run(self, message, context_id=None):
+            """Yield a single terminal event explaining the missing config."""
             yield _A2AStreamEvent(
                 "final_answer",
                 {"text": "A2A inbound endpoint reached, but settings.a2a.supervisor_config_path is not set."},
@@ -1714,7 +1719,9 @@ if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
         logger.info(f"A2A inbound: routing requests through supervisor at {_a2a_supervisor_cfg}")
     else:
         _a2a_runner = _PlaceholderA2ARunner()
-        logger.warning("A2A inbound enabled but settings.a2a.supervisor_config_path is empty; using placeholder runner.")
+        logger.warning(
+            "A2A inbound enabled but settings.a2a.supervisor_config_path is empty; using placeholder runner."
+        )
     app.include_router(_build_a2a_router(runner=_a2a_runner, settings=_a2a_settings_dict))
 
 

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -1631,106 +1631,12 @@ app.include_router(secrets_routes.router)
 
 if getattr(settings, "a2a", None) and getattr(settings.a2a, "enabled", False):
     # The A2A package is only imported when explicitly enabled in settings,
-    # so disabled deployments pay no import-time cost for it.
-    from cuga.backend.server.a2a import build_router as _build_a2a_router  # noqa: E402
+    # so disabled deployments pay no import-time cost for it. All runner
+    # wiring lives in cuga.backend.server.a2a.runner — main.py just
+    # delegates the mount.
+    from cuga.backend.server.a2a.runner import build_a2a_router_for_settings  # noqa: E402
 
-    class _A2AStreamEvent:
-        """Duck-typed event the A2A task adapter consumes."""
-
-        __slots__ = ("name", "data", "final")
-
-        def __init__(self, name, data=None, final=False):
-            """Capture an event name + payload + terminal-flag triple."""
-            self.name = name
-            self.data = data
-            self.final = final
-
-    class _SupervisorA2ARunner:
-        """Run inbound A2A messages through a lazily-created CugaSupervisor.
-
-        We instantiate the supervisor on first use rather than during
-        lifespan startup so deployments that enable A2A but never receive
-        a request pay no init cost. The supervisor is cached on
-        ``app_state.a2a_supervisor`` afterward.
-        """
-
-        def __init__(self, app_state_ref, supervisor_config_path: str):
-            """Stash the app_state and YAML path; no I/O until ``run()``."""
-            self._app_state = app_state_ref
-            self._yaml_path = supervisor_config_path
-            self._lock = asyncio.Lock()
-
-        async def _ensure_supervisor(self):
-            """Return the cached supervisor or build one under a lock (double-checked)."""
-            existing = getattr(self._app_state, "a2a_supervisor", None)
-            if existing is not None:
-                return existing
-            async with self._lock:
-                existing = getattr(self._app_state, "a2a_supervisor", None)
-                if existing is not None:
-                    return existing
-                from cuga.sdk import CugaSupervisor
-
-                supervisor = await CugaSupervisor.from_yaml(self._yaml_path)
-                self._app_state.a2a_supervisor = supervisor
-                return supervisor
-
-        async def run(self, message, context_id=None):
-            """Invoke the supervisor and emit one terminal event with its answer."""
-            try:
-                supervisor = await self._ensure_supervisor()
-                result = await supervisor.invoke(message, thread_id=context_id)
-                answer = getattr(result, "answer", None) or str(result)
-                error = getattr(result, "error", None)
-                if error:
-                    yield _A2AStreamEvent("error", {"text": f"Supervisor error: {error}"}, final=True)
-                    return
-                yield _A2AStreamEvent("final_answer", {"text": answer}, final=True)
-            except Exception as exc:  # surface failures across the wire
-                # Don't expose raw exception text (paths, config, runtime
-                # state) to the remote caller. Class name is enough to
-                # triage; the full traceback is captured server-side by
-                # logger.exception.
-                logger.exception("A2A inbound delegation failed")
-                yield _A2AStreamEvent(
-                    "error",
-                    {"text": f"A2A handler error: {type(exc).__name__}"},
-                    final=True,
-                )
-
-    class _PlaceholderA2ARunner:
-        """Used when ``a2a.supervisor_config_path`` is unset.
-
-        Returns a clear "endpoint reached but unconfigured" terminal event
-        so callers get a well-formed Task envelope instead of a 5xx.
-        """
-
-        async def run(self, message, context_id=None):
-            """Yield a single terminal event explaining the missing config."""
-            yield _A2AStreamEvent(
-                "final_answer",
-                {"text": "A2A inbound endpoint reached, but settings.a2a.supervisor_config_path is not set."},
-                final=True,
-            )
-
-    _a2a_settings_dict = {
-        "agent_name": getattr(settings.a2a, "agent_name", "cuga"),
-        "agent_description": getattr(settings.a2a, "agent_description", "CUGA agent exposed over A2A."),
-        "agent_version": getattr(settings.a2a, "agent_version", "0.0.0"),
-        "agent_url": getattr(settings.a2a, "agent_url", "http://localhost:8000"),
-        "auth_required": getattr(settings.a2a, "auth_required", False),
-        "skill_ids": list(getattr(settings.a2a, "skill_ids", []) or []),
-    }
-    _a2a_supervisor_cfg = getattr(settings.a2a, "supervisor_config_path", "") or ""
-    if _a2a_supervisor_cfg:
-        _a2a_runner: Any = _SupervisorA2ARunner(app_state, _a2a_supervisor_cfg)
-        logger.info(f"A2A inbound: routing requests through supervisor at {_a2a_supervisor_cfg}")
-    else:
-        _a2a_runner = _PlaceholderA2ARunner()
-        logger.warning(
-            "A2A inbound enabled but settings.a2a.supervisor_config_path is empty; using placeholder runner."
-        )
-    app.include_router(_build_a2a_router(runner=_a2a_runner, settings=_a2a_settings_dict))
+    app.include_router(build_a2a_router_for_settings(settings.a2a, app_state))
 
 
 @app.get("/health")

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -223,3 +223,12 @@ save_on_success = true       # Save trajectory on successful task completion
 save_on_failure = true       # Save trajectory on failed task completion
 async_save = true            # Fire-and-forget trajectory saving (non-blocking)
 timeout = 30.0               # Timeout in seconds for Evolve MCP calls
+
+[a2a]
+enabled = false                                              # Master toggle. When false, the A2A router is not mounted and the package is never imported.
+agent_name = "cuga"                                          # The name advertised in the AgentCard.
+agent_description = "CUGA agent exposed over A2A."           # Free-text description for the AgentCard.
+agent_version = "0.0.0"                                      # Version string for the AgentCard.
+agent_url = "http://localhost:8000"                          # Public URL clients should hit. Override per-deployment.
+auth_required = false                                        # When true, the AgentCard advertises a bearer security scheme.
+skill_ids = ["delegate_task"]                                # Skill IDs surfaced in the AgentCard.

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -232,3 +232,4 @@ agent_version = "0.0.0"                                      # Version string fo
 agent_url = "http://localhost:8000"                          # Public URL clients should hit. Override per-deployment.
 auth_required = false                                        # When true, the AgentCard advertises a bearer security scheme.
 skill_ids = ["delegate_task"]                                # Skill IDs surfaced in the AgentCard.
+supervisor_config_path = ""                                  # YAML config for the CugaSupervisor that handles A2A inbound. When empty, a placeholder runner is used.

--- a/tests/integration/a2a/conftest.py
+++ b/tests/integration/a2a/conftest.py
@@ -1,0 +1,129 @@
+"""Shared fixtures for the A2A integration tests.
+
+These tests target the module that will live at ``cuga.backend.server.a2a``.
+Until that module exists, every test using these fixtures will skip via
+``pytest.importorskip``. No test in this directory binds a real port — we
+drive the FastAPI app via ``httpx.ASGITransport`` so the suite stays
+hermetic and CI-friendly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Callable, List, Optional
+
+import pytest
+
+
+@dataclass
+class FakeStreamEvent:
+    """Stand-in for cuga's internal StreamEvent.
+
+    The real adapter contract takes whatever CUGA already emits; we keep
+    this fake shaped like a (name, data) pair so tests don't depend on
+    importing internal types.
+    """
+
+    name: str
+    data: Any = None
+    final: bool = False
+
+
+@dataclass
+class ScriptedGraphRunner:
+    """A GraphRunner stub the router can call.
+
+    The real ``build_router`` accepts any callable matching the
+    ``GraphRunner`` protocol: ``run(message, context_id) -> AsyncIterator[StreamEvent]``.
+    We implement that here so router tests don't need a real graph.
+    """
+
+    events: List[FakeStreamEvent] = field(default_factory=list)
+    on_run: Optional[Callable[[str, Optional[str]], None]] = None
+    received: List[tuple[str, Optional[str]]] = field(default_factory=list)
+
+    async def run(self, message: str, context_id: Optional[str] = None) -> AsyncIterator[FakeStreamEvent]:
+        self.received.append((message, context_id))
+        if self.on_run is not None:
+            self.on_run(message, context_id)
+        for ev in self.events:
+            yield ev
+
+
+@pytest.fixture
+def fake_event_factory():
+    """Factory the tests use to script a stream."""
+
+    def _make(name: str, data: Any = None, final: bool = False) -> FakeStreamEvent:
+        return FakeStreamEvent(name=name, data=data, final=final)
+
+    return _make
+
+
+@pytest.fixture
+def scripted_runner(fake_event_factory):
+    """A scripted runner that completes after one 'working' + one final event."""
+
+    return ScriptedGraphRunner(
+        events=[
+            fake_event_factory("agent_thinking", {"text": "planning"}),
+            fake_event_factory("final_answer", {"text": "the answer is 42"}, final=True),
+        ]
+    )
+
+
+@pytest.fixture
+def a2a_settings():
+    """The minimal settings object the router needs.
+
+    Mirrors the [a2a] block we'll add to settings.toml. Tests construct
+    this in-line so we don't touch real settings during unit/integration runs.
+    """
+
+    return {
+        "enabled": True,
+        "path_prefix": "",
+        "agent_name": "cuga-test",
+        "agent_description": "Test instance of CUGA exposed over A2A.",
+        "agent_version": "0.0.0-test",
+        "agent_url": "http://test.local",
+        "skill_ids": ["delegate_task"],
+    }
+
+
+@pytest.fixture
+def app_with_a2a(scripted_runner, a2a_settings):
+    """Build a fresh FastAPI app with only the A2A router mounted.
+
+    Mounting only the A2A router (not the full CUGA server) keeps these
+    tests fast and isolated. The real ``main.py`` integration is verified
+    separately by ``test_main_unchanged_when_disabled``.
+    """
+
+    pytest.importorskip("cuga.backend.server.a2a")
+    from fastapi import FastAPI
+
+    from cuga.backend.server.a2a import build_router
+
+    app = FastAPI()
+    app.include_router(build_router(runner=scripted_runner, settings=a2a_settings))
+    return app
+
+
+@pytest.fixture
+def app_a2a_disabled(a2a_settings):
+    """A FastAPI app simulating ``a2a.enabled = False``: router never mounted."""
+
+    from fastapi import FastAPI
+
+    return FastAPI()
+
+
+@pytest.fixture
+async def asgi_client(app_with_a2a):
+    """An httpx.AsyncClient bound to the in-process app via ASGITransport."""
+
+    httpx = pytest.importorskip("httpx")
+    transport = httpx.ASGITransport(app=app_with_a2a)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test.local") as client:
+        yield client

--- a/tests/integration/a2a/test_a2a_client_roundtrip.py
+++ b/tests/integration/a2a/test_a2a_client_roundtrip.py
@@ -1,0 +1,73 @@
+"""Roundtrip tests using the real a2a-sdk against our router.
+
+These are the strongest contract tests in the suite: if the SDK that real
+A2A clients use can talk to our server end-to-end, we know the protocol
+is correct beyond what hand-rolled JSON assertions can verify.
+
+The client speaks to the in-process FastAPI app via httpx.ASGITransport,
+so no port is bound and no LLM is called.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+a2a_client = pytest.importorskip("a2a.client")
+a2a_types = pytest.importorskip("a2a.compat.v0_3.types")
+httpx = pytest.importorskip("httpx")
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+async def asgi_httpx(app_with_a2a):
+    transport = httpx.ASGITransport(app=app_with_a2a)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test.local") as client:
+        yield client
+
+
+async def test_sdk_card_resolver_fetches_agent_card(asgi_httpx):
+    """The SDK's official resolver must accept what we serve at the
+    well-known path. If this passes, our AgentCard is wire-compliant."""
+    from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+
+    resolver = a2a_client.A2ACardResolver(
+        httpx_client=asgi_httpx,
+        base_url="http://test.local",
+        agent_card_path=AGENT_CARD_WELL_KNOWN_PATH,
+    )
+    card = await resolver.get_agent_card()
+    assert card is not None
+    assert card.name == "cuga-test"
+    assert card.capabilities.streaming is True
+
+
+async def test_jsonrpc_send_message_returns_task(asgi_httpx):
+    """A JSON-RPC ``message/send`` against our router must return a Task
+    that round-trips through the SDK's pydantic model. The task ID and
+    completed terminal status are what real clients key off of."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid4()),
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "hello CUGA"}],
+                "messageId": uuid4().hex,
+            }
+        },
+    }
+    resp = await asgi_httpx.post("/a2a", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("jsonrpc") == "2.0"
+    assert body.get("error") is None
+    result = body["result"]
+    # Round-trip through SDK pydantic Task — strongest cheap check.
+    task = a2a_types.Task.model_validate(result)
+    assert task.id
+    assert task.status.state == a2a_types.TaskState.completed

--- a/tests/integration/a2a/test_a2a_router.py
+++ b/tests/integration/a2a/test_a2a_router.py
@@ -1,0 +1,180 @@
+"""Integration tests for the A2A FastAPI router.
+
+These drive the router via httpx.ASGITransport (no port bind) and assert
+on the JSON-RPC + AgentCard contract. The CUGA graph is replaced with a
+scripted runner via the `app_with_a2a` fixture in conftest.py.
+
+Bug classes these target:
+- malformed AgentCard at /.well-known/agent.json
+- mounting the router unconditionally (it must be opt-in)
+- raising HTTP 500 on protocol-level errors instead of returning a
+  JSON-RPC error envelope (a real client would crash)
+- silently ignoring unknown JSON-RPC methods
+- regressing on the existing /stream endpoint
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+a2a_types = pytest.importorskip("a2a.compat.v0_3.types")
+
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_well_known_agent_card_returns_valid_card(asgi_client):
+    resp = await asgi_client.get("/.well-known/agent.json")
+    assert resp.status_code == 200
+    body = resp.json()
+    # Round-trip via the SDK's Pydantic model — the most robust contract check.
+    card = a2a_types.AgentCard.model_validate(body)
+    assert card.name
+    assert card.capabilities is not None
+
+
+async def test_well_known_agent_card_advertises_streaming(asgi_client):
+    resp = await asgi_client.get("/.well-known/agent.json")
+    body = resp.json()
+    assert body["capabilities"]["streaming"] is True
+
+
+async def test_well_known_404_when_router_not_mounted(app_a2a_disabled):
+    """When the [a2a] section is disabled, main.py must not mount the
+    router. This test simulates that by using an app with no router."""
+    httpx = pytest.importorskip("httpx")
+    transport = httpx.ASGITransport(app=app_a2a_disabled)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test.local") as client:
+        resp = await client.get("/.well-known/agent.json")
+    assert resp.status_code == 404
+
+
+async def test_send_message_happy_path_returns_jsonrpc_envelope(asgi_client):
+    """JSON-RPC 2.0 contract: response carries jsonrpc=2.0, the same id,
+    and a `result` field. Failing this breaks every A2A client."""
+    request_id = "req-123"
+    payload = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "hello"}],
+                "messageId": "m-1",
+            }
+        },
+    }
+    resp = await asgi_client.post("/a2a", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("jsonrpc") == "2.0"
+    assert body.get("id") == request_id
+    assert "result" in body and "error" not in body
+
+
+async def test_send_message_invokes_underlying_runner(asgi_client, scripted_runner):
+    """The router must actually call the graph runner with the user text.
+    A router that returns a static answer would pass the contract test
+    above but fail this one."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "req-1",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "what is 2+2"}],
+                "messageId": "m-1",
+            }
+        },
+    }
+    await asgi_client.post("/a2a", json=payload)
+    assert any("what is 2+2" in msg for (msg, _ctx) in scripted_runner.received)
+
+
+async def test_invalid_jsonrpc_returns_jsonrpc_error_not_http_500(asgi_client):
+    """Per JSON-RPC 2.0, malformed envelopes return -32600/-32700 with
+    HTTP 200, NOT an HTTP 5xx. Real clients only parse the JSON body."""
+    resp = await asgi_client.post(
+        "/a2a", content=b"{not valid json", headers={"content-type": "application/json"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("jsonrpc") == "2.0"
+    assert "error" in body
+    # -32700 = Parse error, -32600 = Invalid Request
+    assert body["error"]["code"] in (-32700, -32600)
+
+
+async def test_unknown_method_returns_method_not_found(asgi_client):
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "req-1",
+        "method": "methods/does_not_exist",
+        "params": {},
+    }
+    resp = await asgi_client.post("/a2a", json=payload)
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32601  # Method not found
+
+
+async def test_streaming_subscribe_yields_lifecycle(asgi_client):
+    """`message/stream` (SSE) must yield at least one working update and
+    a terminal completed event. The id from the request must be echoed
+    in each chunk so a client can correlate."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "stream-1",
+        "method": "message/stream",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "go"}],
+                "messageId": "m-1",
+            }
+        },
+    }
+    async with asgi_client.stream("POST", "/a2a", json=payload) as resp:
+        assert resp.status_code == 200
+        chunks = []
+        async for line in resp.aiter_lines():
+            line = line.strip()
+            if not line:
+                continue
+            # SSE: "data: {...}"
+            if line.startswith("data:"):
+                line = line[len("data:") :].strip()
+            try:
+                chunks.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    # Every chunk is a JSON-RPC frame keyed back to our request id.
+    assert all(c.get("id") == "stream-1" for c in chunks if "id" in c)
+    # We saw a terminal-ish event somewhere in the stream.
+    serialized = json.dumps(chunks)
+    assert "completed" in serialized or "final" in serialized
+
+
+async def test_context_id_propagates_to_graph_runner(asgi_client, scripted_runner):
+    """contextId in the A2A request must be passed to the graph runner so
+    multi-turn conversations land on the same thread."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "req-1",
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "follow-up"}],
+                "messageId": "m-2",
+                "contextId": "ctx-existing-thread",
+            }
+        },
+    }
+    await asgi_client.post("/a2a", json=payload)
+    contexts = [ctx for (_msg, ctx) in scripted_runner.received]
+    assert "ctx-existing-thread" in contexts

--- a/tests/integration/a2a/test_a2a_router.py
+++ b/tests/integration/a2a/test_a2a_router.py
@@ -159,6 +159,103 @@ async def test_streaming_subscribe_yields_lifecycle(asgi_client):
     assert "completed" in serialized or "final" in serialized
 
 
+async def test_sse_stream_emits_jsonrpc_error_when_runner_raises(fake_event_factory, a2a_settings):
+    """If the runner blows up mid-stream, clients must still receive a
+    parseable JSON-RPC error frame — not a half-open stream they can't
+    distinguish from a network drop. Earlier the SSE generator just
+    propagated the exception and SSE silently terminated."""
+    pytest.importorskip("cuga.backend.server.a2a")
+    from fastapi import FastAPI
+
+    from cuga.backend.server.a2a import build_router
+
+    class _BlowingRunner:
+        async def run(self, message, context_id=None):
+            raise RuntimeError("simulated graph crash")
+            yield  # pragma: no cover — mark as async generator
+
+    app = FastAPI()
+    app.include_router(build_router(runner=_BlowingRunner(), settings=a2a_settings))
+
+    httpx = pytest.importorskip("httpx")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test.local") as client:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "stream-err",
+            "method": "message/stream",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "boom"}],
+                    "messageId": "m-1",
+                }
+            },
+        }
+        chunks = []
+        async with client.stream("POST", "/a2a", json=payload) as resp:
+            assert resp.status_code == 200
+            async for line in resp.aiter_lines():
+                line = line.strip()
+                if not line:
+                    continue
+                if line.startswith("data:"):
+                    line = line[len("data:") :].strip()
+                try:
+                    chunks.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    assert chunks, "expected at least one frame, got an empty stream"
+    error_frames = [c for c in chunks if "error" in c]
+    assert error_frames, f"expected a JSON-RPC error frame, got {chunks!r}"
+    err = error_frames[-1]["error"]
+    assert err["code"] == -32603  # internal error
+    # Wire message must NOT contain the raw exception text.
+    assert "simulated graph crash" not in err.get("message", "")
+
+
+async def test_jsonrpc_send_does_not_leak_raw_exception_text(fake_event_factory, a2a_settings):
+    """When the runner raises during ``message/send``, the JSON envelope
+    must surface a generic message (plus exception class) — never the
+    raw ``str(exc)`` which can leak paths/config."""
+    pytest.importorskip("cuga.backend.server.a2a")
+    from fastapi import FastAPI
+
+    from cuga.backend.server.a2a import build_router
+
+    class _BlowingRunner:
+        async def run(self, message, context_id=None):
+            raise RuntimeError("/secret/path/leak")
+            yield  # pragma: no cover
+
+    app = FastAPI()
+    app.include_router(build_router(runner=_BlowingRunner(), settings=a2a_settings))
+
+    httpx = pytest.importorskip("httpx")
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test.local") as client:
+        resp = await client.post(
+            "/a2a",
+            json={
+                "jsonrpc": "2.0",
+                "id": "leak-check",
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "go"}],
+                        "messageId": "m-1",
+                    }
+                },
+            },
+        )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32603
+    assert "/secret/path/leak" not in body["error"]["message"]
+    assert "RuntimeError" in body["error"]["message"]  # class is fine; details aren't
+
+
 async def test_context_id_propagates_to_graph_runner(asgi_client, scripted_runner):
     """contextId in the A2A request must be passed to the graph runner so
     multi-turn conversations land on the same thread."""

--- a/tests/integration/a2a/test_cuga_to_cuga.py
+++ b/tests/integration/a2a/test_cuga_to_cuga.py
@@ -1,0 +1,158 @@
+"""End-to-end: a CUGA agent talking to another CUGA agent via A2A.
+
+This is the symmetry test. CUGA already speaks A2A as a *client* (via
+``cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol``). Once
+the new server module lands, the same SDK that powers outbound delegation
+must be able to talk to our own inbound endpoint.
+
+We run two CUGAs in-process:
+
+  Server CUGA  -- FastAPI app + A2A router + scripted graph
+  Client CUGA  -- the existing supervisor delegation helpers, pointed
+                  at the server via httpx.ASGITransport
+
+If this test passes, CUGA's outbound and inbound A2A halves agree on the
+wire format — the strongest single check we can run without standing up
+a real network.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+a2a_client = pytest.importorskip("a2a.client")
+a2a_types = pytest.importorskip("a2a.compat.v0_3.types")
+httpx = pytest.importorskip("httpx")
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+async def server_asgi_client(app_with_a2a):
+    """Server CUGA accessible via in-process httpx transport."""
+    transport = httpx.ASGITransport(app=app_with_a2a)
+    async with httpx.AsyncClient(transport=transport, base_url="http://server-cuga.local") as client:
+        yield client
+
+
+async def test_client_cuga_fetches_server_cuga_agent_card(server_asgi_client):
+    """Client CUGA discovers Server CUGA exactly as it would discover any
+    third-party A2A agent."""
+    from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+
+    resolver = a2a_client.A2ACardResolver(
+        httpx_client=server_asgi_client,
+        base_url="http://server-cuga.local",
+        agent_card_path=AGENT_CARD_WELL_KNOWN_PATH,
+    )
+    card = await resolver.get_agent_card()
+    assert card is not None
+    assert card.name == "cuga-test"
+    # Server CUGA must advertise at least one skill so the client can route to it.
+    assert len(card.skills) >= 1
+
+
+async def test_client_cuga_delegates_simple_task_to_server_cuga(server_asgi_client, scripted_runner):
+    """The full delegation path: discover card, send message, receive
+    response. Reuses the existing client helpers in
+    a2a_protocol.py so we're testing what production would actually run."""
+    pytest.importorskip("cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol")
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import (
+        delegate_task_via_a2a_sdk,
+    )
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid4()),
+        "method": "message/send",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "please summarize"}],
+                "messageId": uuid4().hex,
+            }
+        },
+    }
+    resp = await server_asgi_client.post("/a2a", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("error") is None
+    # Round-trip the result through the SDK's pydantic Task — the same
+    # validation a real client would apply.
+    task = a2a_types.Task.model_validate(body["result"])
+    assert task.status.state == a2a_types.TaskState.completed
+    # Server's scripted graph received the user's task verbatim.
+    assert any("please summarize" in msg for (msg, _ctx) in scripted_runner.received)
+    # Sanity: the helper module is importable and its public API still exists
+    # (regression guard — if that module breaks, real delegation breaks too).
+    assert callable(delegate_task_via_a2a_sdk)
+
+
+async def test_streaming_events_propagate_end_to_end(server_asgi_client):
+    """A2A streaming: the server must emit task updates the client SDK
+    can consume incrementally."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "stream-e2e",
+        "method": "message/stream",
+        "params": {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": "stream please"}],
+                "messageId": "m-1",
+            }
+        },
+    }
+    saw_lifecycle = False
+    async with server_asgi_client.stream("POST", "/a2a", json=payload) as resp:
+        assert resp.status_code == 200
+        async for line in resp.aiter_lines():
+            if "completed" in line or "working" in line:
+                saw_lifecycle = True
+    assert saw_lifecycle
+
+
+async def test_context_id_isolation_between_concurrent_delegations(
+    app_with_a2a, scripted_runner, fake_event_factory
+):
+    """Two concurrent delegations with distinct contextIds must not
+    cross-contaminate threads on the server."""
+    import asyncio
+
+    transport = httpx.ASGITransport(app=app_with_a2a)
+    async with httpx.AsyncClient(transport=transport, base_url="http://server-cuga.local") as c:
+
+        async def call(text, ctx):
+            payload = {
+                "jsonrpc": "2.0",
+                "id": f"req-{ctx}",
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": text}],
+                        "messageId": uuid4().hex,
+                        "contextId": ctx,
+                    }
+                },
+            }
+            return await c.post("/a2a", json=payload)
+
+        responses = await asyncio.gather(
+            call("task-A", "ctx-A"),
+            call("task-B", "ctx-B"),
+        )
+    assert all(r.status_code == 200 for r in responses)
+    contexts = {ctx for (_msg, ctx) in scripted_runner.received}
+    assert {"ctx-A", "ctx-B"}.issubset(contexts)
+
+
+@pytest.mark.xfail(reason="auth-token forwarding across A2A boundary not yet implemented")
+async def test_auth_token_forwarded_on_delegation(server_asgi_client):
+    """When the client CUGA authenticates to server CUGA, its bearer
+    token must reach require_chat_access on the server side. Marked xfail
+    until we ship token forwarding in v1."""
+    raise AssertionError("token forwarding not implemented")

--- a/tests/integration/a2a/test_cuga_to_cuga.py
+++ b/tests/integration/a2a/test_cuga_to_cuga.py
@@ -55,40 +55,39 @@ async def test_client_cuga_fetches_server_cuga_agent_card(server_asgi_client):
     assert len(card.skills) >= 1
 
 
-async def test_client_cuga_delegates_simple_task_to_server_cuga(server_asgi_client, scripted_runner):
+async def test_client_cuga_delegates_simple_task_to_server_cuga(app_with_a2a, scripted_runner):
     """The full delegation path: discover card, send message, receive
-    response. Reuses the existing client helpers in
-    a2a_protocol.py so we're testing what production would actually run."""
-    pytest.importorskip("cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol")
+    response. This drives the actual production delegate_task_via_a2a_sdk
+    helper at the in-process server CUGA via ASGI transport — same code
+    path real cross-process delegation would take, just without the TCP
+    hop. If this passes, both halves of CUGA's A2A surface agree."""
+    from unittest.mock import patch
+
     from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import (
         delegate_task_via_a2a_sdk,
     )
 
-    payload = {
-        "jsonrpc": "2.0",
-        "id": str(uuid4()),
-        "method": "message/send",
-        "params": {
-            "message": {
-                "role": "user",
-                "parts": [{"kind": "text", "text": "please summarize"}],
-                "messageId": uuid4().hex,
-            }
-        },
-    }
-    resp = await server_asgi_client.post("/a2a", json=payload)
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body.get("error") is None
-    # Round-trip the result through the SDK's pydantic Task — the same
-    # validation a real client would apply.
-    task = a2a_types.Task.model_validate(body["result"])
-    assert task.status.state == a2a_types.TaskState.completed
-    # Server's scripted graph received the user's task verbatim.
+    transport = httpx.ASGITransport(app=app_with_a2a)
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    class _Card:
+        url = "http://server-cuga.local"
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol.httpx.AsyncClient",
+        side_effect=_factory,
+    ):
+        result = await delegate_task_via_a2a_sdk(_Card(), "please summarize")
+
+    # The supervisor helper got a real answer back from the in-process server.
+    assert result["status"] == "success"
+    assert "42" in result["result"]  # scripted_runner replies with "the answer is 42"
+    # And the server's scripted graph received the user's task verbatim.
     assert any("please summarize" in msg for (msg, _ctx) in scripted_runner.received)
-    # Sanity: the helper module is importable and its public API still exists
-    # (regression guard — if that module breaks, real delegation breaks too).
-    assert callable(delegate_task_via_a2a_sdk)
 
 
 async def test_streaming_events_propagate_end_to_end(server_asgi_client):

--- a/tests/integration/a2a/test_outbound_protocol.py
+++ b/tests/integration/a2a/test_outbound_protocol.py
@@ -86,7 +86,7 @@ def test_agent_card_rpc_url_extracts_from_supported_interfaces_proto_shape():
 
     class _ProtoCard:
         url = ""  # absent on protobuf
-        supported_interfaces = [_Iface()]
+        supported_interfaces = (_Iface(),)
 
     assert _agent_card_rpc_url(_ProtoCard()) == "http://peer.example:8002/a2a"
 
@@ -106,7 +106,7 @@ def test_agent_card_rpc_url_prefers_jsonrpc_interface_when_multiple_present():
 
     class _Card:
         url = ""
-        supported_interfaces = [_Grpc(), _Json()]
+        supported_interfaces = (_Grpc(), _Json())
 
     assert _agent_card_rpc_url(_Card()) == "https://peer.example/a2a"
 

--- a/tests/integration/a2a/test_outbound_protocol.py
+++ b/tests/integration/a2a/test_outbound_protocol.py
@@ -1,0 +1,158 @@
+"""Tests for the rewritten outbound A2A client.
+
+The previous SDK-1.x-incompatible imports made this code path silently
+no-op; these tests pin the new behavior so the regression doesn't recur.
+The strongest check is the round-trip: drive the rewritten outbound
+client at the in-process A2A router via ``httpx.ASGITransport`` and
+assert text flows end-to-end.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+a2a_types = pytest.importorskip("a2a.compat.v0_3.types")
+httpx = pytest.importorskip("httpx")
+pytest.importorskip("cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol")
+
+
+pytestmark = pytest.mark.anyio
+
+
+def test_module_reports_sdk_available():
+    """If this flips back to False, every HTTP-A2A delegation silently
+    no-ops. A bare assertion is the cheapest tripwire we can install."""
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import HAS_A2A_SDK
+
+    assert HAS_A2A_SDK is True
+
+
+def test_extract_text_picks_latest_agent_message():
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _extract_text_from_task
+
+    task = {
+        "history": [
+            {"role": "user", "parts": [{"text": "hi"}]},
+            {"role": "agent", "parts": [{"text": "first reply"}]},
+            {"role": "agent", "parts": [{"text": "final reply"}]},
+        ],
+    }
+    assert _extract_text_from_task(task) == "final reply"
+
+
+def test_extract_text_falls_back_to_status_message():
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _extract_text_from_task
+
+    task = {
+        "history": [],
+        "status": {"message": {"parts": [{"text": "from status"}]}},
+    }
+    assert _extract_text_from_task(task) == "from status"
+
+
+def test_agent_card_rpc_url_uses_card_url_when_endpoint_already_set():
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _agent_card_rpc_url
+
+    class _Card:
+        url = "https://peer.example/a2a"
+
+    assert _agent_card_rpc_url(_Card()) == "https://peer.example/a2a"
+
+
+def test_agent_card_rpc_url_appends_a2a_when_card_points_at_base():
+    """Cards from CUGA's own builder advertise the base URL, not /a2a.
+    The outbound client must still find the JSON-RPC endpoint."""
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _agent_card_rpc_url
+
+    class _Card:
+        url = "https://peer.example"
+
+    assert _agent_card_rpc_url(_Card()) == "https://peer.example/a2a"
+
+
+def test_agent_card_rpc_url_uses_fallback_when_card_has_no_url():
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _agent_card_rpc_url
+
+    class _Card:
+        url = None
+
+    assert _agent_card_rpc_url(_Card(), fallback_base="http://fallback") == "http://fallback/a2a"
+
+
+async def test_delegate_round_trips_against_real_router(app_with_a2a, scripted_runner):
+    """The strongest check: drive the rewritten outbound client at our
+    inbound router and assert that the user message reaches the runner
+    AND the answer comes back. If either half breaks, this test fails."""
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import (
+        delegate_task_via_a2a_sdk,
+    )
+
+    transport = httpx.ASGITransport(app=app_with_a2a)
+
+    # Patch the module-level httpx.AsyncClient constructor so the outbound
+    # client transparently routes through the in-process app — no port bind.
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    class _Card:
+        url = "http://test.local"
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol.httpx.AsyncClient",
+        side_effect=_factory,
+    ):
+        result = await delegate_task_via_a2a_sdk(_Card(), "please count to three")
+
+    # Server received the user's text verbatim — proves the wire roundtrips.
+    assert any("please count to three" in msg for (msg, _ctx) in scripted_runner.received)
+    # And the response shape is what callers downstream expect.
+    assert isinstance(result, dict)
+    assert result["status"] == "success"
+    # The scripted runner replies with "the answer is 42" for final events,
+    # which our adapter wraps into the task's last agent message.
+    assert "42" in result["result"]
+
+
+async def test_delegate_surfaces_jsonrpc_error_as_runtime_error():
+    """If the peer returns a JSON-RPC error envelope, the helper must
+    raise — silent failure here lets bad delegations look like empty
+    successes upstream. We stand up a tiny FastAPI app that always
+    answers with a JSON-RPC error so the helper hits the error branch
+    deterministically."""
+    from fastapi import FastAPI
+
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import (
+        delegate_task_via_a2a_sdk,
+    )
+
+    error_app = FastAPI()
+
+    @error_app.post("/a2a")
+    async def _always_error():
+        return {
+            "jsonrpc": "2.0",
+            "id": "x",
+            "error": {"code": -32603, "message": "boom"},
+        }
+
+    transport = httpx.ASGITransport(app=error_app)
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    class _Card:
+        url = "http://test.local"
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol.httpx.AsyncClient",
+        side_effect=_factory,
+    ):
+        with pytest.raises(RuntimeError, match="A2A send_message failed"):
+            await delegate_task_via_a2a_sdk(_Card(), "anything")

--- a/tests/integration/a2a/test_outbound_protocol.py
+++ b/tests/integration/a2a/test_outbound_protocol.py
@@ -72,6 +72,45 @@ def test_agent_card_rpc_url_appends_a2a_when_card_points_at_base():
     assert _agent_card_rpc_url(_Card()) == "https://peer.example/a2a"
 
 
+def test_agent_card_rpc_url_extracts_from_supported_interfaces_proto_shape():
+    """SDK 1.x's A2ACardResolver returns a *protobuf* AgentCard whose
+    URL lives in ``supported_interfaces[0].url`` rather than ``.url``.
+    This is how every real outbound delegation gets its endpoint, so
+    if this test breaks, every cross-process A2A call breaks with it."""
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _agent_card_rpc_url
+
+    class _Iface:
+        url = "http://peer.example:8002"
+        protocol_binding = "JSONRPC"
+        protocol_version = "0.3.0"
+
+    class _ProtoCard:
+        url = ""  # absent on protobuf
+        supported_interfaces = [_Iface()]
+
+    assert _agent_card_rpc_url(_ProtoCard()) == "http://peer.example:8002/a2a"
+
+
+def test_agent_card_rpc_url_prefers_jsonrpc_interface_when_multiple_present():
+    """When a peer advertises both gRPC and JSONRPC interfaces, we must
+    pick JSONRPC — that's the wire we actually speak."""
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _agent_card_rpc_url
+
+    class _Grpc:
+        url = "grpc://peer.example:50051"
+        protocol_binding = "GRPC"
+
+    class _Json:
+        url = "https://peer.example/a2a"
+        protocol_binding = "JSONRPC"
+
+    class _Card:
+        url = ""
+        supported_interfaces = [_Grpc(), _Json()]
+
+    assert _agent_card_rpc_url(_Card()) == "https://peer.example/a2a"
+
+
 def test_agent_card_rpc_url_uses_fallback_when_card_has_no_url():
     from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import _agent_card_rpc_url
 

--- a/tests/integration/a2a/test_outbound_protocol.py
+++ b/tests/integration/a2a/test_outbound_protocol.py
@@ -195,3 +195,90 @@ async def test_delegate_surfaces_jsonrpc_error_as_runtime_error():
     ):
         with pytest.raises(RuntimeError, match="A2A send_message failed"):
             await delegate_task_via_a2a_sdk(_Card(), "anything")
+
+
+async def test_delegate_surfaces_peer_task_failure_as_failed_status():
+    """When the peer answers 200 with a Task whose state=failed, the
+    helper must return status='failed' instead of the prior bug where
+    every shaped 200 was flattened to status='success'."""
+    from fastapi import FastAPI
+
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import (
+        delegate_task_via_a2a_sdk,
+    )
+
+    failing_app = FastAPI()
+
+    @failing_app.post("/a2a")
+    async def _peer_task_failed():
+        # Shape mirrors what our own router emits when a graph errors.
+        return {
+            "jsonrpc": "2.0",
+            "id": "x",
+            "result": {
+                "id": "task-1",
+                "contextId": "ctx-1",
+                "status": {"state": "failed"},
+                "history": [
+                    {
+                        "role": "agent",
+                        "parts": [{"kind": "text", "text": "remote LLM 401"}],
+                        "messageId": "m-final",
+                    }
+                ],
+            },
+        }
+
+    transport = httpx.ASGITransport(app=failing_app)
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    class _Card:
+        url = "http://test.local"
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol.httpx.AsyncClient",
+        side_effect=_factory,
+    ):
+        result = await delegate_task_via_a2a_sdk(_Card(), "anything")
+
+    assert result["status"] == "failed"
+    assert "remote LLM 401" in result["result"]
+
+
+async def test_delegate_raises_when_response_lacks_task_envelope():
+    """If the peer answers 200 with neither error nor a dict result, the
+    earlier code returned status='success' with empty text — making the
+    failure indistinguishable from a successful empty answer. The helper
+    must raise instead so callers can route the failure."""
+    from fastapi import FastAPI
+
+    from cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol import (
+        delegate_task_via_a2a_sdk,
+    )
+
+    bogus_app = FastAPI()
+
+    @bogus_app.post("/a2a")
+    async def _bogus():
+        return {"jsonrpc": "2.0", "id": "x", "result": "not-a-task-object"}
+
+    transport = httpx.ASGITransport(app=bogus_app)
+    real_async_client = httpx.AsyncClient
+
+    def _factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    class _Card:
+        url = "http://test.local"
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_supervisor.a2a_protocol.httpx.AsyncClient",
+        side_effect=_factory,
+    ):
+        with pytest.raises(RuntimeError, match="missing a valid"):
+            await delegate_task_via_a2a_sdk(_Card(), "anything")

--- a/tests/unit/a2a/test_agent_card.py
+++ b/tests/unit/a2a/test_agent_card.py
@@ -1,0 +1,99 @@
+"""Unit tests for cuga.backend.server.a2a.agent_card.
+
+These pin the AgentCard contract: required fields, capability flags,
+skill construction, and round-trip validity against the a2a-sdk Pydantic
+models. The build is pure — no I/O, no app wiring — so these tests are
+the cheapest place to catch breakage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+a2a_types = pytest.importorskip("a2a.compat.v0_3.types")
+
+
+@pytest.fixture
+def agent_card_module():
+    return pytest.importorskip("cuga.backend.server.a2a.agent_card")
+
+
+@pytest.fixture
+def base_settings():
+    return {
+        "enabled": True,
+        "path_prefix": "",
+        "agent_name": "cuga",
+        "agent_description": "CUGA exposed over A2A.",
+        "agent_version": "1.2.3",
+        "agent_url": "https://cuga.example/a2a",
+        "skill_ids": ["delegate_task"],
+    }
+
+
+def test_agent_card_minimal_fields(agent_card_module, base_settings):
+    card = agent_card_module.build_agent_card(base_settings, skills=[])
+    assert card.name == "cuga"
+    assert card.description == "CUGA exposed over A2A."
+    assert card.version == "1.2.3"
+    assert str(card.url).startswith("https://cuga.example")
+
+
+def test_agent_card_capabilities_streaming_true(agent_card_module, base_settings):
+    """CUGA already streams via SSE — the AgentCard must advertise it."""
+    card = agent_card_module.build_agent_card(base_settings, skills=[])
+    assert card.capabilities is not None
+    assert card.capabilities.streaming is True
+
+
+def test_agent_card_skills_built_from_registry(agent_card_module, base_settings):
+    skills_input = [
+        {"id": "delegate_task", "name": "Delegate task", "description": "Run a CUGA task"},
+        {"id": "summarize", "name": "Summarize", "description": "Summarize text"},
+    ]
+    card = agent_card_module.build_agent_card(base_settings, skills=skills_input)
+    assert len(card.skills) == 2
+    ids = {s.id for s in card.skills}
+    assert ids == {"delegate_task", "summarize"}
+
+
+def test_agent_card_skill_ids_are_stable(agent_card_module, base_settings):
+    """A skill id is what an A2A client routes against. It must round-trip
+    verbatim — no slugifying, no renaming."""
+    card = agent_card_module.build_agent_card(
+        base_settings, skills=[{"id": "delegate_task", "name": "Delegate task"}]
+    )
+    assert card.skills[0].id == "delegate_task"
+
+
+def test_agent_card_default_input_output_modes_include_text(agent_card_module, base_settings):
+    """A2A clients negotiate on default modes; CUGA must accept text."""
+    card = agent_card_module.build_agent_card(base_settings, skills=[])
+    assert "text" in (card.default_input_modes or [])
+    assert "text" in (card.default_output_modes or [])
+
+
+def test_agent_card_validates_against_a2a_sdk_types(agent_card_module, base_settings):
+    """The strongest check we can run cheaply: round-trip through the SDK's
+    Pydantic model. If the SDK rejects it, no real client will accept it."""
+    card = agent_card_module.build_agent_card(
+        base_settings, skills=[{"id": "delegate_task", "name": "Delegate task"}]
+    )
+    dumped = card.model_dump(mode="json", exclude_none=True)
+    rebuilt = a2a_types.AgentCard.model_validate(dumped)
+    assert rebuilt.name == card.name
+    assert {s.id for s in rebuilt.skills} == {s.id for s in card.skills}
+
+
+def test_agent_card_security_schemes_when_auth_required(agent_card_module, base_settings):
+    """When auth is on, the card must declare a securityScheme so callers
+    know to attach a token. When off, security can be empty/None."""
+    settings_with_auth = {**base_settings, "auth_required": True}
+    card = agent_card_module.build_agent_card(settings_with_auth, skills=[])
+    assert card.security_schemes is not None and len(card.security_schemes) > 0
+
+
+def test_agent_card_no_security_when_auth_off(agent_card_module, base_settings):
+    settings_no_auth = {**base_settings, "auth_required": False}
+    card = agent_card_module.build_agent_card(settings_no_auth, skills=[])
+    assert not card.security_schemes

--- a/tests/unit/a2a/test_agent_card.py
+++ b/tests/unit/a2a/test_agent_card.py
@@ -8,6 +8,8 @@ the cheapest place to catch breakage.
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 import pytest
 
 a2a_types = pytest.importorskip("a2a.compat.v0_3.types")
@@ -36,7 +38,9 @@ def test_agent_card_minimal_fields(agent_card_module, base_settings):
     assert card.name == "cuga"
     assert card.description == "CUGA exposed over A2A."
     assert card.version == "1.2.3"
-    assert str(card.url).startswith("https://cuga.example")
+    parsed_url = urlparse(str(card.url))
+    assert parsed_url.scheme == "https"
+    assert parsed_url.hostname == "cuga.example"
 
 
 def test_agent_card_capabilities_streaming_true(agent_card_module, base_settings):

--- a/tests/unit/a2a/test_task_adapter.py
+++ b/tests/unit/a2a/test_task_adapter.py
@@ -141,3 +141,36 @@ def test_empty_stream_emits_at_least_terminal_state(adapter):
     # Either completed or failed is acceptable; what's not acceptable is
     # an open-ended task with no terminal event.
     assert any("complet" in s or "fail" in s for s in states)
+
+
+def test_error_terminal_event_maps_to_failed_not_completed(adapter):
+    """When the runner yields a terminal `error` event, A2A clients must
+    see TaskState.failed — otherwise upstream callers can't tell a
+    successful run from a crashed one. Earlier revisions silently mapped
+    every terminal to `completed`, masking real failures."""
+    out = list(
+        adapter.stream_events_to_a2a(
+            [_Ev("error", {"text": "kaboom"}, final=True)],
+            task_id="t-1",
+            context_id="c-1",
+        )
+    )
+    states = _states(out)
+    assert any("fail" in s for s in states), f"expected failed state in {states!r}"
+    assert not any("complet" in s for s in states), f"unexpected completed in {states!r}"
+
+
+def test_named_error_event_without_final_flag_still_terminates(adapter):
+    """Even when the runner forgot to set `final=True`, an event named
+    `error` / `failed` / `failure` / `exception` must close the task
+    with state=failed. This is what protected the demo when the provider
+    surfaced a model-access 401 as a single un-flagged error event."""
+    out = list(
+        adapter.stream_events_to_a2a(
+            [_Ev("failure", {"text": "remote refused"})],
+            task_id="t-1",
+            context_id="c-1",
+        )
+    )
+    states = _states(out)
+    assert any("fail" in s for s in states), f"expected failed state in {states!r}"

--- a/tests/unit/a2a/test_task_adapter.py
+++ b/tests/unit/a2a/test_task_adapter.py
@@ -1,0 +1,143 @@
+"""Unit tests for cuga.backend.server.a2a.task_adapter.
+
+The adapter is the only place where CUGA's StreamEvent shape meets the
+A2A wire format, so the failure modes worth pinning are:
+- happy-path lifecycle (working -> completed),
+- HITL interrupts (-> input-required),
+- thread/context-id round-trip,
+- forward-compatibility (unknown event names must not crash).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def adapter():
+    return pytest.importorskip("cuga.backend.server.a2a.task_adapter")
+
+
+@dataclass
+class _Ev:
+    name: str
+    data: Any = None
+    final: bool = False
+
+
+def _states(out):
+    """Pull the `state` value out of whatever the adapter emits.
+
+    The adapter may return a list of A2A TaskStatusUpdateEvent, or pairs
+    of (event, message). We accept either shape and just probe `.status.state`.
+    """
+    states = []
+    for item in out:
+        # TaskStatusUpdateEvent.status.state, or a tuple where item[0] is one
+        target = item[0] if isinstance(item, tuple) else item
+        status = getattr(target, "status", None)
+        state = getattr(status, "state", None) if status is not None else None
+        if state is not None:
+            states.append(str(state))
+    return states
+
+
+def test_in_flight_event_emits_working(adapter):
+    out = list(
+        adapter.stream_events_to_a2a(
+            [_Ev("agent_thinking", {"text": "planning"})],
+            task_id="t-1",
+            context_id="c-1",
+        )
+    )
+    states = _states(out)
+    assert states, "adapter must emit at least one A2A event for an in-flight stream event"
+    assert any("working" in s for s in states)
+
+
+def test_final_event_emits_completed(adapter):
+    out = list(
+        adapter.stream_events_to_a2a(
+            [_Ev("final_answer", {"text": "done"}, final=True)],
+            task_id="t-1",
+            context_id="c-1",
+        )
+    )
+    states = _states(out)
+    assert any("completed" in s for s in states), f"expected completed in {states!r}"
+
+
+def test_full_lifecycle_progresses_working_then_completed(adapter):
+    out = list(
+        adapter.stream_events_to_a2a(
+            [
+                _Ev("agent_thinking", {"text": "planning"}),
+                _Ev("final_answer", {"text": "done"}, final=True),
+            ],
+            task_id="t-1",
+            context_id="c-1",
+        )
+    )
+    states = _states(out)
+    # Must see at least one working before completed.
+    working_idx = next((i for i, s in enumerate(states) if "working" in s), -1)
+    completed_idx = next((i for i, s in enumerate(states) if "completed" in s), -1)
+    assert working_idx >= 0 and completed_idx >= 0
+    assert working_idx < completed_idx
+
+
+def test_hitl_event_maps_to_input_required(adapter):
+    """If an interrupt is signalled, A2A must surface state=input-required
+    so the client knows it needs to send a follow-up message."""
+    out = list(
+        adapter.stream_events_to_a2a(
+            [_Ev("approval_required", {"prompt": "Confirm?"})],
+            task_id="t-1",
+            context_id="c-1",
+        )
+    )
+    states = _states(out)
+    assert any("input" in s for s in states), f"expected input-required state in {states!r}"
+
+
+def test_context_id_round_trips_to_thread(adapter):
+    """contextId in == contextId out. Mismatch breaks resumption."""
+    out = list(
+        adapter.stream_events_to_a2a(
+            [_Ev("final_answer", {"text": "ok"}, final=True)],
+            task_id="task-abc",
+            context_id="ctx-xyz",
+        )
+    )
+    seen_ctx = set()
+    for item in out:
+        target = item[0] if isinstance(item, tuple) else item
+        ctx = getattr(target, "context_id", None) or getattr(target, "contextId", None)
+        if ctx:
+            seen_ctx.add(str(ctx))
+    assert "ctx-xyz" in seen_ctx
+
+
+def test_unknown_event_name_does_not_raise(adapter):
+    """Forward-compat: a brand-new CUGA event type must not 500 the A2A
+    endpoint. The adapter should drop or coerce it, never propagate."""
+    list(
+        adapter.stream_events_to_a2a(
+            [_Ev("a_brand_new_event_type_we_havent_seen_before", {"x": 1})],
+            task_id="t-1",
+            context_id="c-1",
+        )
+    )
+
+
+def test_empty_stream_emits_at_least_terminal_state(adapter):
+    """An empty stream (graph yielded nothing) should still close the task
+    cleanly so the A2A client doesn't hang."""
+    out = list(adapter.stream_events_to_a2a([], task_id="t-1", context_id="c-1"))
+    states = _states(out)
+    # Either completed or failed is acceptable; what's not acceptable is
+    # an open-ended task with no terminal event.
+    assert any("complet" in s or "fail" in s for s in states)


### PR DESCRIPTION
## Summary

- Adds an opt-in A2A server module (`src/cuga/backend/server/a2a/`) that exposes CUGA over A2A v0.3 (JSON-RPC) — `/.well-known/agent.json`, `/.well-known/agent-card.json`, and a `/a2a` endpoint supporting `message/send` and SSE `message/stream`. Mounted only when `settings.a2a.enabled = true`, so disabled deployments are byte-identical to before.
- Wires the inbound endpoint to a lazily-instantiated `CugaSupervisor` configured via `settings.a2a.supervisor_config_path`. Runner glue (`A2AStreamEvent`, `SupervisorA2ARunner`, `PlaceholderA2ARunner`, `build_a2a_router_for_settings`) lives in `src/cuga/backend/server/a2a/runner.py`; `main.py` is a 5-line opt-in mount.
- Rewrites the **outbound** `delegate_task_via_a2a_sdk` to speak v0.3 JSON-RPC directly via `httpx`. The previous implementation imported names removed in `a2a-sdk` 1.x (`A2AClient`, `MessageSendParams`, `TextPart`, `JSONRPCErrorResponse`, `a2a.utils.message`), making `HAS_A2A_SDK = False` and silently disabling HTTP-A2A delegation in production.
- Handles **both** AgentCard shapes the SDK can return: the v0.3 pydantic model (top-level `.url`) and the v1.0 protobuf model that `A2ACardResolver.get_agent_card()` actually returns (URL lives at `supported_interfaces[i].url` with a `protocol_binding`). Multi-binding peers prefer the JSONRPC interface; non-HTTP fallbacks (e.g. `grpc://`) are skipped so the JSON-RPC sender never POSTs to a scheme it can't speak.
- Maps terminal events named `error`/`failed`/`failure`/`exception` to `TaskState.failed` instead of silently flattening every terminal to `completed`. Outbound delegate now propagates peer Task `status.state=failed` as caller-visible `status="failed"` and raises when the response lacks a recognizable Task envelope (instead of returning empty success).
- SSE generator wraps runner/adapter calls in try/except and emits a final JSON-RPC error frame on failure. Wire-bound error messages no longer leak `str(exc)` — they carry only the exception class name; the full traceback is logged via `logger.exception`.
- Adds a working two-CUGA demo at `docs/examples/a2a_two_cuga/`: provider YAML (digital_sales toolset), consumer YAML (no local tools, one external A2A agent), launch scripts, and a preflight that loads `.env` and works around #322.
- Test coverage: **46 passed, 1 xfailed** (auth-token forwarding, intentionally deferred). New `test_outbound_protocol.py` covers `_extract_text_from_task`, the proto-shape AgentCard URL extraction, JSONRPC-vs-GRPC interface preference, end-to-end roundtrip via `httpx.ASGITransport`, JSON-RPC error envelope handling, peer-Task-failure surfacing, and missing-Task-envelope raising. New `test_a2a_router.py` cases cover SSE error frames and exception-text scrubbing. `test_task_adapter.py` covers error → failed mapping.
- 100% docstring coverage on every changed Python file (was 45.16%, threshold 80%).

## End-to-end verification

Smoke-tested live in this branch on macOS, Azure/gpt-4.1 via `ete-litellm` gateway:

```
# Terminal 1: cuga start registry
# Terminal 2: docs/examples/a2a_two_cuga/run_provider.sh   → :8002
# Terminal 3: docs/examples/a2a_two_cuga/run_consumer.sh   → :7860
# Browser:    http://localhost:7860 → "list my territory accounts"
```

Result: consumer chat UI → consumer supervisor → A2A JSON-RPC → provider on :8002 → digital_sales tools → 50 real territory accounts → final answer back in the chat UI. Provider log shows `POST /a2a → 200`, consumer log shows `Delegating to provider: List my territory accounts...`.

## Commits (7)

1. `4d51fe6` — initial opt-in A2A inbound module with placeholder runner
2. `66ba88c` — real graph runner + outbound v0.3 client + two-CUGA demo
3. `4183c63` — protobuf AgentCard URL extraction (fixes "Agent card carries no URL")
4. `5bdac5f` — CodeQL autofix for URL substring sanitization in a test
5. `7be1dca` — docstrings on every changed function/class + ruff format
6. `7bb1487` — error terminals → `failed`; surface peer failures; harden SSE; scrub exception text
7. `8cd7e9e` — extract runner setup from `main.py` to `a2a/runner.py`; lint nits

## Related

- Issue #322 — saved-config startup wipes `MODEL_NAME` env var when `llm.model` is empty (force_env mode). The demo's `_preflight.py` is a workaround; once #322 lands, the preflight can be deleted.

## Out of scope

- Auth-token forwarding across A2A (`xfail` test stays xfail).
- Per-step streaming through `message/stream` — currently folds the whole supervisor run into one terminal frame.

## Test plan

- [x] `uv run pytest tests/unit/a2a/ tests/integration/a2a/` → 46 passed, 1 xfailed
- [x] `uv run ruff check src/cuga/backend/server/a2a/ src/cuga/backend/server/main.py src/cuga/backend/cuga_graph/nodes/cuga_supervisor/a2a_protocol.py docs/examples/a2a_two_cuga/_preflight.py tests/integration/a2a/ tests/unit/a2a/` → clean
- [x] `uv run ruff format --check` on the same paths → clean
- [x] Live cross-process round-trip with the digital_sales demo on macOS, Azure/gpt-4.1 via `ete-litellm` gateway
- [x] Review feedback addressed: see PR comment summarizing per-thread responses
- [ ] Reviewer: confirm the opt-in mount truly preserves the disabled-deployment surface (no new imports under `settings.a2a.enabled = false`)
- [ ] Reviewer: spot-check the proto-shape `_agent_card_rpc_url` against any internal A2A peers that aren't CUGA-fronted