### PR TITLE
fix: fall back to base_tools in ChatAgent.execute_tool when tools is None

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/chat/chat_agent/chat_agent.py
+++ b/src/cuga/backend/cuga_graph/nodes/chat/chat_agent/chat_agent.py
@@ -334,7 +334,7 @@ class ChatAgent(BaseAgent):
         tool_name = tool_call.get("name")
         tool_args = tool_call.get("args", {})
 
-        for tool_i in self.tools:
+        for tool_i in self.tools or self.base_tools or []:
             if tool_i.name == tool_name:
                 try:
                     return await tool_i.ainvoke(tool_args)
@@ -345,7 +345,7 @@ class ChatAgent(BaseAgent):
                         logger.info("Attempting to reconnect due to closed resource error...")
                         await self.setup()
                         # Retry the tool execution with fresh session
-                        for fresh_tool in self.tools:
+                        for fresh_tool in self.tools or self.base_tools or []:
                             if fresh_tool.name == tool_name:
                                 return await fresh_tool.ainvoke(tool_args)
                     raise e

--- a/tests/unit/test_chat_agent_knowledge_toggle.py
+++ b/tests/unit/test_chat_agent_knowledge_toggle.py
@@ -45,6 +45,19 @@ async def test_chat_agent_skips_knowledge_runtime_tools_when_disabled(monkeypatc
     assert prompt_inputs["knowledge_instructions"] == ""
 
 
+@pytest.mark.asyncio
+async def test_execute_tool_falls_back_to_base_tools_when_tools_is_none():
+    agent = ChatAgent()
+    agent._is_setup = True
+    agent.use_regular_chat = True
+    agent.tools = None
+    agent.base_tools = [base_chat_tool]
+
+    result = await agent.execute_tool({"name": "base_chat_tool", "args": {}})
+
+    assert result == "ok"
+
+
 def test_knowledge_client_rejects_disabled_session_scope():
     engine = SimpleNamespace(
         _config=SimpleNamespace(


### PR DESCRIPTION
## Summary
- Fixes `TypeError: 'NoneType' object is not iterable` in `ChatAgent.execute_tool()` when running in regular chat mode (e.g. IBM Cloud Code Engine without SSE)
- Both tool lookup loops now fall back to `self.base_tools` when `self.tools` is `None`
- Adds a unit test covering the regular chat mode tool execution path

Closes #334

## Test plan
- [x] `uv run pytest tests/unit/test_chat_agent_knowledge_toggle.py -q` (4 passed)
- [ ] Deploy to Code Engine without SSE and verify CRM tool execution works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat agent resilience by adding fallback logic to use base tools when primary tools become unavailable, particularly during reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->