### PR TITLE
Add WebMCP benchmark variants for CUGA

### DIFF
--- a/src/cuga/backend/activity_tracker/tracker.py
+++ b/src/cuga/backend/activity_tracker/tracker.py
@@ -75,6 +75,9 @@ class ActivityTracker(object):
     final_answer: Optional[str] = None
     task_id: str = "default"
     actions_count: int = 0
+    webmcp_calls: int = 0
+    observe_page_calls: int = 0
+    webmcp_tool_result_visible: bool = False
     token_usage: int = 0
     steps: List[Step] = []
     images: List[str] = []
@@ -375,6 +378,9 @@ class ActivityTracker(object):
         self.steps = []
         self.images = []
         self.actions_count = 0
+        self.webmcp_calls = 0
+        self.observe_page_calls = 0
+        self.webmcp_tool_result_visible = False
         self.final_answer = None
         self.task_id = task_id
         self.intent = intent
@@ -526,6 +532,17 @@ class ActivityTracker(object):
             count (int): The number of times the token is used.
         """
         self.token_usage += count
+
+    def collect_webmcp_feedback(self, feedback_entry: dict[str, Any]) -> None:
+        action = feedback_entry.get("action")
+        if feedback_entry.get("status") == "error":
+            return
+        if action == "webmcp_call":
+            self.webmcp_calls += 1
+            if feedback_entry.get("message"):
+                self.webmcp_tool_result_visible = True
+        elif action == "observe_page":
+            self.observe_page_calls += 1
 
     def collect_image(self, img: str) -> None:
         if not img:
@@ -712,6 +729,9 @@ class ActivityTracker(object):
                     "intent": self.intent,
                     "dataset_name": self.dataset_name,
                     "actions_count": self.actions_count,
+                    "webmcp_calls": self.webmcp_calls,
+                    "observe_page_calls": self.observe_page_calls,
+                    "webmcp_tool_result_visible": self.webmcp_tool_result_visible,
                     "task_id": self.task_id,
                     "eval": self.eval,
                     "steps": [new_step.model_dump()],
@@ -726,6 +746,9 @@ class ActivityTracker(object):
                         "intent": self.intent,
                         "dataset_name": self.dataset_name,
                         "actions_count": self.actions_count,
+                        "webmcp_calls": self.webmcp_calls,
+                        "observe_page_calls": self.observe_page_calls,
+                        "webmcp_tool_result_visible": self.webmcp_tool_result_visible,
                         "task_id": self.task_id,
                         "eval": self.eval,
                         "score": self.score,
@@ -783,6 +806,9 @@ class ActivityTracker(object):
                     "intent": self.intent,
                     "dataset_name": self.dataset_name,
                     "actions_count": self.actions_count,
+                    "webmcp_calls": self.webmcp_calls,
+                    "observe_page_calls": self.observe_page_calls,
+                    "webmcp_tool_result_visible": self.webmcp_tool_result_visible,
                     "task_id": self.task_id,
                     "eval": self.eval,
                     "steps": [d.model_dump() for d in self.steps],

--- a/src/cuga/backend/activity_tracker/tracker.py
+++ b/src/cuga/backend/activity_tracker/tracker.py
@@ -535,7 +535,7 @@ class ActivityTracker(object):
 
     def collect_webmcp_feedback(self, feedback_entry: dict[str, Any]) -> None:
         action = feedback_entry.get("action")
-        if feedback_entry.get("status") == "error":
+        if feedback_entry.get("status") in {"error", "alert"}:
             return
         if action == "webmcp_call":
             self.webmcp_calls += 1

--- a/src/cuga/backend/activity_tracker/tracker.py
+++ b/src/cuga/backend/activity_tracker/tracker.py
@@ -52,6 +52,16 @@ class Step(BaseModel):
     image_before: Optional[str] = ""
 
 
+class VariantTraceStep(BaseModel):
+    prompt_stage: str = "standard"
+    current_url: Optional[str] = ""
+    action_surface: List[str] = Field(default_factory=list)
+    has_full_page_observation: bool = True
+    has_webmcp_catalog: bool = False
+    webmcp_tool_count: int = 0
+    webmcp_tool_names: List[str] = Field(default_factory=list)
+
+
 class TasksMetadata(BaseModel):
     task_ids: List[str]
     description: Optional[str] = ""
@@ -80,6 +90,7 @@ class ActivityTracker(object):
     webmcp_tool_result_visible: bool = False
     token_usage: int = 0
     steps: List[Step] = []
+    variant_steps: List[VariantTraceStep] = []
     images: List[str] = []
     score: float = 0.0
     tools: Dict[str, List[StructuredTool]] = {}
@@ -376,6 +387,7 @@ class ActivityTracker(object):
         self.prompts = []
         self.run_id = ""
         self.steps = []
+        self.variant_steps = []
         self.images = []
         self.actions_count = 0
         self.webmcp_calls = 0
@@ -543,6 +555,13 @@ class ActivityTracker(object):
                 self.webmcp_tool_result_visible = True
         elif action == "observe_page":
             self.observe_page_calls += 1
+
+    def collect_variant_step(self, step: VariantTraceStep | dict[str, Any]) -> None:
+        if not isinstance(step, VariantTraceStep):
+            step = VariantTraceStep(**step)
+        self.variant_steps.append(step)
+        if settings.advanced_features.tracker_enabled:
+            self.to_file()
 
     def collect_image(self, img: str) -> None:
         if not img:
@@ -734,6 +753,7 @@ class ActivityTracker(object):
                     "webmcp_tool_result_visible": self.webmcp_tool_result_visible,
                     "task_id": self.task_id,
                     "eval": self.eval,
+                    "variant_steps": [d.model_dump() for d in self.variant_steps],
                     "steps": [new_step.model_dump()],
                     "score": self.score,
                 }
@@ -751,6 +771,7 @@ class ActivityTracker(object):
                         "webmcp_tool_result_visible": self.webmcp_tool_result_visible,
                         "task_id": self.task_id,
                         "eval": self.eval,
+                        "variant_steps": [d.model_dump() for d in self.variant_steps],
                         "score": self.score,
                     }
                 )
@@ -811,6 +832,7 @@ class ActivityTracker(object):
                     "webmcp_tool_result_visible": self.webmcp_tool_result_visible,
                     "task_id": self.task_id,
                     "eval": self.eval,
+                    "variant_steps": [d.model_dump() for d in self.variant_steps],
                     "steps": [d.model_dump() for d in self.steps],
                     "score": self.score,
                 },

--- a/src/cuga/backend/browser_env/browser/gym_obs/obs_async.py
+++ b/src/cuga/backend/browser_env/browser/gym_obs/obs_async.py
@@ -12,6 +12,7 @@ from typing import Literal
 import numpy as np
 import PIL.Image
 import playwright
+import playwright.async_api
 from browsergym.core.observation import (
     __DATA_REGEXP,
     MarkingError,
@@ -21,6 +22,16 @@ from loguru import logger
 
 EXTRACT_OBS_MAX_TRIES = 5
 BID_ATTR = "bid"
+TRANSIENT_FRAME_ERRORS = (
+    "Frame was detached",
+    "Frame has been detached",
+    "Frame with the given frameId is not found",
+    "Execution context was destroyed",
+)
+
+
+def _is_transient_frame_error(error: Exception) -> bool:
+    return any(msg in str(error) for msg in TRANSIENT_FRAME_ERRORS)
 
 
 async def _pre_extract(
@@ -98,7 +109,7 @@ async def _post_extract(page: playwright.async_api.Page):
 
             await frame.evaluate(js_frame_unmark_elements)
         except playwright.async_api.Error as e:
-            if any(msg in str(e) for msg in ("Frame was detached", "Frame has been detached")):
+            if _is_transient_frame_error(e):
                 pass
             else:
                 raise e

--- a/src/cuga/backend/browser_env/page_understanding/extractor_utils/extract_async.py
+++ b/src/cuga/backend/browser_env/page_understanding/extractor_utils/extract_async.py
@@ -8,6 +8,7 @@ from typing import Literal
 import numpy as np
 import PIL.Image
 import playwright
+import playwright.async_api
 from loguru import logger
 from cuga.backend.utils.consts import BROWSERGYM_ID_ATTRIBUTE as BID_ATTR
 from cuga.backend.utils.consts import BROWSERGYM_SETOFMARKS_ATTRIBUTE as SOM_ATTR
@@ -16,6 +17,12 @@ from cuga.backend.utils.consts import BROWSERGYM_VISIBILITY_ATTRIBUTE as VIS_ATT
 __BID_EXPR = r"([a-zA-Z0-9]+)"
 
 __DATA_REGEXP = re.compile(r"^browsergym_id_" + __BID_EXPR + r"\s?" + r"(.*)")
+TRANSIENT_FRAME_ERRORS = (
+    "Frame was detached",
+    "Frame has been detached",
+    "Frame with the given frameId is not found",
+    "Execution context was destroyed",
+)
 
 
 # Error = playwright._impl._api_types.Error
@@ -24,6 +31,10 @@ __DATA_REGEXP = re.compile(r"^browsergym_id_" + __BID_EXPR + r"\s?" + r"(.*)")
 
 class MarkingError(Exception):
     pass
+
+
+def _is_transient_frame_error(error: Exception) -> bool:
+    return any(msg in str(error) for msg in TRANSIENT_FRAME_ERRORS)
 
 
 async def _pre_extract(
@@ -101,7 +112,7 @@ async def _post_extract(page: playwright.async_api.Page):
 
             await frame.evaluate(js_frame_unmark_elements)
         except playwright.async_api.Error as e:
-            if any(msg in str(e) for msg in ("Frame was detached", "Frame has been detached")):
+            if _is_transient_frame_error(e):
                 pass
             else:
                 raise e

--- a/src/cuga/backend/browser_env/tools/playwright_commands.py
+++ b/src/cuga/backend/browser_env/tools/playwright_commands.py
@@ -219,6 +219,90 @@ async def check_for_alert(page: Page) -> Optional[str]:
     return None
 
 
+async def _is_visible(elem: Any) -> bool:
+    try:
+        return await elem.is_visible(timeout=300)
+    except TypeError:
+        return await elem.is_visible()
+    except Exception:
+        return False
+
+
+async def _resolve_visible_counterpart(page: Page, elem: Any) -> Any:
+    """Use the visible copy when a responsive page duplicates a control."""
+    if await _is_visible(elem):
+        return elem
+
+    try:
+        attrs = await elem.evaluate(
+            """(e) => ({
+                tag: e.tagName ? e.tagName.toLowerCase() : "",
+                id: e.id || "",
+                name: e.getAttribute("name") || "",
+                type: e.getAttribute("type") || "",
+                placeholder: e.getAttribute("placeholder") || "",
+                ariaLabel: e.getAttribute("aria-label") || "",
+                value: e.getAttribute("value") || "",
+                title: e.getAttribute("title") || ""
+            })"""
+        )
+        handle = await page.evaluate_handle(
+            """(attrs) => {
+                const visible = (e) => !!(e.offsetWidth || e.offsetHeight || e.getClientRects().length);
+                const same = (e) => {
+                    if (!visible(e)) return false;
+                    if (attrs.id && e.id !== attrs.id) return false;
+                    if (attrs.name && e.getAttribute("name") !== attrs.name) return false;
+                    if (attrs.type && e.getAttribute("type") !== attrs.type) return false;
+                    if (attrs.placeholder && e.getAttribute("placeholder") !== attrs.placeholder) return false;
+                    if (attrs.ariaLabel && e.getAttribute("aria-label") !== attrs.ariaLabel) return false;
+                    if (attrs.value && e.getAttribute("value") !== attrs.value) return false;
+                    if (attrs.title && e.getAttribute("title") !== attrs.title) return false;
+                    return true;
+                };
+                return Array.from(document.querySelectorAll(attrs.tag || "*")).find(same) || null;
+            }""",
+            attrs,
+        )
+        candidate = handle.as_element()
+        if candidate:
+            logger.info("Using visible counterpart for hidden duplicated control")
+            return candidate
+    except Exception as exc:
+        logger.debug(f"Visible counterpart lookup failed: {exc}")
+
+    return elem
+
+
+async def _should_submit_search_after_type(elem: Any) -> bool:
+    try:
+        return bool(
+            await elem.evaluate(
+                """(e) => {
+                    const form = e.form;
+                    const type = (e.getAttribute("type") || "").toLowerCase();
+                    const name = (e.getAttribute("name") || "").toLowerCase();
+                    const id = (e.id || "").toLowerCase();
+                    const placeholder = (e.getAttribute("placeholder") || "").toLowerCase();
+                    const inputLooksLikeSearch =
+                        e.tagName && e.tagName.toLowerCase() === "input" &&
+                        ["", "text", "search"].includes(type) &&
+                        (["q", "query", "search"].includes(name) ||
+                         ["q", "query", "search"].includes(id) ||
+                         placeholder.includes("search"));
+                    if (!inputLooksLikeSearch || !form) return false;
+                    const action = (form.getAttribute("action") || "").toLowerCase();
+                    const role = (form.getAttribute("role") || "").toLowerCase();
+                    const klass = (form.getAttribute("class") || "").toLowerCase();
+                    return action.includes("/search") || role === "search" || klass.includes("search");
+                }"""
+            )
+        )
+    except Exception as exc:
+        logger.debug(f"Search-form submit detection failed: {exc}")
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Public command implementations
 # ---------------------------------------------------------------------------
@@ -236,6 +320,7 @@ async def click_impl(
     # demo_mode: str = config.get("configurable", {}).get("demo_mode", "off")
 
     elem = await get_elem_by_bid_async(page, bid, True)
+    elem = await _resolve_visible_counterpart(page, elem)
     await add_animation(page, elem, "loading", "CUGA is clicking...")
 
     try:
@@ -260,12 +345,20 @@ async def type_impl(
     demo_mode: str = config.get("configurable", {}).get("demo_mode", "off")
 
     elem = await get_elem_by_bid_async(page, bid, demo_mode != "off")
+    elem = await _resolve_visible_counterpart(page, elem)
     await add_animation(page, elem, "typing", "CUGA is typing...")
 
     try:
         await elem.fill(value, timeout=1000)
-        if press_enter:
+        submit_search = (not press_enter) and await _should_submit_search_after_type(elem)
+        if press_enter or submit_search:
+            if submit_search:
+                logger.info("Auto-submitting search form after typing into search input")
             await page.keyboard.press("Enter")
+            try:
+                await page.wait_for_load_state("domcontentloaded", timeout=3000)
+            except Exception:
+                pass
 
         alert_str = await check_for_alert(page)
         if alert_str:

--- a/src/cuga/backend/browser_env/tools/playwright_commands.py
+++ b/src/cuga/backend/browser_env/tools/playwright_commands.py
@@ -13,7 +13,7 @@ from typing import Any, List, Literal, Optional
 
 from loguru import logger
 from langchain_core.runnables import RunnableConfig
-from playwright.async_api import Page
+from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
 
 from cuga.backend.browser_env.page_understanding.extractor_utils.extract_async import (
     extract_focused_element_bid,
@@ -341,7 +341,7 @@ async def click_impl(
     await add_animation(page, elem, "loading", "CUGA is clicking...")
 
     try:
-        await elem.click(modifiers=modifiers, timeout=5000, force=True)
+        await elem.click(button=button, modifiers=modifiers, timeout=5000, force=True)
         alert_str = await check_for_alert(page)
         if alert_str:
             logger.warning("Returning alert value")
@@ -371,8 +371,8 @@ async def type_impl(
             await page.keyboard.press("Enter")
             try:
                 await page.wait_for_load_state("domcontentloaded", timeout=3000)
-            except Exception as exc:
-                logger.debug(f"Post-Enter domcontentloaded wait did not complete: {exc}")
+            except PlaywrightTimeoutError as exc:
+                logger.debug(f"Post-Enter domcontentloaded wait timed out: {exc}")
 
         alert_str = await check_for_alert(page)
         if alert_str:

--- a/src/cuga/backend/browser_env/tools/playwright_commands.py
+++ b/src/cuga/backend/browser_env/tools/playwright_commands.py
@@ -367,12 +367,12 @@ async def type_impl(
 
     try:
         await elem.fill(value, timeout=1000)
-        if press_enter:
+        if press_enter or await _should_submit_search_after_type(elem):
             await page.keyboard.press("Enter")
             try:
                 await page.wait_for_load_state("domcontentloaded", timeout=3000)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(f"Post-Enter domcontentloaded wait did not complete: {exc}")
 
         alert_str = await check_for_alert(page)
         if alert_str:

--- a/src/cuga/backend/browser_env/tools/playwright_commands.py
+++ b/src/cuga/backend/browser_env/tools/playwright_commands.py
@@ -22,7 +22,7 @@ from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.alert import Alert
 
 # ---------------------------------------------------------------------------
 # Low-level helpers originally defined inside tools.py (copied here for
-# isolation).  No extension/communicator logic – pure Playwright utilities.
+# isolation).  No extension/communicator logic - pure Playwright utilities.
 # ---------------------------------------------------------------------------
 
 
@@ -243,14 +243,29 @@ async def _resolve_visible_counterpart(page: Page, elem: Any) -> Any:
                 placeholder: e.getAttribute("placeholder") || "",
                 ariaLabel: e.getAttribute("aria-label") || "",
                 value: e.getAttribute("value") || "",
-                title: e.getAttribute("title") || ""
+                title: e.getAttribute("title") || "",
+                text: (e.innerText || e.textContent || "").trim(),
+                label: e.labels ? Array.from(e.labels).map((label) => label.innerText || label.textContent || "").join(" ").trim() : ""
             })"""
         )
