### PR TITLE
docs: document CodeRabbit PR complexity labels

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
   auto_apply_labels: true
 
   labeling_instructions:
-    - label: complexity: low
+    - label: "complexity: low"
       instructions: |
         Apply exactly one complexity label per PR. Judge by scope and conceptual risk, not diff size.
         Use complexity: low when the change is narrow, well-bounded, and easy to reason about:
@@ -20,7 +20,7 @@ reviews:
         - A large diff can still be low complexity if it is mechanical (formatting, renames, generated
           output, bulk docs) and does not alter runtime behavior or review risk
 
-    - label: complexity: medium
+    - label: "complexity: medium"
       instructions: |
         Apply exactly one complexity label per PR. Judge by scope and conceptual risk, not diff size.
         Use complexity: medium when the change spans multiple concerns or needs careful validation:
@@ -31,7 +31,7 @@ reviews:
         - Requires checking edge cases, test coverage, and interactions between changed parts
         - A small diff can still be medium complexity if the behavioral surface area is non-obvious
 
-    - label: complexity: high
+    - label: "complexity: high"
       instructions: |
         Apply exactly one complexity label per PR. Judge by scope and conceptual risk, not diff size.
         Use complexity: high when the change is broad, risky, or hard to validate:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,10 @@ Why this matters:
 
 ## Pull Request Guidelines
 
+### PR complexity labels
+
+CodeRabbit automatically applies one `complexity: low`, `complexity: medium`, or `complexity: high` label to each PR based on **scope and conceptual risk**, not diff size. See [`.coderabbit.yaml`](.coderabbit.yaml) for the rubric.
+
 - Keep diffs small; avoid drive-by refactors. Separate formatting-only PRs from feature/fix PRs.
 - Include a brief summary of what/why, and link related issues (e.g., `Refs: #123`).
 - Add/update tests when changing behavior.


### PR DESCRIPTION
## Summary
- Adds a short note to `CONTRIBUTING.md` explaining the automated `complexity: low/medium/high` PR labels
- **Test PR** for validating CodeRabbit auto-labeling from `.coderabbit.yaml`

## Test plan
- [ ] CodeRabbit reviews the PR and applies `complexity: low`
- [ ] Label appears on the PR automatically (`auto_apply_labels: true`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines with new guidance on automatic PR complexity labels and where to find the repo’s labeling rubric configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->