### PR TITLE
fix(cuga-lite): normalize numpy types at producer boundaries for checkpointing

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from langchain_core.tools import StructuredTool
 from cuga.backend.cuga_graph.nodes.cuga_lite.providers.base import AppDefinition
 from cuga.backend.llm.utils.helpers import create_chat_prompt_from_templates
+from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
 from cuga.backend.cuga_graph.nodes.cuga_lite.model_runtime_profile import runtime_defaults_for_model
 
 
@@ -363,12 +364,11 @@ class PromptUtils:
                         # Fallback for other types
                         output_schema = {"value": raw_output_schema} if raw_output_schema is not None else {}
 
-            # Use model_dump with by_alias=True to ensure proper field names
             enriched_tool = Tool(
                 name=api_detail.name,
-                input=input_schema,  # Use alias name
+                input=VariableUtils.sanitize_value(input_schema),
                 reasoning=api_detail.reasoning,
-                output_schema=output_schema,
+                output_schema=VariableUtils.sanitize_value(output_schema),
                 params_doc=params_doc,
                 response_doc=response_doc,
             )

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tracking/tracker.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tracking/tracker.py
@@ -93,10 +93,12 @@ class ToolCallTracker:
         if calls is None:
             return
 
+        from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+
         record = {
             "name": tool_name,
-            "arguments": arguments,
-            "result": result,
+            "arguments": VariableUtils.sanitize_value(arguments),
+            "result": VariableUtils.sanitize_value(result),
             "app_name": app_name,
             "operation_id": operation_id,
             "timestamp": datetime.now().isoformat(),

--- a/src/cuga/backend/cuga_graph/state/agent_state.py
+++ b/src/cuga/backend/cuga_graph/state/agent_state.py
@@ -153,6 +153,10 @@ class VariablesManager(object):
         Returns:
             str: The name of the variable that was created or updated
         """
+        from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+
+        value = VariableUtils.sanitize_value(value)
+
         is_new = True
         original_name = name
 
@@ -825,6 +829,10 @@ class StateVariablesManager(VariablesManager):
 
     def add_variable(self, value: Any, name: Optional[str] = None, description: Optional[str] = None) -> str:
         """Add variable and store in state."""
+        from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+
+        value = VariableUtils.sanitize_value(value)
+
         if name is None:
             self.variable_counter += 1
             name = f"variable_{self.variable_counter}"

--- a/tests/unit/test_numpy_checkpoint_serialization.py
+++ b/tests/unit/test_numpy_checkpoint_serialization.py
@@ -1,0 +1,131 @@
+"""Tests for producer-side numpy normalization (issue #229)."""
+
+import numpy as np
+import pytest
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+from cuga.backend.cuga_graph.nodes.cuga_lite.tracking.tracker import ToolCallTracker
+from cuga.backend.cuga_graph.state.agent_state import AgentState, VariablesManager
+
+
+class TestVariablesManagerNumpySanitization:
+    def setup_method(self):
+        VariablesManager().reset()
+
+    def teardown_method(self):
+        VariablesManager().reset()
+
+    def test_add_variable_converts_numpy_scalar(self):
+        manager = VariablesManager()
+        manager.add_variable(np.float64(0.75), name="score")
+
+        stored = manager.get_variable("score")
+        assert stored == 0.75
+        assert isinstance(stored, float)
+
+    def test_add_variable_converts_nested_numpy(self):
+        manager = VariablesManager()
+        manager.add_variable(
+            {"values": np.array([1, 2, 3]), "enabled": np.bool_(True)},
+            name="nested",
+        )
+
+        stored = manager.get_variable("nested")
+        assert stored == {"values": [1, 2, 3], "enabled": True}
+
+    def test_state_variables_manager_sanitizes_on_ingest(self):
+        state = AgentState(input="test", url="http://example.com")
+        state.variables_manager.add_variable(np.float64(0.98), name="confidence")
+
+        stored = state.variables_manager.get_variable("confidence")
+        assert stored == 0.98
+        assert isinstance(stored, float)
+
+        serializer = JsonPlusSerializer()
+        serializer.dumps_typed(state.variables_storage)
+
+
+class TestToolCallTrackerNumpySanitization:
+    def test_record_call_normalizes_numpy_for_checkpointing(self):
+        ToolCallTracker.start_tracking(enabled=True)
+
+        ToolCallTracker.record_call(
+            tool_name="find_tools",
+            arguments={
+                "score": np.float64(0.75),
+                "nested": {"values": np.array([1, 2, 3]), "enabled": np.bool_(True)},
+            },
+            result={
+                "output": {
+                    "value": "# Found 2 Matching Tool(s)",
+                    "confidence": np.float64(0.98),
+                }
+            },
+            app_name="crm",
+            operation_id="find_tools",
+        )
+
+        calls = ToolCallTracker.stop_tracking()
+
+        assert len(calls) == 1
+        assert calls[0]["arguments"]["score"] == 0.75
+        assert isinstance(calls[0]["arguments"]["score"], float)
+        assert calls[0]["arguments"]["nested"]["values"] == [1, 2, 3]
+        assert calls[0]["arguments"]["nested"]["enabled"] is True
+        assert calls[0]["result"]["output"]["confidence"] == 0.98
+        assert isinstance(calls[0]["result"]["output"]["confidence"], float)
+
+        serializer = JsonPlusSerializer()
+        serializer.dumps_typed(calls)
+
+
+@pytest.mark.asyncio
+async def test_find_tools_sanitizes_tool_schemas():
+    mock_tool = MagicMock()
+    mock_tool.name = "crm_get_contacts"
+    mock_tool.description = "Get contacts"
+    mock_tool.args_schema = MagicMock()
+    mock_tool.args_schema.schema.return_value = {
+        "type": "object",
+        "properties": {"limit": {"type": "number", "default": np.float64(10.0)}},
+    }
+    mock_tool.func = MagicMock()
+    mock_tool.func._response_schemas = {
+        "success": {"score": np.float64(0.95), "items": np.array([1, 2])},
+    }
+    mock_tool.func._param_constraints = {}
+
+    api_detail = MagicMock()
+    api_detail.name = "crm_get_contacts"
+    api_detail.reasoning = "Relevant for contact lookup"
+
+    shortlister_response = MagicMock()
+    shortlister_response.result = [api_detail]
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.PromptUtils.get_tool_docs",
+            return_value=("params", "response"),
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.shared.base_agent.BaseAgent.get_chain",
+        ) as mock_chain,
+        patch(
+            "cuga.backend.llm.models.LLMManager",
+        ),
+    ):
+        mock_chain.return_value.ainvoke = AsyncMock(return_value=shortlister_response)
+
+        result = await PromptUtils.find_tools(
+            query="check contacts",
+            all_tools=[mock_tool],
+            all_apps=[],
+        )
+
+    assert "crm_get_contacts" in result
+    assert "Found 1 Matching Tool" in result
+
+    serializer = JsonPlusSerializer()
+    serializer.dumps_typed(result)


### PR DESCRIPTION
## Summary
- Fixes #229 by normalizing numpy scalars to Python builtins at producer boundaries instead of checkpoint-time coercion (per PR #180 consensus).
- `find_tools` now sanitizes `input_schema` and `output_schema` via `VariableUtils.sanitize_value` before building tool results.
- `VariablesManager` / `StateVariablesManager.add_variable` sanitizes values on ingestion so `variables_storage` is always msgpack-safe.
- `ToolCallTracker.record_call` sanitizes `arguments` and `result` so tracked `tool_calls` survive `JsonPlusSerializer` checkpoint writes.

## Test plan
- [x] `uv run pytest tests/unit/test_numpy_checkpoint_serialization.py -v` (5 tests pass)
- [x] Verified `JsonPlusSerializer.dumps_typed()` succeeds on sanitized `variables_storage`, `tool_calls`, and `find_tools` output
- [ ] Manual: run CRM demo with `find_tools` shortlisting enabled and confirm no `numpy.float64` checkpoint error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved normalization of numerical data types to ensure compatibility with checkpointing and serialization across the system.

* **Tests**
  * Added comprehensive tests validating proper handling of numerical data types during serialization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->