+        has_stable_match = any(
+            attrs.get(key)
+            for key in ("id", "name", "placeholder", "ariaLabel", "value", "title", "text", "label")
+        )
+        if not has_stable_match:
+            return elem
         handle = await page.evaluate_handle(
             """(attrs) => {
+                const clean = (value) => (value || "").replace(/\\s+/g, " ").trim();
                 const visible = (e) => !!(e.offsetWidth || e.offsetHeight || e.getClientRects().length);
+                const labelText = (e) => e.labels ? Array.from(e.labels).map((label) => label.innerText || label.textContent || "").join(" ") : "";
                 const same = (e) => {
                     if (!visible(e)) return false;
+                    const hasIdentifier = !!(
+                        attrs.id || attrs.name || attrs.placeholder || attrs.ariaLabel ||
+                        attrs.value || attrs.title || attrs.text || attrs.label
+                    );
+                    if (!hasIdentifier) return false;
                     if (attrs.id && e.id !== attrs.id) return false;
                     if (attrs.name && e.getAttribute("name") !== attrs.name) return false;
                     if (attrs.type && e.getAttribute("type") !== attrs.type) return false;
@@ -258,6 +273,8 @@ async def _resolve_visible_counterpart(page: Page, elem: Any) -> Any:
                     if (attrs.ariaLabel && e.getAttribute("aria-label") !== attrs.ariaLabel) return false;
                     if (attrs.value && e.getAttribute("value") !== attrs.value) return false;
                     if (attrs.title && e.getAttribute("title") !== attrs.title) return false;
+                    if (attrs.text && clean(e.innerText || e.textContent) !== clean(attrs.text)) return false;
+                    if (attrs.label && clean(labelText(e)) !== clean(attrs.label)) return false;
                     return true;
                 };
                 return Array.from(document.querySelectorAll(attrs.tag || "*")).find(same) || null;
@@ -350,10 +367,7 @@ async def type_impl(
 
     try:
         await elem.fill(value, timeout=1000)
-        submit_search = (not press_enter) and await _should_submit_search_after_type(elem)
-        if press_enter or submit_search:
-            if submit_search:
-                logger.info("Auto-submitting search form after typing into search input")
+        if press_enter:
             await page.keyboard.press("Enter")
             try:
                 await page.wait_for_load_state("domcontentloaded", timeout=3000)
@@ -380,7 +394,7 @@ async def select_option_impl(
     try:
         await elem.select_option(options, timeout=500)
     except Exception:
-        logger.warning("Exception – select_option failed; trying alternative paths")
+        logger.warning("Exception - select_option failed; trying alternative paths")
         try:
             focused_bid = await extract_focused_element_bid(page)
             if focused_bid:

--- a/src/cuga/backend/cuga_graph/nodes/browser/action.py
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action.py
@@ -131,6 +131,19 @@ class ActionNode(BaseNode):
 
         if not result.tool_calls:
             logger.warning("No tool calls by action agent")
+            state.feedback.append(
+                {
+                    "action": "ActionAgent",
+                    "status": "error",
+                    "message": (
+                        "ActionAgent returned no executable tool call. Retry with exactly one "
+                        "available tool call for the current step."
+                    ),
+                }
+            )
+            state.stm_steps_history.append(
+                "Response of (ActionAgent): no executable tool call was returned."
+            )
             state.sender = name
             state.messages.append(result)
             return state
@@ -147,6 +160,12 @@ class ActionNode(BaseNode):
                     ),
                 )
             )
+
+            if call["name"] == "answer":
+                result.content = f"FINAL ANSWER \n {call['args']}"
+                state.messages.append(result)
+                state.sender = "END"
+                return state
 
             if call["name"] in NO_BID_ACTIONS:
                 if 'human_in_the_loop' in call["name"]:
@@ -191,11 +210,6 @@ class ActionNode(BaseNode):
 
             action_state = call["args"]
 
-            if call["name"] == "answer":
-                result.content = f"FINAL ANSWER \n {action_state}"
-                state.messages.append(result)
-                state.sender = "END"
-                return state
             element_predicted = extract_element_predicted(action_state)
             if not is_valid_element(element_predicted):
                 feedback = {

--- a/src/cuga/backend/cuga_graph/nodes/browser/action.py
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action.py
@@ -113,6 +113,15 @@ def update_call_with_fixed_element(call: Dict[str, Any]) -> Dict[str, Any]:
         return call  # Return the original call if we can't process it
 
 
+def format_answer_tool_args(args: Any) -> str:
+    if isinstance(args, dict):
+        if "text" in args:
+            return str(args["text"])
+        if len(args) == 1:
+            return str(next(iter(args.values())))
+    return str(args)
+
+
 class ActionNode(BaseNode):
     def __init__(self, action_agent: ActionAgent):
         super().__init__()
@@ -162,7 +171,7 @@ class ActionNode(BaseNode):
             )
 
             if call["name"] == "answer":
-                result.content = f"FINAL ANSWER \n {call['args']}"
+                result.content = f"FINAL ANSWER \n {format_answer_tool_args(call['args'])}"
                 state.messages.append(result)
                 state.sender = "END"
                 return state

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/action_agent.py
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/action_agent.py
@@ -5,6 +5,7 @@ from langchain_core.messages import AIMessage, BaseMessage
 from langchain_core.prompts import ChatPromptTemplate
 
 from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import setup_tools
+from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.webmcp import webmcp_advanced_enabled
 from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
 from cuga.backend.cuga_graph.state.agent_state import AgentState
 from cuga.backend.llm.models import LLMManager
@@ -18,9 +19,20 @@ class ActionAgent(BaseAgent):
     def __init__(self, prompt_template: ChatPromptTemplate, llm: BaseChatModel, tools: Any = None):
         super().__init__()
         self.name = "ActionAgent"
-        prompt = prompt_template.partial(tool_names=", ".join([tool.name for key, tool in tools.items()]))
-        tools = tools.values()
-        self.chain = prompt | llm.bind_tools(tools)
+        self.prompt_template = prompt_template
+        self.llm = llm
+        self.chain = self._build_chain(tools)
+        self.tool_stage_chain = None
+        self.page_fallback_chain = None
+        if webmcp_advanced_enabled():
+            self.tool_stage_chain = self._build_chain(setup_tools("tool_stage"))
+            self.page_fallback_chain = self._build_chain(setup_tools("page_fallback"))
+
+    def _build_chain(self, tools: Any):
+        prompt = self.prompt_template.partial(
+            tool_names=", ".join([tool.name for key, tool in tools.items()])
+        )
+        return prompt | self.llm.bind_tools(tools.values())
 
     @staticmethod
     def output_parser(result: BaseMessage, name) -> BaseMessage:
@@ -34,7 +46,15 @@ class ActionAgent(BaseAgent):
         else:
             data["variables_history"] = ""
 
-        return self.chain.invoke(data)
+        chain = self.chain
+        if webmcp_advanced_enabled():
+            prompt_stage = getattr(input_variables, "webmcp_prompt_stage", "standard")
+            if prompt_stage == "tool_stage" and self.tool_stage_chain is not None:
+                chain = self.tool_stage_chain
+            elif prompt_stage == "page_fallback" and self.page_fallback_chain is not None:
+                chain = self.page_fallback_chain
+
+        return chain.invoke(data)
 
     @staticmethod
     def create():

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/system.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/system.jinja2
@@ -41,11 +41,17 @@ To systematically progress towards task completion by selecting the most appropr
   - **click(element_id)**: Click on buttons or links.
   - **go_back(element_id)**: Go back to previous page.
   - **type(element_id, text)**: Input text into fields.
+  - **webmcp_call(tool, params)**: If listed in Available Tools, call a WebMCP tool from the Current WebMCP Tools section using a JSON string for params.
+  - **observe_page()**: In advanced WebMCP mode, request the full page observation when the listed tools are not enough.
+  - **answer(text)**: Provide the final answer when the task is complete.
 - **Provide Exact Arguments**:
   - Ensure tool arguments match the required format.
 - **Examples**:
   - **click('element_id')**
   - **type('element_id', '12/31/2022')**
+  - **webmcp_call('tool_name', '{}')**
+  - **observe_page()**
+  - **answer('final answer')**
   - **open_dropdown('element_id')**
 
 **Adaptability**:

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/system.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/system.jinja2
@@ -41,7 +41,7 @@ To systematically progress towards task completion by selecting the most appropr
   - **click(element_id)**: Click on buttons or links.
   - **go_back(element_id)**: Go back to previous page.
   - **type(element_id, text)**: Input text into fields.
-  - **webmcp_call(tool, params)**: If listed in Available Tools, call a WebMCP tool from the Current WebMCP Tools section using a JSON string for params.
+  - **webmcp_call(tool, params)**: If listed in Available Tools, call a WebMCP tool from the Current WebMCP Tools section using a JSON object for params.
   - **observe_page()**: In advanced WebMCP mode, request the full page observation when the listed tools are not enough.
   - **answer(text)**: Provide the final answer when the task is complete.
 - **Provide Exact Arguments**:
@@ -49,7 +49,7 @@ To systematically progress towards task completion by selecting the most appropr
 - **Examples**:
   - **click('element_id')**
   - **type('element_id', '12/31/2022')**
-  - **webmcp_call('tool_name', '{}')**
+  - **webmcp_call('tool_name', {})**
   - **observe_page()**
   - **answer('final answer')**
   - **open_dropdown('element_id')**

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/user.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/user.jinja2
@@ -16,5 +16,5 @@ Use this variable history in order to get values based on current step.
 {% if webmcp_prompt_stage == "tool_stage" %}
 **Page observation**: withheld for advanced WebMCP tool stage. Use observe_page if you need the accessibility tree or ordinary browser actions.
 {% else %}
-**Elements accessibility tree: {{elements_as_string}}
+**Elements accessibility tree**: {{elements_as_string}}
 {% endif %}

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/user.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/prompts/user.jinja2
@@ -9,4 +9,12 @@ Use this variable history in order to get values based on current step.
 **Current URL**: {{url}}
 **Current step**: {{next_step}}
 **Available Tools**: {{tool_names}}
+{% if webmcp_tools %}
+**Current WebMCP Tools**:
+{{webmcp_tools}}
+{% endif %}
+{% if webmcp_prompt_stage == "tool_stage" %}
+**Page observation**: withheld for advanced WebMCP tool stage. Use observe_page if you need the accessibility tree or ordinary browser actions.
+{% else %}
 **Elements accessibility tree: {{elements_as_string}}
+{% endif %}

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/tools.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from langchain_core.messages import ToolCall
 from langchain_core.runnables import RunnableConfig
@@ -11,6 +11,15 @@ from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.webmcp import (
     webmcp_advanced_enabled,
     webmcp_enabled,
 )
+
+
+def _page_from_config(config: RunnableConfig | None):
+    if not isinstance(config, dict):
+        raise ValueError("webmcp_call requires RunnableConfig with configurable.page")
+    configurable = config.get("configurable")
+    if not isinstance(configurable, dict) or configurable.get("page") is None:
+        raise ValueError("webmcp_call requires RunnableConfig with configurable.page")
+    return configurable["page"]
 
 
 # ----------------------------------------------------------------------------
@@ -31,7 +40,7 @@ def get_params_and_values_except(func, exclude_param, *args, **kwargs):
 
 
 # ----------------------------------------------------------
-# Delegation helper – choose implementation set at import time
+# Delegation helper - choose implementation set at import time
 # ----------------------------------------------------------
 
 
@@ -96,7 +105,7 @@ async def click(
 @tool
 async def select_option(bid: str, options: str | list[str], config: RunnableConfig = None) -> Optional[Alert]:
     """
-    Select one or more options in a dropdown – delegate to implementation.
+    Select one or more options in a dropdown - delegate to implementation.
     """
     _select_option = _retrieve_impl(config, 'select_option')
     return await _select_option(bid=bid, options=options, config=config)
@@ -119,20 +128,22 @@ async def type(bid: str, value: str, press_enter: bool, config: RunnableConfig) 
 
 
 @tool
-async def webmcp_call(tool: str, params: str = "{}", config: RunnableConfig = None) -> str:
+async def webmcp_call(
+    tool: str, params: str | Dict[str, Any] = "{}", config: RunnableConfig = None
+) -> str:
     """
     Call a WebMCP tool exposed by the current page.
 
     Examples:
-        webmcp_call('search_map', '{"query": "London"}')
-        webmcp_call('list_issues', '{"state": "opened"}')
+        webmcp_call('search_map', {'query': 'London'})
+        webmcp_call('list_issues', {'state': 'opened'})
     """
-    page = config["configurable"]["page"]
+    page = _page_from_config(config)
     return await execute_tool(page=page, tool=tool, params=params)
 
 
 @tool
-async def observe_page() -> str:
+def observe_page() -> str:
     """
     Request the full page observation in advanced WebMCP mode.
     """

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/tools.py
@@ -6,6 +6,11 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool, tool
 from cuga.backend.browser_env.tools.providers import BrowserToolImplProvider
 from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.alert import Alert
+from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.webmcp import (
+    execute_tool,
+    webmcp_advanced_enabled,
+    webmcp_enabled,
+)
 
 
 # ----------------------------------------------------------------------------
@@ -113,6 +118,35 @@ async def type(bid: str, value: str, press_enter: bool, config: RunnableConfig) 
     return await _type(bid=bid, value=value, press_enter=press_enter, config=config)
 
 
+@tool
+async def webmcp_call(tool: str, params: str = "{}", config: RunnableConfig = None) -> str:
+    """
+    Call a WebMCP tool exposed by the current page.
+
+    Examples:
+        webmcp_call('search_map', '{"query": "London"}')
+        webmcp_call('list_issues', '{"state": "opened"}')
+    """
+    page = config["configurable"]["page"]
+    return await execute_tool(page=page, tool=tool, params=params)
+
+
+@tool
+async def observe_page() -> str:
+    """
+    Request the full page observation in advanced WebMCP mode.
+    """
+    return "Full page observation requested."
+
+
+@tool
+def answer(text: str) -> str:
+    """
+    Provide the final answer for the task.
+    """
+    return text
+
+
 def format_tools(tools: List[ToolCall]):
     res = []
     for t in tools:
@@ -179,16 +213,31 @@ def scroll(state) -> str:
 # ----------------------------------------------------------------------------
 
 
-def setup_tools() -> Dict[str, BaseTool]:
+def _normal_browser_tools() -> Dict[str, BaseTool]:
+    return {
+        "click": click,
+        "type": type,  # Now refers to the @tool decorated function, not builtin type
+        "go_back": go_back,
+        "select_option": select_option,
+        "answer": answer,
+    }
+
+
+def setup_tools(stage: str = "standard") -> Dict[str, BaseTool]:
     """
     Set up and return all available tools for the action agent.
     This function is placed at the end of the file to ensure all tool functions
     are defined before being referenced, avoiding the name collision with Python's
     built-in 'type' function.
     """
-    return {
-        "click": click,
-        "type": type,  # Now refers to the @tool decorated function, not builtin type
-        "go_back": go_back,
-        "select_option": select_option,
-    }
+    if webmcp_advanced_enabled() and stage == "tool_stage":
+        return {
+            "webmcp_call": webmcp_call,
+            "observe_page": observe_page,
+            "answer": answer,
+        }
+
+    tools = _normal_browser_tools()
+    if webmcp_enabled() and not (webmcp_advanced_enabled() and stage == "page_fallback"):
+        tools["webmcp_call"] = webmcp_call
+    return tools

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/webmcp.py
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/webmcp.py
@@ -61,17 +61,37 @@ async () => {
 
 
 EXECUTE_JS = """
-async ({toolName, paramStr}) => {
+async ({toolName, params, paramsText}) => {
   let api = null;
   if (typeof navigator.modelContextTesting?.executeTool === 'function') api = navigator.modelContextTesting;
   else if (typeof navigator.modelContext?.executeTool === 'function') api = navigator.modelContext;
   else if (typeof document.modelContext?.executeTool === 'function') api = document.modelContext;
   if (!api) return {error: 'WebMCP executeTool is unavailable on this page.'};
+
+  const candidates = [];
+  const addCandidate = (target, args) => {
+    if (target !== undefined && target !== null) candidates.push([target, args]);
+  };
+
   try {
-    return {result: await api.executeTool(toolName, paramStr)};
-  } catch (e) {
-    return {error: (e && e.message) ? e.message : String(e)};
+    const tools = await (api.getTools ? api.getTools() : (api.listTools ? api.listTools() : []));
+    const tool = Array.isArray(tools) ? tools.find((item) => item && item.name === toolName) : null;
+    addCandidate(tool, params);
+    addCandidate(tool, paramsText);
+  } catch (_) {}
+
+  addCandidate(toolName, params);
+  addCandidate(toolName, paramsText);
+
+  let lastError = null;
+  for (const [target, args] of candidates) {
+    try {
+      return {result: await api.executeTool(target, args)};
+    } catch (e) {
+      lastError = e;
+    }
   }
+  return {error: (lastError && lastError.message) ? lastError.message : String(lastError)};
 }
 """
 
@@ -130,9 +150,22 @@ def _flatten_tool_result(value: Any) -> str:
     return "" if result is None else str(result)
 
 
+def _normalize_tool_params(params: str | Dict[str, Any]) -> tuple[Any, str]:
+    if isinstance(params, str):
+        text = params
+        try:
+            return json.loads(params or "{}"), text
+        except json.JSONDecodeError:
+            return {}, text
+    return params or {}, json.dumps(params or {})
+
+
 async def execute_tool(page, tool: str, params: str | Dict[str, Any] = "{}") -> str:
-    param_str = params if isinstance(params, str) else json.dumps(params)
-    raw = await page.evaluate(EXECUTE_JS, {"toolName": tool, "paramStr": param_str})
+    param_value, param_text = _normalize_tool_params(params)
+    raw = await page.evaluate(
+        EXECUTE_JS,
+        {"toolName": tool, "params": param_value, "paramsText": param_text},
+    )
     try:
         await page.wait_for_timeout(500)
     except Exception:
@@ -151,7 +184,7 @@ def format_tools_for_prompt(tools: List[Dict[str, Any]]) -> str:
     lines = [
         "WebMCP tools available on the current page:",
         "Use webmcp_call(tool, params) when one listed tool directly serves the current step.",
-        "Params must be a JSON string matching the input schema.",
+        "Params must be a JSON object matching the input schema.",
         "",
     ]
     for tool in tools:
@@ -171,7 +204,7 @@ def format_tools_for_prompt(tools: List[Dict[str, Any]]) -> str:
                 arg_parts.append(f"{prop_name} ({prop_info.get('type', 'string')}{req})")
             lines.append(f"  args: {', '.join(arg_parts)}")
             example = {prop_name: f"<{prop_name}>" for prop_name in props}
-            lines.append(f"  example: webmcp_call({name!r}, {json.dumps(json.dumps(example))})")
+            lines.append(f"  example: webmcp_call({name!r}, {json.dumps(example)})")
         else:
-            lines.append(f"  example: webmcp_call({name!r}, '{{}}')")
+            lines.append(f"  example: webmcp_call({name!r}, {{}})")
     return "\n".join(lines)

--- a/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/webmcp.py
+++ b/src/cuga/backend/cuga_graph/nodes/browser/action_agent/tools/webmcp.py
@@ -1,0 +1,177 @@
+import json
+import os
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List
+
+from loguru import logger
+
+LAB_FLAG = "enable-web-mcp@1"
+
+
+def webmcp_mode() -> str:
+    mode = os.environ.get("CUGA_WEBMCP_MODE", "none").strip().lower()
+    if mode in {"1", "true", "yes", "on"}:
+        return "naive"
+    if mode in {"none", "off", "0", "false", "no", "naive", "advanced"}:
+        return "none" if mode in {"off", "0", "false", "no"} else mode
+    return "none"
+
+
+def webmcp_enabled() -> bool:
+    return webmcp_mode() in {"naive", "advanced"}
+
+
+def webmcp_advanced_enabled() -> bool:
+    return webmcp_mode() == "advanced"
+
+
+def seed_local_state_for_webmcp(user_data_dir: str | Path) -> None:
+    profile = Path(user_data_dir)
+    profile.mkdir(parents=True, exist_ok=True)
+    local_state = profile / "Local State"
+    state: Dict[str, Any] = {}
+    if local_state.exists():
+        try:
+            state = json.loads(local_state.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning(f"not seeding WebMCP flag: {local_state} is not readable JSON ({exc})")
+            return
+    experiments = state.setdefault("browser", {}).setdefault("enabled_labs_experiments", [])
+    if LAB_FLAG not in experiments:
+        experiments.append(LAB_FLAG)
+    local_state.write_text(json.dumps(state), encoding="utf-8")
+
+
+DISCOVER_JS = """
+async () => {
+  let api = null;
+  if (typeof navigator.modelContextTesting?.listTools === 'function') api = navigator.modelContextTesting;
+  else if (typeof navigator.modelContext?.getTools === 'function') api = navigator.modelContext;
+  else if (typeof document.modelContext?.getTools === 'function') api = document.modelContext;
+  if (!api) return [];
+  try {
+    const tools = await (api.listTools ? api.listTools() : api.getTools());
+    return tools || [];
+  } catch (e) {
+    return [];
+  }
+}
+"""
+
+
+EXECUTE_JS = """
+async ({toolName, paramStr}) => {
+  let api = null;
+  if (typeof navigator.modelContextTesting?.executeTool === 'function') api = navigator.modelContextTesting;
+  else if (typeof navigator.modelContext?.executeTool === 'function') api = navigator.modelContext;
+  else if (typeof document.modelContext?.executeTool === 'function') api = document.modelContext;
+  if (!api) return {error: 'WebMCP executeTool is unavailable on this page.'};
+  try {
+    return {result: await api.executeTool(toolName, paramStr)};
+  } catch (e) {
+    return {error: (e && e.message) ? e.message : String(e)};
+  }
+}
+"""
+
+
+async def discover_tools(page) -> List[Dict[str, Any]]:
+    if not webmcp_enabled():
+        return []
+    last_error = None
+    for _ in range(12):
+        try:
+            tools = await page.evaluate(DISCOVER_JS)
+        except Exception as exc:
+            last_error = exc
+            tools = []
+        if tools:
+            return tools
+        try:
+            await page.wait_for_timeout(250)
+        except Exception:
+            await asyncio.sleep(0.25)
+    if last_error:
+        logger.warning(f"WebMCP tool discovery failed: {last_error}")
+    return []
+
+
+def _parse_schema(schema: Any) -> Dict[str, Any]:
+    if isinstance(schema, str):
+        try:
+            return json.loads(schema)
+        except json.JSONDecodeError:
+            return {}
+    return schema or {}
+
+
+def _flatten_tool_result(value: Any) -> str:
+    result = value
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else value
+        if isinstance(parsed, dict) and isinstance(parsed.get("sections"), list):
+            paths = [
+                item.get("menu_path")
+                for item in parsed["sections"]
+                if isinstance(item, dict) and item.get("menu_path")
+            ]
+            if paths:
+                return "Available menu paths:\n" + "\n".join(f"- {path}" for path in paths)
+        if isinstance(parsed, dict) and isinstance(parsed.get("content"), list):
+            texts = [item.get("text", "") for item in parsed["content"] if isinstance(item, dict)]
+            joined = "\n".join(text for text in texts if text)
+            if joined:
+                result = joined
+        elif isinstance(parsed, (dict, list)):
+            result = json.dumps(parsed, ensure_ascii=False)
+    except Exception:
+        pass
+    return "" if result is None else str(result)
+
+
+async def execute_tool(page, tool: str, params: str | Dict[str, Any] = "{}") -> str:
+    param_str = params if isinstance(params, str) else json.dumps(params)
+    raw = await page.evaluate(EXECUTE_JS, {"toolName": tool, "paramStr": param_str})
+    try:
+        await page.wait_for_timeout(500)
+    except Exception:
+        pass
+    if isinstance(raw, dict) and raw.get("error"):
+        raise RuntimeError(f"webmcp_call({tool!r}) failed: {raw['error']}")
+    value = raw.get("result") if isinstance(raw, dict) else raw
+    result_text = _flatten_tool_result(value)
+    logger.info(f"[webmcp_call result] {tool}: {result_text[:500]}")
+    return result_text
+
+
+def format_tools_for_prompt(tools: List[Dict[str, Any]]) -> str:
+    if not tools:
+        return ""
+    lines = [
+        "WebMCP tools available on the current page:",
+        "Use webmcp_call(tool, params) when one listed tool directly serves the current step.",
+        "Params must be a JSON string matching the input schema.",
+        "",
+    ]
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name", "<unknown>")
+        desc = tool.get("description", "")
+        schema = _parse_schema(tool.get("inputSchema"))
+        props = schema.get("properties") or {}
+        required = set(schema.get("required") or [])
+        lines.append(f"- {name}: {desc}".rstrip())
+        if props:
+            arg_parts = []
+            for prop_name, prop_info in props.items():
+                prop_info = prop_info if isinstance(prop_info, dict) else {}
+                req = " required" if prop_name in required else ""
+                arg_parts.append(f"{prop_name} ({prop_info.get('type', 'string')}{req})")
+            lines.append(f"  args: {', '.join(arg_parts)}")
+            example = {prop_name: f"<{prop_name}>" for prop_name in props}
+            lines.append(f"  example: webmcp_call({name!r}, {json.dumps(json.dumps(example))})")
+        else:
+            lines.append(f"  example: webmcp_call({name!r}, '{{}}')")
+    return "\n".join(lines)

--- a/src/cuga/backend/cuga_graph/nodes/browser/browser_planner_agent/prompts/system.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/browser/browser_planner_agent/prompts/system.jinja2
@@ -2,8 +2,8 @@ Today's date is: {{current_date}}, You are an autonomous Web Planner Agent; your
 
 **Capabilities of Agents**:
 1. Action Agent (ActionAgent):
-   - No complex planning capabilities; can only perform single-step UI actions on the current page.
-   - Available actions: click, type, select option, and go back.
+   - No complex planning capabilities; can only perform single-step UI or WebMCP actions on the current page.
+   - Available actions: click, type, select option, go back, answer, and webmcp_call when Current WebMCP Tools are listed. In advanced WebMCP tool stage, ActionAgent can also use observe_page to request ordinary page observation.
 2. Question Answering Agent (QaAgent):
    - Can answer detailed questions on the current page.
 3. Memorize Agent (MemorizeAgent):
@@ -17,6 +17,7 @@ Today's date is: {{current_date}}, You are an autonomous Web Planner Agent; your
 At each turn, your goal is to decide on the next agent and next instruction to perform based on previous steps
 1. **Action Agent**:
     - Choose to advance in the web application and to perform UI actions.
+    - If Current WebMCP Tools are listed and one directly serves the next step, instruct Action Agent to call it by name with JSON params.
     - To avoid any ambiguity, always provide the full and detailed element name along with the associated actions, such as click, type, or select.
     - Instruct to search or filter before dealing with large tables.
     - Remember to submit forms and apply filters. Unless the user specifies not to.
@@ -27,6 +28,7 @@ At each turn, your goal is to decide on the next agent and next instruction to p
     - Choose when its important to remember values for later use, such as comparison..
 4. **Conclude Task Agent**:
     - Choose when the original task has succeeded or is unable to continue to the original task.
+    - If the current page content or prior tool result already contains the requested answer, choose ConcludeTaskAgent instead of taking extra verification actions.
 
 {% if use_vision -%}
 **Usage of screenshot**:

--- a/src/cuga/backend/cuga_graph/nodes/browser/browser_planner_agent/prompts/user.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/browser/browser_planner_agent/prompts/user.jinja2
@@ -23,10 +23,24 @@ Use this variable history in order to get values based on original task and curr
 
 **Current URL**: {{url}}.
 
+{% if webmcp_tools %}
+**Current WebMCP Tools**:
+"""
+{{webmcp_tools}}
+"""
+{% endif %}
+
+{% if webmcp_prompt_stage == "tool_stage" %}
+**Page observation**:
+"""
+Withheld for advanced WebMCP tool stage. Prefer ActionAgent with webmcp_call when a listed tool directly serves the next step. Ask for observe_page only when the accessibility tree or ordinary browser actions are needed.
+"""
+{% else %}
 **Elements accessibility tree**:
 """
 {{elements_as_string}}
 """
+{% endif %}
 
 **Original task**:
 """

--- a/src/cuga/backend/cuga_graph/nodes/shared/base_agent.py
+++ b/src/cuga/backend/cuga_graph/nodes/shared/base_agent.py
@@ -61,6 +61,13 @@ def _structured_output_missing_parsed_field(exc: BaseException) -> bool:
     )
 
 
+def _structured_output_markdown_json(exc: BaseException) -> bool:
+    if not isinstance(exc, ValidationError):
+        return False
+    msg = str(exc)
+    return "Invalid JSON" in msg and "```" in msg
+
+
 def create_partial(func, **kwargs):
     partial_func = functools.partial(func, **kwargs)
 
@@ -119,10 +126,10 @@ class BaseAgent(ABC):
                 output = await json_schema_chain.ainvoke(inputs)
                 return BaseAgent.validate_and_retry_output(output, schema)
             except Exception as exc:
-                if _structured_output_missing_parsed_field(exc):
+                if _structured_output_missing_parsed_field(exc) or _structured_output_markdown_json(exc):
                     logger.warning(
                         "json_schema structured output not supported by this model endpoint "
-                        "(parsed=None, refusal=None); falling back to json_mode parser"
+                        "(parsed=None, refusal=None, or fenced JSON); falling back to json_mode parser"
                     )
                     output = await json_mode_chain.ainvoke(inputs)
                     return BaseAgent.validate_and_retry_output(output, schema)

--- a/src/cuga/backend/cuga_graph/state/agent_state.py
+++ b/src/cuga/backend/cuga_graph/state/agent_state.py
@@ -986,6 +986,9 @@ class AgentState(BaseModel):
     hitl_response: Optional[ActionResponse] = None
     update_plan_reason: Optional[str] = "First plan to be created"
     read_page: Optional[str] = ""  # The outer text of the page
+    webmcp_tools: Optional[str] = ""
+    webmcp_prompt_stage: Optional[str] = "standard"
+    webmcp_page_observed: bool = False
     env_policy: List[dict] = Field(default_factory=list)
     tool_call: Optional[dict] = None
     cuga_lite_metadata: Optional[Dict[str, Any]] = Field(

--- a/src/cuga/backend/cuga_graph/utils/agent_loop.py
+++ b/src/cuga/backend/cuga_graph/utils/agent_loop.py
@@ -128,6 +128,14 @@ class AgentLoopAnswer(BaseModel):
     flow_generalized: Optional[bool] = False
 
 
+def _extract_final_answer(content: Any) -> str:
+    text = "" if content is None else str(content)
+    marker = "FINAL ANSWER"
+    if marker in text:
+        return text.split(marker, 1)[1].strip()
+    return text.strip()
+
+
 class StreamEvent(BaseModel):
     """
     Model representing a stream event.
@@ -556,6 +564,14 @@ class AgentLoop:
         if "__interrupt__" in event_keys:
             logger.debug("Detected __interrupt__ in event_keys")
             answer = ""
+            if getattr(state, "sender", None) == "END":
+                return AgentLoopAnswer(
+                    end=True,
+                    interrupt=False,
+                    has_tools=False,
+                    answer=_extract_final_answer(msg.content if msg else answer),
+                    tools=[],
+                )
             if msg and msg.tool_calls and len(msg.tool_calls) > 0:
                 return AgentLoopAnswer(
                     end=False, interrupt=True, has_tools=True, answer=msg.content, tools=msg.tool_calls

--- a/src/cuga/backend/cuga_graph/utils/agent_loop.py
+++ b/src/cuga/backend/cuga_graph/utils/agent_loop.py
@@ -556,9 +556,17 @@ class AgentLoop:
         if "__interrupt__" in event_keys:
             logger.debug("Detected __interrupt__ in event_keys")
             answer = ""
-            if msg.tool_calls and len(msg.tool_calls) > 0:
+            if msg and msg.tool_calls and len(msg.tool_calls) > 0:
                 return AgentLoopAnswer(
                     end=False, interrupt=True, has_tools=True, answer=msg.content, tools=msg.tool_calls
+                )
+            if getattr(state, "sender", None) == "ActionAgent":
+                return AgentLoopAnswer(
+                    end=False,
+                    interrupt=True,
+                    has_tools=False,
+                    answer=msg.content if msg else answer,
+                    tools=[],
                 )
             else:
                 return AgentLoopAnswer(end=True, interrupt=True, has_tools=False, answer=answer, tools=[])

--- a/src/cuga/backend/cuga_graph/utils/controller.py
+++ b/src/cuga/backend/cuga_graph/utils/controller.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import re
 
-from cuga.backend.activity_tracker.tracker import ActivityTracker, Step
+from cuga.backend.activity_tracker.tracker import ActivityTracker, Step, VariantTraceStep
 
 import os
 from typing import Any, List, Optional, Literal, AsyncGenerator, Union
@@ -90,6 +90,7 @@ class ExperimentResult(BaseModel):
     observe_page_calls: int = 0
     tool_result_visible: bool = False
     steps: Optional[List[Step]] = []
+    variant_steps: Optional[List[VariantTraceStep]] = []
 
 
 class AgentRunner:
@@ -191,6 +192,37 @@ class AgentRunner:
         # Create description
         state.current_app_description = f"web application for '{title}' and url '{url_app_name}'"
 
+    @staticmethod
+    def _webmcp_tool_names(tools: list[dict[str, Any]]) -> list[str]:
+        names = []
+        for tool in tools:
+            name = tool.get("name") if isinstance(tool, dict) else None
+            if name:
+                names.append(str(name))
+        return names
+
+    @staticmethod
+    def _action_surface_for_stage(stage: str) -> list[str]:
+        return sorted(setup_tools(stage).keys())
+
+    def record_variant_step(self, state: AgentState, tools: list[dict[str, Any]]) -> None:
+        tool_names = self._webmcp_tool_names(tools) if state.webmcp_tools else []
+        tracker.collect_variant_step(
+            VariantTraceStep(
+                prompt_stage=state.webmcp_prompt_stage or "standard",
+                current_url=state.url,
+                action_surface=self._action_surface_for_stage(state.webmcp_prompt_stage or "standard"),
+                has_full_page_observation=not (
+                    webmcp_advanced_enabled()
+                    and state.webmcp_prompt_stage == "tool_stage"
+                    and bool(tool_names)
+                ),
+                has_webmcp_catalog=bool(tool_names),
+                webmcp_tool_count=len(tool_names),
+                webmcp_tool_names=tool_names,
+            )
+        )
+
     async def initialize_appworld_env(self):
         self.env = BrowserEnvGymAsync(
             OpenEndedTaskAsync,
@@ -246,6 +278,7 @@ class AgentRunner:
                 state.webmcp_prompt_stage = "page_fallback"
         else:
             state.webmcp_prompt_stage = "standard"
+        self.record_variant_step(state, tools)
 
     @staticmethod
     def apply_action_feedback(state: AgentState, feedback: List[dict]) -> bool:
@@ -383,6 +416,7 @@ class AgentRunner:
                 observe_page_calls=tracker.observe_page_calls,
                 tool_result_visible=tracker.webmcp_tool_result_visible,
                 steps=tracker.steps,
+                variant_steps=tracker.variant_steps,
             )
         else:
             return ExperimentResult(
@@ -394,6 +428,7 @@ class AgentRunner:
                 observe_page_calls=tracker.observe_page_calls,
                 tool_result_visible=tracker.webmcp_tool_result_visible,
                 steps=tracker.steps,
+                variant_steps=tracker.variant_steps,
             )
 
     async def run_task_generic_yield(
@@ -490,6 +525,8 @@ class AgentRunner:
                             webmcp_calls=tracker.webmcp_calls,
                             observe_page_calls=tracker.observe_page_calls,
                             tool_result_visible=tracker.webmcp_tool_result_visible,
+                            steps=tracker.steps,
+                            variant_steps=tracker.variant_steps,
                         )
                         return  # Exit the entire function
                     elif event.interrupt:
@@ -516,6 +553,8 @@ class AgentRunner:
                 webmcp_calls=tracker.webmcp_calls,
                 observe_page_calls=tracker.observe_page_calls,
                 tool_result_visible=tracker.webmcp_tool_result_visible,
+                steps=tracker.steps,
+                variant_steps=tracker.variant_steps,
             )
 
 

--- a/src/cuga/backend/cuga_graph/utils/controller.py
+++ b/src/cuga/backend/cuga_graph/utils/controller.py
@@ -13,6 +13,13 @@ from cuga.backend.browser_env.browser.gym_obs.http_stream_comm import ChromeExte
 from cuga.backend.browser_env.tools.providers import BrowserToolImplProvider
 from cuga.backend.cuga_graph.graph import DynamicAgentGraph
 from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import setup_tools
+from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.webmcp import (
+    discover_tools,
+    format_tools_for_prompt,
+    seed_local_state_for_webmcp,
+    webmcp_advanced_enabled,
+    webmcp_enabled,
+)
 from cuga.backend.cuga_graph.utils.event_porcessors.action_agent_event_processor import (
     ActionAgentEventProcessor,
 )
@@ -34,6 +41,44 @@ except ImportError:
         LangfuseCallbackHandler = None
 
 tracker = ActivityTracker()
+
+
+def legacy_nocodeui_extension_args() -> list[str]:
+    extension_dir = os.path.join(
+        PACKAGE_ROOT, "backend", "browser_env", "browser", "nocodeui_obs", "prod"
+    )
+    manifest_path = os.path.join(extension_dir, "manifest.json")
+    if not os.path.isfile(manifest_path):
+        logger.warning(
+            "Skipping legacy NoCodeUI Chrome extension because manifest.json was not found at "
+            f"{manifest_path}"
+        )
+        return []
+    return [
+        f"--disable-extensions-except={extension_dir}",
+        f"--load-extension={extension_dir}",
+    ]
+
+
+async def normalize_osm_first_run_state(page) -> None:
+    try:
+        for _ in range(3):
+            await page.evaluate(
+                """() => {
+                    const looksLikeOsmMap =
+                        document.querySelector("#map") ||
+                        document.querySelector(".welcome") ||
+                        document.querySelector('form[action="/search"]');
+                    if (!looksLikeOsmMap) return;
+                    document.cookie = "_osm_welcome=hide; path=/; SameSite=Lax";
+                    for (const el of document.querySelectorAll(".welcome.visible")) {
+                        el.classList.remove("visible");
+                    }
+                }"""
+            )
+            await page.wait_for_timeout(250)
+    except Exception as exc:
+        logger.debug(f"OSM first-run normalization skipped: {exc}")
 
 
 class ExperimentResult(BaseModel):
@@ -83,6 +128,33 @@ class AgentRunner:
     async def initialize_webarena_env(self, task_id):
         from evaluation.tasks.task import GenericWebArenaTask
 
+        user_data_dir = None
+        pw_chromium_kwargs = {}
+        pw_extra_args = [
+            *settings.get("PLAYWRIGHT_ARGS", []),
+            *legacy_nocodeui_extension_args(),
+        ]
+        if webmcp_enabled():
+            logging_dir = os.environ.get("CUGA_LOGGING_DIR") or os.getcwd()
+            user_data_dir = os.path.join(logging_dir, "webmcp-profile")
+            seed_local_state_for_webmcp(user_data_dir)
+            pw_extra_args.extend(
+                [
+                    "--no-first-run",
+                    "--no-default-browser-check",
+                    "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
+                ]
+            )
+            secure_origins = os.environ.get("BROWSERGYM_WEBMCP_SECURE_ORIGINS", "").strip()
+            if secure_origins:
+                pw_extra_args.append(f"--unsafely-treat-insecure-origin-as-secure={secure_origins}")
+            chrome_executable = os.environ.get("BROWSERGYM_CHROME_EXECUTABLE")
+            if not chrome_executable:
+                default_chrome = os.path.join(os.path.expanduser("~"), "Chrome149", "chrome.exe")
+                chrome_executable = default_chrome if os.path.exists(default_chrome) else ""
+            if chrome_executable:
+                pw_chromium_kwargs["executable_path"] = chrome_executable
+
         self.env = BrowserEnvGymAsync(
             GenericWebArenaTask,
             headless=settings.eval_config.headless,
@@ -90,15 +162,14 @@ class AgentRunner:
             enable_playwright_tracing=True,
             feedback=[],
             task_kwargs={"task_id": task_id},
+            user_data_dir=user_data_dir,
             enable_nocodeui_pu=True,
-            pw_extra_args=[
-                *settings.get("PLAYWRIGHT_ARGS", []),
-                f"--disable-extensions-except={os.path.join(PACKAGE_ROOT, './cuga/backend/browser_env/browser/nocodeui_obs/prod')}",
-                f"--load-extension={os.path.join(PACKAGE_ROOT, './cuga/backend/browser_env/browser/nocodeui_obs/prod')}",
-            ],
+            pw_extra_args=pw_extra_args,
+            pw_chromium_kwargs=pw_chromium_kwargs,
         )
 
         self.obs, self.info = await self.env.reset()
+        await normalize_osm_first_run_state(self.env.page)
 
     async def setup_page_info(self, state: AgentState, env):
         """Setup page URL, app name, and description from environment."""
@@ -159,6 +230,35 @@ class AgentRunner:
         state.focused_element_bid = pu_answer.focused_element_bid
         tracker.collect_image(pu_answer.img)
         state.read_page = pu_answer.page_content
+        tools = await discover_tools(self.env.page) if webmcp_enabled() else []
+        if webmcp_enabled() and (not webmcp_advanced_enabled() or not state.webmcp_page_observed):
+            state.webmcp_tools = format_tools_for_prompt(tools)
+        else:
+            state.webmcp_tools = ""
+        if webmcp_advanced_enabled():
+            if tools and not state.webmcp_page_observed:
+                state.webmcp_prompt_stage = "tool_stage"
+            else:
+                state.webmcp_prompt_stage = "page_fallback"
+        else:
+            state.webmcp_prompt_stage = "standard"
+
+    @staticmethod
+    def apply_action_feedback(state: AgentState, feedback: List[dict]) -> bool:
+        observe_page_requested = False
+        for feedback_entry in feedback:
+            if feedback_entry['status'] == "alert":
+                logger.warning(f"Adding to stm the alert {feedback_entry['message']}")
+                state.stm_steps_history.append(
+                    "Response of (ActionAgent): {}".format(feedback_entry['message'])
+                )
+            elif feedback_entry.get("action") in {"webmcp_call", "observe_page"} and feedback_entry.get("message"):
+                state.stm_steps_history.append(
+                    "Response of (ActionAgent): {}".format(feedback_entry["message"])
+                )
+            if feedback_entry.get("action") == "observe_page" and feedback_entry.get("status") != "error":
+                observe_page_requested = True
+        return observe_page_requested
 
     def get_current_state(self) -> AgentState:
         """
@@ -212,6 +312,7 @@ class AgentRunner:
         state.pi = tracker.pi
         agent_response = await self.agent_loop_obj.run(state=state)
         reward = 0.0
+        early_success = False
         i = 0
         while True:
             if agent_response.has_tools:
@@ -221,39 +322,47 @@ class AgentRunner:
                     state.messages[-1].tool_calls,
                     state.elements,
                     self.env.page,
-                    self.env.tool_implementation_provider,
                     session_id=session_id,
                     tool_provider=self.env.tool_implementation_provider,
                 )
                 state.feedback = state.feedback + feedback
-                if len(feedback) > 0 and feedback[-1]['status'] == "alert":
-                    logger.warning(f"Adding to stm the alert {feedback[-1]['message']}")
-                    state.stm_steps_history.append(
-                        "Response of (ActionAgent): {}".format(feedback[-1]['message'])
-                    )
+                observe_page_requested = self.apply_action_feedback(state, feedback)
                 self.env.messages = state.messages
+                if observe_page_requested and webmcp_advanced_enabled():
+                    state.webmcp_page_observed = True
+                    await self.browser_update_state(state)
+                    self.agent_loop_obj.graph.update_state(
+                        {"configurable": {"thread_id": self.thread_id}}, state
+                    )
+                    agent_response = await self.agent_loop_obj.run(state=None)
+                    continue
                 obs, reward, terminated, truncated, info = await self.env.step("")
-                if eval_mode and reward == 1.0 or len(tracker.steps) >= settings.evaluation.max_steps:
+                if eval_mode and reward == 1.0:
+                    early_success = True
                     break
+                if len(tracker.steps) >= settings.evaluation.max_steps:
+                    break
+                state.webmcp_page_observed = False
                 await self.browser_update_state(state)
                 self.agent_loop_obj.graph.update_state({"configurable": {"thread_id": self.thread_id}}, state)
                 agent_response = await self.agent_loop_obj.run(state=None)
+            elif agent_response.interrupt:
+                agent_response = await self.agent_loop_obj.run(state=None)
             elif agent_response.end:
                 tracker.final_answer = agent_response.answer
-                if self.env:
-                    obs, reward, terminated, truncated, info = await self.env.step("")
                 break
             else:
                 raise Exception("Agent stopped but no tools or finish.")
 
         if eval_mode:
-            if self.env.chat:
+            if len(tracker.steps) >= settings.evaluation.max_steps and not tracker.final_answer:
+                tracker.final_answer = "N/A"
+            if self.env.chat and (tracker.final_answer or not early_success):
                 await self.env.chat.add_message(
                     role="assistant",
-                    msg="Final answer: {}".format(tracker.final_answer),
+                    msg=str(tracker.final_answer),
                 )
-            if len(tracker.steps) >= settings.evaluation.max_steps:
-                tracker.final_answer = "N/A"
+                self.env.messages = list(self.env.chat.messages)
                 obs, reward, terminated, truncated, info = await self.env.step("")
             if sites and len(sites) > 1:
                 logger.debug("Sleep on finish if multi site")
@@ -340,15 +449,19 @@ class AgentRunner:
                             session_id=session_id,
                         )
                         state.feedback = state.feedback + feedback
