### PR TITLE
fix(supervisor): expose A2A subagent endpoint in /api/config/subagents

### DIFF
--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -2960,9 +2960,12 @@ async def get_subagents_config(current_user: Optional[UserInfo] = Depends(requir
             source_config = {"type": "direct"}
 
             if agent_config.get('a2a_protocol', {}).get('enabled'):
+                a2a_protocol = agent_config.get('a2a_protocol', {})
                 source_config = {
                     "type": "a2a",
-                    "url": agent_config.get('a2a_protocol', {}).get('url', ''),
+                    # Supervisor YAML uses `endpoint` (matching delegation.py); fall
+                    # back to `url` for any older configs that used that key.
+                    "url": a2a_protocol.get('endpoint') or a2a_protocol.get('url', ''),
                     "name": agent_name,
                 }
             elif mcp_servers:


### PR DESCRIPTION
## Bug fix

Fixes #338

### Summary

The `GET /api/config/subagents` route handler read `a2a_protocol.url` from each agent's supervisor config, but the supervisor YAML schema (and `cuga_graph/nodes/cuga_supervisor/delegation.py`) uses `a2a_protocol.endpoint`. As a result, the API returned an empty `source.url` for every A2A sub-agent — even when the endpoint was set and delegation worked correctly.

This patches the handler to read `endpoint` first and fall back to `url` for backwards compatibility with any older configs.

### Testing
- [x] Verified fix locally; tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved A2A sub-agent source configuration handling to support both new and legacy configuration formats, ensuring backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->