### PR TITLE
fix: quote complexity labels in coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
   auto_apply_labels: true
 
   labeling_instructions:
-    - label: complexity: low
+    - label: "complexity: low"
       instructions: |
         Apply exactly one complexity label per PR. Judge by scope and conceptual risk, not diff size.
         Use complexity: low when the change is narrow, well-bounded, and easy to reason about:
@@ -20,7 +20,7 @@ reviews:
         - A large diff can still be low complexity if it is mechanical (formatting, renames, generated
           output, bulk docs) and does not alter runtime behavior or review risk
 
-    - label: complexity: medium
+    - label: "complexity: medium"
       instructions: |
         Apply exactly one complexity label per PR. Judge by scope and conceptual risk, not diff size.
         Use complexity: medium when the change spans multiple concerns or needs careful validation:
@@ -31,7 +31,7 @@ reviews:
         - Requires checking edge cases, test coverage, and interactions between changed parts
         - A small diff can still be medium complexity if the behavioral surface area is non-obvious
 
-    - label: complexity: high
+    - label: "complexity: high"
       instructions: |
         Apply exactly one complexity label per PR. Judge by scope and conceptual risk, not diff size.
         Use complexity: high when the change is broad, risky, or hard to validate:


### PR DESCRIPTION
## Summary
- Fixes YAML parse error in `.coderabbit.yaml` caused by unquoted colons in label names (`complexity: low`, etc.)
- CodeRabbit was falling back to default settings because the config could not be parsed

## Test plan
- [ ] Merge this PR
- [ ] Re-run CodeRabbit on #332 — `@coderabbitai configuration` should show no parsing errors
- [ ] Confirm `complexity: low` label is auto-applied on the test PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->