-                        if len(feedback) > 0 and feedback[-1]['status'] == "alert":
-                            logger.warning(f"Adding to stm the alert {feedback[-1]['message']}")
-                            state.stm_steps_history.append(
-                                "Response of (ActionAgent): {}".format(feedback[-1]['message'])
-                            )
+                        observe_page_requested = self.apply_action_feedback(state, feedback)
                         self.env.messages = state.messages
+                        if observe_page_requested and webmcp_advanced_enabled():
+                            state.webmcp_page_observed = True
+                            await self.browser_update_state(state)
+                            self.agent_loop_obj.graph.update_state(
+                                {"configurable": {"thread_id": self.thread_id}}, state
+                            )
+                            break
                         obs, reward, terminated, truncated, info = await self.env.step("")
                         if eval_mode and reward == 1.0 or len(tracker.steps) >= settings.evaluation.max_steps:
                             break  # Break to handle final result outside the loop
+                        state.webmcp_page_observed = False
                         await self.browser_update_state(state)
                         self.agent_loop_obj.graph.update_state(
                             {"configurable": {"thread_id": self.thread_id}}, state

--- a/src/cuga/backend/cuga_graph/utils/controller.py
+++ b/src/cuga/backend/cuga_graph/utils/controller.py
@@ -139,7 +139,8 @@ class AgentRunner:
         ]
         if webmcp_enabled():
             logging_dir = os.environ.get("CUGA_LOGGING_DIR") or os.getcwd()
