### PR TITLE
fix(evaluation): skip Langfuse retry loop when credentials missing

### DIFF
--- a/src/cuga/evaluation/langfuse/get_langfuse_data.py
+++ b/src/cuga/evaluation/langfuse/get_langfuse_data.py
@@ -42,6 +42,13 @@ class LangfuseTraceHandler:
         if not self.trace_id:
             print("No Langfuse trace ID, cannot get data")
             return None
+        # Skip the retry loop if credentials weren't provided at construction
+        # time. Without this guard, httpx fails to build a Basic auth header
+        # from (None, None) and the per-trace retry sleep loop wastes ~150s
+        # per task (2 + 3 + 4.5 + ... over 10 attempts). The warning was
+        # already printed once in __init__. See issue #318.
+        if not self.config.langfuse_public_key or not self.config.langfuse_secret_key:
+            return None
         print(f"Fetching Langfuse data for trace {self.trace_id}...")
         langfuse_data = await self.extract_langfuse_data(
             self.config,


### PR DESCRIPTION
## Bug fix

Fixes #318.
Fixes also [duplicate](https://github.com/cuga-project/cuga-eval/issues/15) in `cuga-eval` repository

### Summary

`LangfuseTraceHandler.__init__` prints a warning when `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` are absent but proceeds to construct a `Config(None, None, host)` anyway. `get_langfuse_data()` then called `extract_langfuse_data()` unconditionally, where `httpx` failed to build a Basic auth header from `None` credentials and the 10-attempt exponential backoff (2.0 + 3.0 + 4.5 + 6.8 + 10.1 + 15.2 + 22.8 + 34.2 + 51.3 ≈ ~150 s) fired **per task**.

For a 40-task AppWorld eval that's ~100 minutes of dead time at the end of tasks while the harness ground against a non-existent endpoint, manifesting as the reported per-task slowdown.

**Fix:** at the top of [`get_langfuse_data`](src/cuga/evaluation/langfuse/get_langfuse_data.py#L46-L55), early-return `None` when either credential is missing on `self.config`. The init-time warning already surfaces the misconfiguration to the user once per process, so the failure mode stays visible — only the retry storm dies.

```python
async def get_langfuse_data(self) -> LangfuseMetrics:
    if not self.trace_id:
        print("No Langfuse trace ID, cannot get data")
        return None
    # Skip the retry loop if credentials weren't provided at construction
    # time. Without this guard, httpx fails to build a Basic auth header
    # from (None, None) and the per-trace retry sleep loop wastes ~150s
    # per task (2 + 3 + 4.5 + ... over 10 attempts). The warning was
    # already printed once in __init__. See issue #318.
    if not self.config.langfuse_public_key or not self.config.langfuse_secret_key:
        return None
    print(f"Fetching Langfuse data for trace {self.trace_id}...")
    ...
```

### Scope

- Fixes the per-task ~150 s wait → ~0 s no-op when Langfuse keys are absent.
- **No behavior change when credentials are present.** Normal cloud-on and self-hosted paths are unaffected — both `trace_id` validation and the credential check are no-ops in the happy path.
- The init-time warning at [`__init__`](src/cuga/evaluation/langfuse/get_langfuse_data.py#L37-L38) is preserved (so misconfigured environments still produce a clear log line, just once instead of in a backoff loop).
- A similar pattern exists in [`src/system_tests/profiling/bin/profile_digital_sales_tasks.py`](src/system_tests/profiling/bin/profile_digital_sales_tasks.py) and would benefit from the same guard — out of scope for this PR, mentioned in #318 for follow-up.

### Testing
- [x] Verified fix locally; tests pass

Without the guard, running an AppWorld eval with `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` commented out reproduces the original symptom:

```
Error: Langfuse host or secret key not set, make sure to add them in your .env file
  Error fetching data (attempt 1/10): sequence item 0: expected a bytes-like object, NoneType found, retrying in 2.0s...
  ...
  Error fetching data (attempt 9/10): ... retrying in 51.3s...
  Warning: Could not fetch Langfuse data for trace <id> after 10 attempts
```

With the guard applied, the same configuration produces a single init-time warning and zero retries — eval finishes at expected wall-clock time.

`uv run ruff format --check` and `uv run ruff check` both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where missing API credentials would cause failed HTTP requests; the system now validates credentials early and provides clear feedback when they are not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->