-            user_data_dir = os.path.join(logging_dir, "webmcp-profile")
+            profile_id = f"{os.getpid()}-{datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')}"
+            user_data_dir = os.path.join(logging_dir, f"webmcp-profile-{profile_id}")
             seed_local_state_for_webmcp(user_data_dir)
             pw_extra_args.extend(
                 [
@@ -491,6 +492,8 @@ class AgentRunner:
                             tool_result_visible=tracker.webmcp_tool_result_visible,
                         )
                         return  # Exit the entire function
+                    elif event.interrupt:
+                        break
                     else:
                         raise Exception("Agent stopped but no tools or finish.")
                 else:

--- a/src/cuga/backend/cuga_graph/utils/controller.py
+++ b/src/cuga/backend/cuga_graph/utils/controller.py
@@ -86,6 +86,9 @@ class ExperimentResult(BaseModel):
     messages: List[AIMessage]
     answer: Optional[str] = ""
     number_of_actions: int = 0
+    webmcp_calls: int = 0
+    observe_page_calls: int = 0
+    tool_result_visible: bool = False
     steps: Optional[List[Step]] = []
 
 
@@ -375,6 +378,9 @@ class AgentRunner:
                 messages=state.messages,
                 answer=tracker.final_answer,
                 number_of_actions=tracker.actions_count,
+                webmcp_calls=tracker.webmcp_calls,
+                observe_page_calls=tracker.observe_page_calls,
+                tool_result_visible=tracker.webmcp_tool_result_visible,
                 steps=tracker.steps,
             )
         else:
@@ -383,6 +389,9 @@ class AgentRunner:
                 messages=state.messages,
                 answer=tracker.final_answer,
                 number_of_actions=tracker.actions_count,
+                webmcp_calls=tracker.webmcp_calls,
+                observe_page_calls=tracker.observe_page_calls,
+                tool_result_visible=tracker.webmcp_tool_result_visible,
                 steps=tracker.steps,
             )
 
@@ -477,6 +486,9 @@ class AgentRunner:
                             messages=state.messages,
                             answer=tracker.final_answer,
                             number_of_actions=tracker.actions_count,
+                            webmcp_calls=tracker.webmcp_calls,
+                            observe_page_calls=tracker.observe_page_calls,
+                            tool_result_visible=tracker.webmcp_tool_result_visible,
                         )
                         return  # Exit the entire function
                     else:
@@ -498,6 +510,9 @@ class AgentRunner:
                 messages=state.messages,
                 answer=tracker.final_answer,
                 number_of_actions=tracker.actions_count,
+                webmcp_calls=tracker.webmcp_calls,
+                observe_page_calls=tracker.observe_page_calls,
+                tool_result_visible=tracker.webmcp_tool_result_visible,
             )
 
 

--- a/src/cuga/backend/cuga_graph/utils/event_porcessors/action_agent_event_processor.py
+++ b/src/cuga/backend/cuga_graph/utils/event_porcessors/action_agent_event_processor.py
@@ -257,6 +257,7 @@ class ActionAgentEventProcessor:
             "message": error_message if message is None else message,
         }
         self.feedback_log.append(feedback_entry)
+        tracker.collect_webmcp_feedback(feedback_entry)
         # langfuse_context.update_current_trace(output= self.feedback_log)
 
         logger.debug(f"Feedback collected for action '{action_name}'")

--- a/src/cuga/backend/cuga_graph/utils/event_porcessors/action_agent_event_processor.py
+++ b/src/cuga/backend/cuga_graph/utils/event_porcessors/action_agent_event_processor.py
@@ -14,6 +14,8 @@ from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import (
     select_option,
     Alert,
     open_app,
+    observe_page,
+    webmcp_call,
 )
 from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import type as typeaction
 
@@ -202,17 +204,27 @@ class ActionAgentEventProcessor:
                     input=tool_def['args'],
                     config=config,
                 )
+            elif action_name == "webmcp_call":
+                res = await webmcp_call.ainvoke(
+                    input=tool_def['args'],
+                    config=config,
+                )
+            elif action_name == "observe_page":
+                res = await observe_page.ainvoke(input=tool_def.get('args') or {}, config=config)
             elif action_name == "update_plan":
                 pass
             else:
                 self.collect_feedback(action_name, element_name, args, "Unrecognized tool action")
                 return
-            await asyncio.sleep(4)
-            tracker.actions_count += 1
+            if action_name != "observe_page":
+                await asyncio.sleep(4)
+                tracker.actions_count += 1
             if isinstance(res, Alert):
                 self.collect_feedback(
                     action_name, element_name, args, error_message=res.message, is_alert=True
                 )
+            elif action_name in {"webmcp_call", "observe_page"}:
+                self.collect_feedback(action_name, element_name, args, error_message="", message=str(res))
             else:
                 self.collect_feedback(action_name, element_name, args, error_message="")
 
@@ -220,7 +232,13 @@ class ActionAgentEventProcessor:
             self.collect_feedback(action_name, element_name, args, str(e))
 
     def collect_feedback(
-        self, action_name: str, element_name: str, args: Any, error_message: str, is_alert=False
+        self,
+        action_name: str,
+        element_name: str,
+        args: Any,
+        error_message: str,
+        is_alert=False,
+        message: str | None = None,
     ):
         """
         Collects feedback for unrecognized or error-prone tool actions.
@@ -234,9 +252,9 @@ class ActionAgentEventProcessor:
             "status": "alert"
             if is_alert
             else ("error" if error_message and len(error_message) > 0 else "success"),
-            "element_id": args['bid'] if 'bid' in args else "",
+            "element_id": args.get('bid', "") if isinstance(args, dict) else "",
             "element_name": element_name,
-            "message": error_message,
+            "message": error_message if message is None else message,
         }
         self.feedback_log.append(feedback_entry)
         # langfuse_context.update_current_trace(output= self.feedback_log)

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -456,7 +456,7 @@ class LLMManager:
     def _get_base_url(self, model_settings: Dict[str, Any], platform: str) -> str:
         """Get base URL: config (JSON) first, then env, then TOML.
 
-        Groq uses its own fixed endpoint — never apply a base URL for it.
+        Groq uses its own fixed endpoint - never apply a base URL for it.
         """
         # Groq SDK manages its own endpoint; any URL in config is ignored
         if platform == "groq":
@@ -907,6 +907,7 @@ def create_llm_from_config(llm_cfg: dict) -> BaseChatModel:
         api_key = None
     platform = llm_cfg.get("provider") or "openai"
     model = llm_cfg.get("model") or None
+    extra_body = llm_cfg.get("extra_body")
     if use_env:
         try:
             code_model = settings.agent.code.model
@@ -925,8 +926,15 @@ def create_llm_from_config(llm_cfg: dict) -> BaseChatModel:
                     platform = toml_platform
                 if toml_model:
                     model = toml_model
+                toml_extra_body = (
+                    code_model.get("extra_body")
+                    if hasattr(code_model, "get")
+                    else getattr(code_model, "extra_body", None)
+                )
+                if extra_body is None:
+                    extra_body = toml_extra_body
                 logger.debug(
-                    "create_llm_from_config: using agent.code from TOML (local mode) — provider=%s model=%s",
+                    "create_llm_from_config: using agent.code from TOML (local mode) - provider=%s model=%s",
                     platform,
                     model,
                 )
@@ -935,7 +943,7 @@ def create_llm_from_config(llm_cfg: dict) -> BaseChatModel:
 
     # For non-local/non-force_env modes (e.g. vault), verify the API key is actually
     # resolvable before attempting to instantiate. Providers like openai require a key
-    # and will raise at construction time if it is missing — which would crash startup.
+    # and will raise at construction time if it is missing - which would crash startup.
     if not use_env and platform in ("openai", "azure", "openrouter"):
         apikey_ref = api_key or llm_cfg.get("apikey_name")
         resolved_key = _normalize_secret(resolve_secret(apikey_ref)) if apikey_ref else None
@@ -962,6 +970,8 @@ def create_llm_from_config(llm_cfg: dict) -> BaseChatModel:
         "max_tokens": max_tokens,
         "streaming": False,
     }
+    if isinstance(extra_body, dict):
+        settings_dict["extra_body"] = extra_body
     wrap = _ModelSettingsWrap(settings_dict)
     model = mgr._create_llm_instance(wrap)
     return mgr._update_model_parameters(

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -631,6 +631,10 @@ class LLMManager:
             if base_url:
                 openai_params["openai_api_base"] = base_url
 
+            extra_body = model_settings.get("extra_body")
+            if isinstance(extra_body, dict):
+                openai_params["extra_body"] = extra_body
+
             ssl_verify = self._get_ssl_verify(model_settings)
             if ssl_verify is not True:
                 openai_params["http_client"] = httpx.Client(verify=ssl_verify)
@@ -786,6 +790,9 @@ class LLMManager:
                 litellm_params["custom_llm_provider"] = "openai"
             if base_url:
                 litellm_params["api_base"] = base_url.rstrip("/")
+            extra_body = model_settings.get("extra_body")
+            if isinstance(extra_body, dict):
+                litellm_params["extra_body"] = extra_body
             auth_headers = self._get_auth_headers(model_settings, "openai")
             if auth_headers and "Authorization" in auth_headers:
                 val = auth_headers["Authorization"]

--- a/src/cuga/backend/tools_env/registry/utils/api_utils.py
+++ b/src/cuga/backend/tools_env/registry/utils/api_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 from typing import List, Optional
@@ -14,6 +15,17 @@ tracker = ActivityTracker()
 
 def _registry_optional_for_benchmark() -> bool:
     return resolved_benchmark() == "webarena"
+
+
+def _is_registry_unavailable_error(error: Exception) -> bool:
+    return isinstance(
+        error,
+        (
+            aiohttp.ClientConnectionError,
+            aiohttp.ServerTimeoutError,
+            asyncio.TimeoutError,
+        ),
+    )
 
 
 def get_agent_id() -> Optional[str]:
@@ -157,7 +169,7 @@ async def get_apps(agent_id: Optional[str] = None) -> List[AppDefinition]:
         if len(external_apps) > 0:
             logger.warning("registry is not running, using external apps")
             return external_apps
-        elif _registry_optional_for_benchmark():
+        elif _registry_optional_for_benchmark() and _is_registry_unavailable_error(e):
             logger.warning("registry is not running in webarena benchmark mode, using no registry apps")
             return []
         else:

--- a/src/cuga/backend/tools_env/registry/utils/api_utils.py
+++ b/src/cuga/backend/tools_env/registry/utils/api_utils.py
@@ -5,11 +5,15 @@ from typing import List, Optional
 import aiohttp
 
 from cuga.backend.tools_env.registry.utils.types import AppDefinition
-from cuga.config import settings
+from cuga.config import resolved_benchmark, settings
 from loguru import logger
 from cuga.backend.activity_tracker.tracker import ActivityTracker
 
 tracker = ActivityTracker()
+
+
+def _registry_optional_for_benchmark() -> bool:
+    return resolved_benchmark() == "webarena"
 
 
 def get_agent_id() -> Optional[str]:
@@ -153,6 +157,9 @@ async def get_apps(agent_id: Optional[str] = None) -> List[AppDefinition]:
         if len(external_apps) > 0:
             logger.warning("registry is not running, using external apps")
             return external_apps
+        elif _registry_optional_for_benchmark():
+            logger.warning("registry is not running in webarena benchmark mode, using no registry apps")
+            return []
         else:
             logger.error("Error while calling registry to get apps")
             raise e

--- a/src/cuga/backend/utils/consts.py
+++ b/src/cuga/backend/utils/consts.py
@@ -24,6 +24,8 @@ ONLY_VALUE_ACTIONS = ['update_plan', 'answer', 'human_in_the_loop', 'send_msg_to
 NO_BID_ACTIONS = [
     'update_plan',
     'answer',
+    'webmcp_call',
+    'observe_page',
     'human_in_the_loop',
     'send_msg_to_user',
     'read_page',

--- a/src/cuga/configurations/instructions/default/answer.md
+++ b/src/cuga/configurations/instructions/default/answer.md
@@ -1,0 +1,1 @@
+When the user asks for a single value, identifier, count, code, date, URL, email, name, or other scalar answer, return only that value. Do not add prose, markdown, labels, quotes, or explanation. For lists, return only the requested items in the requested order and format.

--- a/src/cuga/configurations/models/settings.doubao.toml
+++ b/src/cuga/configurations/models/settings.doubao.toml
@@ -1,0 +1,153 @@
+[agent.task_decomposition.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.planner.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.chat.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.shortlister.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.plan_controller.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.final_answer.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.code.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.code_planner.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.qa.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.action.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 400
+
+[memory.mem0.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 1000
+
+[memory.milvus.step_processing.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 1000
+
+[memory.milvus.fact_extraction.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 1000
+
+[memory.tips_extractor.model]
+platform = "openai"
+model_name = "doubao-seed-2-0-pro-260215"
+url = "https://ark.cn-beijing.volces.com/api/v3"
+api_key = "ARK_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { thinking = { type = "disabled" } }
+temperature = 0.1
+max_tokens = 5000

--- a/src/cuga/configurations/models/settings.qwen.toml
+++ b/src/cuga/configurations/models/settings.qwen.toml
@@ -1,0 +1,153 @@
+[agent.task_decomposition.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.planner.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.chat.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.shortlister.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.plan_controller.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.final_answer.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.code.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.code_planner.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.qa.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 16000
+
+[agent.action.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 1000
+
+[memory.mem0.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 1000
+
+[memory.milvus.step_processing.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 1000
+
+[memory.milvus.fact_extraction.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 1000
+
+[memory.tips_extractor.model]
+platform = "openai"
+model_name = "qwen3.6-flash"
+url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = "QWEN_API_KEY"
+enable_format = true
+enable_vision = true
+extra_body = { enable_thinking = false }
+temperature = 0.1
+max_tokens = 5000

--- a/tests/unit/test_benchmark_infra.py
+++ b/tests/unit/test_benchmark_infra.py
@@ -4,6 +4,10 @@ import pytest
 
 from cuga.backend.browser_env.browser.gym_obs import obs_async
 from cuga.backend.browser_env.page_understanding.extractor_utils import extract_async
+from cuga.backend.activity_tracker.tracker import ActivityTracker
+from cuga.backend.cuga_graph.utils.event_porcessors.action_agent_event_processor import (
+    ActionAgentEventProcessor,
+)
 from cuga.backend.tools_env.registry.utils import api_utils
 
 
@@ -79,3 +83,23 @@ def test_browser_obs_cleanup_treats_navigation_context_as_transient():
 
     assert obs_async._is_transient_frame_error(error)
     assert extract_async._is_transient_frame_error(error)
+
+
+def test_webmcp_feedback_updates_tracker():
+    tracker = ActivityTracker()
+    tracker.reset("unit-test")
+    processor = ActionAgentEventProcessor(page=None, tool_handlers={})
+
+    processor.collect_feedback("webmcp_call", "", {}, error_message="", message="zip code 15213")
+    processor.collect_feedback("observe_page", "", {}, error_message="", message="Full page observation requested.")
+    processor.collect_feedback("webmcp_call", "", {}, error_message="tool failed")
+
+    assert tracker.webmcp_calls == 1
+    assert tracker.observe_page_calls == 1
+    assert tracker.webmcp_tool_result_visible is True
+
+    tracker.reset("unit-test")
+
+    assert tracker.webmcp_calls == 0
+    assert tracker.observe_page_calls == 0
+    assert tracker.webmcp_tool_result_visible is False

--- a/tests/unit/test_benchmark_infra.py
+++ b/tests/unit/test_benchmark_infra.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from cuga.backend.browser_env.browser.gym_obs import obs_async
@@ -13,7 +15,31 @@ class FailingSession:
         return False
 
     def get(self, *_args, **_kwargs):
-        raise RuntimeError("registry unavailable")
+        raise asyncio.TimeoutError("registry unavailable")
+
+
+class BrokenResponse:
+    status = 500
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def text(self):
+        return "registry error"
+
+
+class BrokenResponseSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def get(self, *_args, **_kwargs):
+        return BrokenResponse()
 
 
 @pytest.mark.asyncio
@@ -33,7 +59,18 @@ async def test_get_apps_still_raises_missing_registry_by_default(monkeypatch):
     monkeypatch.setattr(api_utils, "resolved_benchmark", lambda: "default")
     monkeypatch.setattr(api_utils.aiohttp, "ClientSession", FailingSession)
 
-    with pytest.raises(RuntimeError, match="registry unavailable"):
+    with pytest.raises(asyncio.TimeoutError, match="registry unavailable"):
+        await api_utils.get_apps()
+
+
+@pytest.mark.asyncio
+async def test_get_apps_raises_broken_registry_response_for_webarena(monkeypatch):
+    monkeypatch.setattr(api_utils.settings.advanced_features, "registry", True)
+    monkeypatch.setattr(api_utils.tracker, "apps", [])
+    monkeypatch.setattr(api_utils, "resolved_benchmark", lambda: "webarena")
+    monkeypatch.setattr(api_utils.aiohttp, "ClientSession", BrokenResponseSession)
+
+    with pytest.raises(Exception, match="Request failed with status 500"):
         await api_utils.get_apps()
 
 

--- a/tests/unit/test_benchmark_infra.py
+++ b/tests/unit/test_benchmark_infra.py
@@ -93,6 +93,7 @@ def test_webmcp_feedback_updates_tracker():
     processor.collect_feedback("webmcp_call", "", {}, error_message="", message="zip code 15213")
     processor.collect_feedback("observe_page", "", {}, error_message="", message="Full page observation requested.")
     processor.collect_feedback("webmcp_call", "", {}, error_message="tool failed")
+    processor.collect_feedback("webmcp_call", "", {}, error_message="tool alert", is_alert=True)
 
     assert tracker.webmcp_calls == 1
     assert tracker.observe_page_calls == 1

--- a/tests/unit/test_benchmark_infra.py
+++ b/tests/unit/test_benchmark_infra.py
@@ -1,0 +1,44 @@
+import pytest
+
+from cuga.backend.browser_env.browser.gym_obs import obs_async
+from cuga.backend.browser_env.page_understanding.extractor_utils import extract_async
+from cuga.backend.tools_env.registry.utils import api_utils
+
+
+class FailingSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def get(self, *_args, **_kwargs):
+        raise RuntimeError("registry unavailable")
+
+
+@pytest.mark.asyncio
+async def test_get_apps_allows_missing_registry_for_webarena(monkeypatch):
+    monkeypatch.setattr(api_utils.settings.advanced_features, "registry", True)
+    monkeypatch.setattr(api_utils.tracker, "apps", [])
+    monkeypatch.setattr(api_utils, "resolved_benchmark", lambda: "webarena")
+    monkeypatch.setattr(api_utils.aiohttp, "ClientSession", FailingSession)
+
+    assert await api_utils.get_apps() == []
+
+
+@pytest.mark.asyncio
+async def test_get_apps_still_raises_missing_registry_by_default(monkeypatch):
+    monkeypatch.setattr(api_utils.settings.advanced_features, "registry", True)
+    monkeypatch.setattr(api_utils.tracker, "apps", [])
+    monkeypatch.setattr(api_utils, "resolved_benchmark", lambda: "default")
+    monkeypatch.setattr(api_utils.aiohttp, "ClientSession", FailingSession)
+
+    with pytest.raises(RuntimeError, match="registry unavailable"):
+        await api_utils.get_apps()
+
+
+def test_browser_obs_cleanup_treats_navigation_context_as_transient():
+    error = Exception("Execution context was destroyed, most likely because of a navigation")
+
+    assert obs_async._is_transient_frame_error(error)
+    assert extract_async._is_transient_frame_error(error)

--- a/tests/unit/test_playwright_commands.py
+++ b/tests/unit/test_playwright_commands.py
@@ -1,0 +1,100 @@
+import pytest
+
+from cuga.backend.browser_env.tools import playwright_commands
+
+
+class FakeKeyboard:
+    def __init__(self):
+        self.presses = []
+
+    async def press(self, key):
+        self.presses.append(key)
+
+
+class FakePage:
+    def __init__(self):
+        self.keyboard = FakeKeyboard()
+
+    async def wait_for_load_state(self, *_args, **_kwargs):
+        return None
+
+
+class FakeInput:
+    def __init__(self):
+        self.filled = []
+
+    async def fill(self, value, **_kwargs):
+        self.filled.append(value)
+
+
+class HiddenAnonymousElement:
+    async def is_visible(self, **_kwargs):
+        return False
+
+    async def evaluate(self, _script):
+        return {
+            "tag": "button",
+            "id": "",
+            "name": "",
+            "type": "",
+            "placeholder": "",
+            "ariaLabel": "",
+            "value": "",
+            "title": "",
+            "text": "",
+            "label": "",
+        }
+
+
+class CounterpartLookupPage:
+    def __init__(self):
+        self.looked_up = False
+
+    async def evaluate_handle(self, *_args, **_kwargs):
+        self.looked_up = True
+        raise AssertionError("anonymous hidden elements should not pick a visible counterpart")
+
+
+@pytest.mark.asyncio
+async def test_type_impl_respects_press_enter_false(monkeypatch):
+    elem = FakeInput()
+    page = FakePage()
+
+    async def get_elem_by_bid_async(*_args, **_kwargs):
+        return elem
+
+    async def resolve_visible_counterpart(_page, candidate):
+        return candidate
+
+    async def add_animation(*_args, **_kwargs):
+        return None
+
+    async def check_for_alert(_page):
+        return None
+
+    monkeypatch.setattr(playwright_commands, "get_elem_by_bid_async", get_elem_by_bid_async)
+    monkeypatch.setattr(playwright_commands, "_resolve_visible_counterpart", resolve_visible_counterpart)
+    monkeypatch.setattr(playwright_commands, "add_animation", add_animation)
+    monkeypatch.setattr(playwright_commands, "check_for_alert", check_for_alert)
+    monkeypatch.setattr(playwright_commands, "schedule_clear_animations", lambda _page: None)
+
+    await playwright_commands.type_impl(
+        bid="1",
+        value="Carnegie Mellon",
+        press_enter=False,
+        config={"configurable": {"page": page, "demo_mode": "off"}},
+    )
+
+    assert elem.filled == ["Carnegie Mellon"]
+    assert page.keyboard.presses == []
+
+
+@pytest.mark.asyncio
+async def test_visible_counterpart_requires_stable_identifier():
+    page = CounterpartLookupPage()
+    elem = HiddenAnonymousElement()
+
+    result = await playwright_commands._resolve_visible_counterpart(page, elem)
+
+    assert result is elem
+    assert page.looked_up is False

--- a/tests/unit/test_playwright_commands.py
+++ b/tests/unit/test_playwright_commands.py
@@ -27,6 +27,11 @@ class FakeInput:
         self.filled.append(value)
 
 
+class FakeSearchInput(FakeInput):
+    async def evaluate(self, _script):
+        return True
+
+
 class HiddenAnonymousElement:
     async def is_visible(self, **_kwargs):
         return False
@@ -87,6 +92,40 @@ async def test_type_impl_respects_press_enter_false(monkeypatch):
 
     assert elem.filled == ["Carnegie Mellon"]
     assert page.keyboard.presses == []
+
+
+@pytest.mark.asyncio
+async def test_type_impl_submits_search_input(monkeypatch):
+    elem = FakeSearchInput()
+    page = FakePage()
+
+    async def get_elem_by_bid_async(*_args, **_kwargs):
+        return elem
+
+    async def resolve_visible_counterpart(_page, candidate):
+        return candidate
+
+    async def add_animation(*_args, **_kwargs):
+        return None
+
+    async def check_for_alert(_page):
+        return None
+
+    monkeypatch.setattr(playwright_commands, "get_elem_by_bid_async", get_elem_by_bid_async)
+    monkeypatch.setattr(playwright_commands, "_resolve_visible_counterpart", resolve_visible_counterpart)
+    monkeypatch.setattr(playwright_commands, "add_animation", add_animation)
+    monkeypatch.setattr(playwright_commands, "check_for_alert", check_for_alert)
+    monkeypatch.setattr(playwright_commands, "schedule_clear_animations", lambda _page: None)
+
+    await playwright_commands.type_impl(
+        bid="1",
+        value="Carnegie Mellon",
+        press_enter=False,
+        config={"configurable": {"page": page, "demo_mode": "off"}},
+    )
+
+    assert elem.filled == ["Carnegie Mellon"]
+    assert page.keyboard.presses == ["Enter"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_playwright_commands.py
+++ b/tests/unit/test_playwright_commands.py
@@ -32,6 +32,14 @@ class FakeSearchInput(FakeInput):
         return True
 
 
+class FakeClickable:
+    def __init__(self):
+        self.click_kwargs = None
+
+    async def click(self, **kwargs):
+        self.click_kwargs = kwargs
+
+
 class HiddenAnonymousElement:
     async def is_visible(self, **_kwargs):
         return False
@@ -126,6 +134,44 @@ async def test_type_impl_submits_search_input(monkeypatch):
 
     assert elem.filled == ["Carnegie Mellon"]
     assert page.keyboard.presses == ["Enter"]
+
+
+@pytest.mark.asyncio
+async def test_click_impl_passes_requested_button(monkeypatch):
+    elem = FakeClickable()
+    page = FakePage()
+
+    async def get_elem_by_bid_async(*_args, **_kwargs):
+        return elem
+
+    async def resolve_visible_counterpart(_page, candidate):
+        return candidate
+
+    async def add_animation(*_args, **_kwargs):
+        return None
+
+    async def check_for_alert(_page):
+        return None
+
+    monkeypatch.setattr(playwright_commands, "get_elem_by_bid_async", get_elem_by_bid_async)
+    monkeypatch.setattr(playwright_commands, "_resolve_visible_counterpart", resolve_visible_counterpart)
+    monkeypatch.setattr(playwright_commands, "add_animation", add_animation)
+    monkeypatch.setattr(playwright_commands, "check_for_alert", check_for_alert)
+    monkeypatch.setattr(playwright_commands, "schedule_clear_animations", lambda _page: None)
+
+    await playwright_commands.click_impl(
+        bid="1",
+        button="right",
+        modifiers=["Shift"],
+        config={"configurable": {"page": page}},
+    )
+
+    assert elem.click_kwargs == {
+        "button": "right",
+        "modifiers": ["Shift"],
+        "timeout": 5000,
+        "force": True,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_webmcp_variants.py
+++ b/tests/unit/test_webmcp_variants.py
@@ -1,0 +1,98 @@
+import pytest
+
+from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import setup_tools
+from cuga.backend.cuga_graph.state.agent_state import AgentState
+from cuga.backend.cuga_graph.utils import controller as controller_mod
+from cuga.backend.cuga_graph.utils.controller import AgentRunner
+
+
+class FakePage:
+    url = "http://example.test/page"
+
+    async def title(self):
+        return "Example Page"
+
+
+class FakePuAnswer:
+    string_representation = "[1] button Example"
+    focused_element_bid = None
+    img = None
+    page_content = "Example page text"
+
+
+class FakePuProcessor:
+    async def transform(self, transformer_params=None):
+        return FakePuAnswer()
+
+
+class FakeEnv:
+    page = FakePage()
+    pu_processor = FakePuProcessor()
+
+    def get_url(self):
+        return self.page.url
+
+
+async def fake_discover_tools(page):
+    return [
+        {
+            "name": "lookup",
+            "description": "Lookup a value",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        }
+    ]
+
+
+def tool_names(mode: str, stage: str = "standard", monkeypatch=None) -> set[str]:
+    if monkeypatch is not None:
+        monkeypatch.setenv("CUGA_WEBMCP_MODE", mode)
+    return set(setup_tools(stage).keys())
+
+
+def test_tool_surface_by_webmcp_mode(monkeypatch):
+    assert "webmcp_call" not in tool_names("none", monkeypatch=monkeypatch)
+
+    naive_tools = tool_names("naive", monkeypatch=monkeypatch)
+    assert "webmcp_call" in naive_tools
+    assert {"click", "type", "answer"}.issubset(naive_tools)
+
+    monkeypatch.setenv("CUGA_WEBMCP_MODE", "advanced")
+    assert tool_names("advanced", "tool_stage") == {"answer", "observe_page", "webmcp_call"}
+    assert "webmcp_call" not in tool_names("advanced", "page_fallback")
+    assert {"click", "type", "answer"}.issubset(tool_names("advanced", "page_fallback"))
+
+
+@pytest.mark.asyncio
+async def test_browser_update_state_sets_webmcp_variant_stages(monkeypatch):
+    monkeypatch.setattr(controller_mod, "discover_tools", fake_discover_tools)
+    runner = AgentRunner()
+    runner.env = FakeEnv()
+
+    monkeypatch.setenv("CUGA_WEBMCP_MODE", "none")
+    state = AgentState(input="goal", url="")
+    await runner.browser_update_state(state)
+    assert state.webmcp_prompt_stage == "standard"
+    assert state.webmcp_tools == ""
+
+    monkeypatch.setenv("CUGA_WEBMCP_MODE", "naive")
+    state = AgentState(input="goal", url="")
+    await runner.browser_update_state(state)
+    assert state.webmcp_prompt_stage == "standard"
+    assert "lookup" in state.webmcp_tools
+    assert state.elements_as_string == "[1] button Example"
+
+    monkeypatch.setenv("CUGA_WEBMCP_MODE", "advanced")
+    state = AgentState(input="goal", url="")
+    await runner.browser_update_state(state)
+    assert state.webmcp_prompt_stage == "tool_stage"
+    assert "lookup" in state.webmcp_tools
+
+    state.webmcp_page_observed = True
+    await runner.browser_update_state(state)
+    assert state.webmcp_prompt_stage == "page_fallback"
+    assert state.webmcp_tools == ""
+    assert state.elements_as_string == "[1] button Example"

--- a/tests/unit/test_webmcp_variants.py
+++ b/tests/unit/test_webmcp_variants.py
@@ -112,10 +112,10 @@ def test_tool_surface_by_webmcp_mode(monkeypatch):
 
 
 def test_webmcp_call_requires_page_config():
-    with pytest.raises(ValueError, match="configurable.page"):
+    with pytest.raises(ValueError, match=r"configurable\.page"):
         _page_from_config(None)
 
-    with pytest.raises(ValueError, match="configurable.page"):
+    with pytest.raises(ValueError, match=r"configurable\.page"):
         _page_from_config({"configurable": {}})
 
     page = object()

--- a/tests/unit/test_webmcp_variants.py
+++ b/tests/unit/test_webmcp_variants.py
@@ -1,5 +1,7 @@
 import pytest
+from langchain_core.messages import AIMessage
 
+from cuga.backend.cuga_graph.nodes.browser.action import ActionNode
 from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import setup_tools
 from cuga.backend.cuga_graph.state.agent_state import AgentState
 from cuga.backend.cuga_graph.utils import controller as controller_mod
@@ -33,6 +35,14 @@ class FakeEnv:
         return self.page.url
 
 
+class FakeAnswerAgent:
+    def run(self, _state):
+        return AIMessage(
+            content="",
+            tool_calls=[{"name": "answer", "args": {"text": "15213"}, "id": "answer-1"}],
+        )
+
+
 async def fake_discover_tools(page):
     return [
         {
@@ -64,6 +74,15 @@ def test_tool_surface_by_webmcp_mode(monkeypatch):
     assert tool_names("advanced", "tool_stage") == {"answer", "observe_page", "webmcp_call"}
     assert "webmcp_call" not in tool_names("advanced", "page_fallback")
     assert {"click", "type", "answer"}.issubset(tool_names("advanced", "page_fallback"))
+
+
+def test_answer_tool_uses_scalar_text_arg():
+    state = AgentState(input="goal", url="")
+
+    result = ActionNode.node_handler(state, agent=FakeAnswerAgent(), name="ActionAgent")
+
+    assert result.sender == "END"
+    assert result.messages[-1].content == "FINAL ANSWER \n 15213"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_webmcp_variants.py
+++ b/tests/unit/test_webmcp_variants.py
@@ -199,6 +199,7 @@ async def test_execute_tool_passes_object_params_to_page():
 @pytest.mark.asyncio
 async def test_browser_update_state_sets_webmcp_variant_stages(monkeypatch):
     monkeypatch.setattr(controller_mod, "discover_tools", fake_discover_tools)
+    controller_mod.tracker.reset("unit-test")
     runner = AgentRunner()
     runner.env = FakeEnv()
 
@@ -207,6 +208,12 @@ async def test_browser_update_state_sets_webmcp_variant_stages(monkeypatch):
     await runner.browser_update_state(state)
     assert state.webmcp_prompt_stage == "standard"
     assert state.webmcp_tools == ""
+    no_trace = controller_mod.tracker.variant_steps[-1]
+    assert no_trace.prompt_stage == "standard"
+    assert no_trace.has_full_page_observation is True
+    assert no_trace.has_webmcp_catalog is False
+    assert no_trace.webmcp_tool_count == 0
+    assert "webmcp_call" not in no_trace.action_surface
 
     monkeypatch.setenv("CUGA_WEBMCP_MODE", "naive")
     state = AgentState(input="goal", url="")
@@ -214,15 +221,33 @@ async def test_browser_update_state_sets_webmcp_variant_stages(monkeypatch):
     assert state.webmcp_prompt_stage == "standard"
     assert "lookup" in state.webmcp_tools
     assert state.elements_as_string == "[1] button Example"
+    naive_trace = controller_mod.tracker.variant_steps[-1]
+    assert naive_trace.prompt_stage == "standard"
+    assert naive_trace.has_full_page_observation is True
+    assert naive_trace.has_webmcp_catalog is True
+    assert naive_trace.webmcp_tool_names == ["lookup"]
+    assert "webmcp_call" in naive_trace.action_surface
 
     monkeypatch.setenv("CUGA_WEBMCP_MODE", "advanced")
     state = AgentState(input="goal", url="")
     await runner.browser_update_state(state)
     assert state.webmcp_prompt_stage == "tool_stage"
     assert "lookup" in state.webmcp_tools
+    tool_trace = controller_mod.tracker.variant_steps[-1]
+    assert tool_trace.prompt_stage == "tool_stage"
+    assert tool_trace.has_full_page_observation is False
+    assert tool_trace.has_webmcp_catalog is True
+    assert tool_trace.webmcp_tool_names == ["lookup"]
+    assert tool_trace.action_surface == ["answer", "observe_page", "webmcp_call"]
 
     state.webmcp_page_observed = True
     await runner.browser_update_state(state)
     assert state.webmcp_prompt_stage == "page_fallback"
     assert state.webmcp_tools == ""
     assert state.elements_as_string == "[1] button Example"
+    fallback_trace = controller_mod.tracker.variant_steps[-1]
+    assert fallback_trace.prompt_stage == "page_fallback"
+    assert fallback_trace.has_full_page_observation is True
+    assert fallback_trace.has_webmcp_catalog is False
+    assert fallback_trace.webmcp_tool_count == 0
+    assert "webmcp_call" not in fallback_trace.action_surface

--- a/tests/unit/test_webmcp_variants.py
+++ b/tests/unit/test_webmcp_variants.py
@@ -2,10 +2,20 @@ import pytest
 from langchain_core.messages import AIMessage
 
 from cuga.backend.cuga_graph.nodes.browser.action import ActionNode
-from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import setup_tools
+from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.webmcp import (
+    _normalize_tool_params,
+    execute_tool,
+    format_tools_for_prompt,
+)
+from cuga.backend.cuga_graph.nodes.browser.action_agent.tools.tools import (
+    _page_from_config,
+    setup_tools,
+)
 from cuga.backend.cuga_graph.state.agent_state import AgentState
+from cuga.backend.cuga_graph.utils.agent_loop import AgentLoop
 from cuga.backend.cuga_graph.utils import controller as controller_mod
 from cuga.backend.cuga_graph.utils.controller import AgentRunner
+from cuga.backend.activity_tracker.tracker import ActivityTracker
 
 
 class FakePage:
@@ -43,6 +53,31 @@ class FakeAnswerAgent:
         )
 
 
+class FakeGraphState:
+    def __init__(self, state):
+        self.values = state.model_dump()
+
+
+class FakeGraph:
+    def __init__(self, state):
+        self.state = state
+
+    def get_state(self, _config):
+        return FakeGraphState(self.state)
+
+
+class FakeExecutePage:
+    def __init__(self):
+        self.payload = None
+
+    async def evaluate(self, _script, payload):
+        self.payload = payload
+        return {"result": {"content": [{"text": payload["params"]["query"]}]}}
+
+    async def wait_for_timeout(self, _timeout):
+        return None
+
+
 async def fake_discover_tools(page):
     return [
         {
@@ -76,6 +111,25 @@ def test_tool_surface_by_webmcp_mode(monkeypatch):
     assert {"click", "type", "answer"}.issubset(tool_names("advanced", "page_fallback"))
 
 
+def test_webmcp_call_requires_page_config():
+    with pytest.raises(ValueError, match="configurable.page"):
+        _page_from_config(None)
+
+    with pytest.raises(ValueError, match="configurable.page"):
+        _page_from_config({"configurable": {}})
+
+    page = object()
+    assert _page_from_config({"configurable": {"page": page}}) is page
+
+
+def test_webmcp_prompt_uses_object_params_example():
+    prompt = format_tools_for_prompt(awaitable_tools := awaitable_lookup_tools())
+
+    assert awaitable_tools[0]["name"] in prompt
+    assert 'webmcp_call(\'lookup\', {"query": "<query>"})' in prompt
+    assert "Params must be a JSON object" in prompt
+
+
 def test_answer_tool_uses_scalar_text_arg():
     state = AgentState(input="goal", url="")
 
@@ -83,6 +137,63 @@ def test_answer_tool_uses_scalar_text_arg():
 
     assert result.sender == "END"
     assert result.messages[-1].content == "FINAL ANSWER \n 15213"
+
+
+def test_agent_loop_ends_on_answer_tool_interrupt():
+    state = AgentState(input="goal", url="")
+    state.sender = "END"
+    state.messages = [
+        AIMessage(
+            content="FINAL ANSWER \n 15213",
+            tool_calls=[{"name": "answer", "args": {"text": "15213"}, "id": "answer-1"}],
+        )
+    ]
+    loop = AgentLoop(
+        thread_id="unit",
+        langfuse_handler=None,
+        graph=FakeGraph(state),
+        tracker=ActivityTracker(),
+    )
+
+    result = loop.get_output({"__interrupt__": []})
+
+    assert result.end is True
+    assert result.has_tools is False
+    assert result.answer == "15213"
+
+
+def awaitable_lookup_tools():
+    return [
+        {
+            "name": "lookup",
+            "description": "Lookup a value",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        }
+    ]
+
+
+def test_normalize_webmcp_params_supports_object_and_string():
+    assert _normalize_tool_params({"query": "cmu"}) == ({"query": "cmu"}, '{"query": "cmu"}')
+    assert _normalize_tool_params('{"query":"cmu"}') == ({"query": "cmu"}, '{"query":"cmu"}')
+    assert _normalize_tool_params("not json") == ({}, "not json")
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_passes_object_params_to_page():
+    page = FakeExecutePage()
+
+    result = await execute_tool(page, "lookup", '{"query":"cmu"}')
+
+    assert result == "cmu"
+    assert page.payload == {
+        "toolName": "lookup",
+        "params": {"query": "cmu"},
+        "paramsText": '{"query":"cmu"}',
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Standardizes CUGA's no, naive, and advanced WebMCP benchmark paths so smoke artifacts can be checked against the shared agent-variant contract. Validated with targeted unit coverage for the variant surface, benchmark infra, and browser command fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebMCP integration: tool discovery/execution, staged prompts, page observation, and a final-answer tool; agent flows adapt to WebMCP stages
  * Activity/experiment outputs now record WebMCP counters and visibility; per-step trace captures page/tool context

* **Improvements**
  * More robust Playwright interactions (visible-counterpart resolution, Enter-submit behavior) and expanded transient-frame error handling
  * Structured-output fallback improved for markdown-embedded JSON

* **Tests**
  * New unit tests for WebMCP flows, Playwright commands, registry fallback, and tracker metrics

* **Documentation**
  * Default answer guidance tightened for scalar-only responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->