### PR TITLE
fix: surface reflection and todos in /chat stream for demo_skills

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
@@ -196,6 +196,9 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
                 )
 
             todo_state_update = extract_task_todos_from_new_vars(new_vars)
+            if todo_state_update is None and getattr(adapter, "_task_todos_ref", None):
+                if adapter._task_todos_ref:
+                    todo_state_update = [dict(item) for item in adapter._task_todos_ref]
             base_update = {
                 "chat_messages": updated_messages,
                 "variables_storage": state.variables_storage,

--- a/src/cuga/backend/cuga_graph/utils/agent_loop.py
+++ b/src/cuga/backend/cuga_graph/utils/agent_loop.py
@@ -259,6 +259,60 @@ class StreamEvent(BaseModel):
         return f"event: {self.name}\ndata: {self.data}\n\n"
 
 
+_SANDBOX_REFLECTION_SEPARATOR = "\n\n---\n\nSummary:\n"
+
+
+def _split_sandbox_execution_output(raw: str) -> tuple[str, str]:
+    if _SANDBOX_REFLECTION_SEPARATOR in raw:
+        execution_part, reflection_part = raw.split(_SANDBOX_REFLECTION_SEPARATOR, 1)
+        return execution_part.strip(), reflection_part.strip()
+    return raw.strip(), ""
+
+
+def _sandbox_stream_events(state_data: dict) -> list[StreamEvent]:
+    execution_output = ""
+    messages = state_data.get("chat_messages", [])
+    if messages:
+        for msg in reversed(messages):
+            if hasattr(msg, "content"):
+                content = msg.content
+            elif isinstance(msg, dict):
+                content = msg.get("content", "")
+            else:
+                continue
+            if "Execution output:" in content:
+                execution_output = content.split("Execution output:\n")[-1]
+                break
+
+    execution_output, reflection_output = _split_sandbox_execution_output(execution_output)
+    events: list[StreamEvent] = []
+
+    if execution_output:
+        events.append(
+            StreamEvent(
+                name="CodeAgent",
+                data=json.dumps(
+                    {
+                        "code": "",
+                        "execution_output": execution_output,
+                        "steps_summary": [],
+                        "summary": "Code execution completed",
+                        "variables": state_data.get("variables_storage", {}),
+                    }
+                ),
+            )
+        )
+
+    if reflection_output:
+        events.append(StreamEvent(name="Reflection", data=reflection_output))
+
+    task_todos = state_data.get("task_todos")
+    if task_todos:
+        events.append(StreamEvent(name="TaskTodos", data=json.dumps({"todos": task_todos})))
+
+    return events
+
+
 class AgentLoop:
     """
     A class to handle the agent loop process, managing events, streaming responses,
@@ -302,7 +356,7 @@ class AgentLoop:
     async def stream_event(self, event: StreamEvent) -> Generator[str, None, None]:
         yield event.format()
 
-    def get_event_message(self, event) -> StreamEvent:
+    def get_event_message(self, event) -> Union[StreamEvent, List[StreamEvent]]:
         # When subgraphs=True, event is a tuple: (namespace_tuple, state_dict)
         # namespace_tuple is like () for root or (node_name,) for subgraph
         if isinstance(event, tuple):
@@ -361,43 +415,15 @@ class AgentLoop:
                 # Handle sandbox node from CugaLite subgraph
                 elif node_name == "sandbox":
                     logger.info("Detected sandbox node - formatting execution output")
-
-                    # Extract execution output from chat_messages
-                    execution_output = ""
-                    messages = state_data.get("chat_messages", [])
-                    if messages:
-                        logger.debug(f"Found {len(messages)} messages in sandbox state")
-                        for msg in reversed(messages):
-                            # Handle both BaseMessage objects and dicts
-                            if hasattr(msg, 'content'):
-                                content = msg.content
-                            elif isinstance(msg, dict):
-                                content = msg.get("content", "")
-                            else:
-                                continue
-
-                            if "Execution output:" in content:
-                                execution_output = content.split("Execution output:\n")[-1]
-                                logger.debug(f"Extracted execution output: {execution_output[:100]}...")
-                                break
-
-                    # Only return event if we have meaningful execution output
-                    if execution_output and execution_output.strip():
-                        output = {
-                            "code": "",
-                            "execution_output": execution_output,
-                            "steps_summary": [],
-                            "summary": "Code execution completed",
-                            "variables": state_data.get("variables_storage", {}),
-                        }
+                    events = _sandbox_stream_events(state_data)
+                    if events:
                         logger.info(
-                            f"Returning sandbox output with execution_output length: {len(execution_output)}"
+                            "Returning sandbox stream events: %s",
+                            [event.name for event in events],
                         )
-                        return StreamEvent(name="CodeAgent", data=json.dumps(output))
-                    else:
-                        # Skip empty sandbox events
-                        logger.debug("Skipping empty sandbox event")
-                        return StreamEvent(name="", data="")
+                        return events
+                    logger.debug("Skipping empty sandbox event")
+                    return StreamEvent(name="", data="")
 
                 # Default handling for other subgraph nodes
                 logger.debug(f"Unhandled subgraph node: {node_name}")
@@ -684,15 +710,16 @@ class AgentLoop:
                 set_session_attribute(self.thread_id)
                 session_tagged = True
 
-            event_msg = self.get_event_message(event)
-            # Skip empty events (events with no name or no data)
-            if not event_msg.name or (not event_msg.data and event_msg.name != "__interrupt__"):
-                logger.debug(
-                    f"Skipping empty event: name='{event_msg.name}', data='{event_msg.data[:50] if event_msg.data else ''}'"
-                )
-                continue
-            # logger.debug(f"current event: {event_msg.format()}")
-            yield event_msg.format()
+            event_msgs = self.get_event_message(event)
+            if not isinstance(event_msgs, list):
+                event_msgs = [event_msgs]
+            for event_msg in event_msgs:
+                if not event_msg.name or (not event_msg.data and event_msg.name != "__interrupt__"):
+                    logger.debug(
+                        f"Skipping empty event: name='{event_msg.name}', data='{event_msg.data[:50] if event_msg.data else ''}'"
+                    )
+                    continue
+                yield event_msg.format()
         yield self.get_output(event)
 
     def get_output_of_obj(self, dict):

--- a/src/cuga/backend/server/demo_manage_setup.py
+++ b/src/cuga/backend/server/demo_manage_setup.py
@@ -732,6 +732,7 @@ def setup_demo_manage_config(
     if tools and (any(t.get("name") == "docs" for t in tools) or demo_type in ("demo", "demo_skills")):
         config["feature_flags"] = config.get("feature_flags") or {}
         config["feature_flags"]["enable_todos"] = True
+        config["feature_flags"]["reflection"] = True
 
     if demo_type == "demo_skills":
         config.setdefault("advanced_features", {})["enable_shell_tool"] = True

--- a/src/frontend_workspaces/agentic_chat/src/CardManager.tsx
+++ b/src/frontend_workspaces/agentic_chat/src/CardManager.tsx
@@ -19,6 +19,7 @@ import AppAnalyzerComponent from "./app_analyzer_component";
 import TaskDecompositionComponent from "./task_decomposition";
 import ShortlisterComponent from "./shortlister";
 import SingleExpandableContent from "./generic_component";
+import TaskTodosComponent from "./task_todos_component";
 import ActionAgent from "./action_agent";
 import QaAgentComponent from "./qa_agent";
 import { FollowupAction } from "./Followup";
@@ -1029,6 +1030,18 @@ const CardManager: React.FC<CardManagerProps> = ({ chatInstance, threadId, useDr
           case "CodeAgent":
             if (parsedContent.code || parsedContent.execution_output) {
               mainElement = <CoderAgentOutput coderData={parsedContent} />;
+            }
+            break;
+          case "Reflection":
+            if (parsedContent) {
+              const reflectionText =
+                typeof parsedContent === "string" ? parsedContent : JSON.stringify(parsedContent, null, 2);
+              mainElement = <SingleExpandableContent title={"Code Reflection"} content={reflectionText} />;
+            }
+            break;
+          case "TaskTodos":
+            if (parsedContent?.todos) {
+              mainElement = <TaskTodosComponent todosData={parsedContent} />;
             }
             break;
           case "Policy":

--- a/src/frontend_workspaces/agentic_chat/src/coder_agent_output.tsx
+++ b/src/frontend_workspaces/agentic_chat/src/coder_agent_output.tsx
@@ -1,13 +1,26 @@
 import React, { useState } from "react";
 import Markdown from "react-markdown";
 
+const REFLECTION_SEPARATOR = "\n\n---\n\nSummary:\n";
+
+function splitExecutionAndReflection(text: string) {
+  if (!text || !text.includes(REFLECTION_SEPARATOR)) {
+    return { execution: text || "", reflection: "" };
+  }
+  const [execution, reflection] = text.split(REFLECTION_SEPARATOR, 2);
+  return { execution: execution.trim(), reflection: reflection.trim() };
+}
+
 export default function CoderAgentOutput({ coderData }) {
   const [showFullCode, setShowFullCode] = useState(false);
   const [showFullOutput, setShowFullOutput] = useState(false);
+  const [showFullReflection, setShowFullReflection] = useState(false);
 
-  // Handle both old format (summary) and new format (execution_output)
-  const { code = "", summary, execution_output, variables } = coderData;
-  const output = execution_output || summary || "";
+  const { code = "", summary, execution_output, reflection, variables } = coderData;
+  const rawOutput = execution_output || summary || "";
+  const splitOutput = splitExecutionAndReflection(rawOutput);
+  const output = reflection ? rawOutput : splitOutput.execution;
+  const reflectionText = reflection || splitOutput.reflection;
 
   function getCodeSnippet(fullCode, maxLines = 4) {
     if (!fullCode) return "";
@@ -80,6 +93,28 @@ export default function CoderAgentOutput({ coderData }) {
               <div className="bg-green-50 rounded p-3 border border-green-200" style={{ overflowY: "auto", maxHeight: showFullOutput ? "none" : "300px" }}>
                 <div className="text-xs text-green-800 leading-relaxed">
                   <Markdown>{showFullOutput ? output : truncateOutput(output)}</Markdown>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {reflectionText && (
+            <div className="mb-3">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs text-gray-600">Code Reflection ({reflectionText.length} chars)</span>
+                {reflectionText.length > 400 && (
+                  <button
+                    onClick={() => setShowFullReflection(!showFullReflection)}
+                    className="text-xs text-blue-600 hover:text-blue-800"
+                  >
+                    {showFullReflection ? "▲ Less" : "▼ More"}
+                  </button>
+                )}
+              </div>
+
+              <div className="bg-blue-50 rounded p-3 border border-blue-200" style={{ overflowY: "auto", maxHeight: showFullReflection ? "none" : "300px" }}>
+                <div className="text-xs text-blue-800 leading-relaxed">
+                  <Markdown>{showFullReflection ? reflectionText : truncateOutput(reflectionText)}</Markdown>
                 </div>
               </div>
             </div>

--- a/src/frontend_workspaces/agentic_chat/src/task_todos_component.tsx
+++ b/src/frontend_workspaces/agentic_chat/src/task_todos_component.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+type TodoItem = {
+  text: string;
+  status: string;
+};
+
+function getStatusIcon(status: string) {
+  const normalized = status.toLowerCase();
+  if (normalized === "completed") return "✅";
+  if (normalized === "in_progress" || normalized === "in-progress") return "🔄";
+  return "⏳";
+}
+
+function getStatusColor(status: string) {
+  const normalized = status.toLowerCase();
+  if (normalized === "completed") return "bg-green-100 text-green-700";
+  if (normalized === "in_progress" || normalized === "in-progress") return "bg-blue-100 text-blue-700";
+  return "bg-gray-100 text-gray-700";
+}
+
+export default function TaskTodosComponent({ todosData }: { todosData: { todos?: TodoItem[] } }) {
+  const todos = todosData?.todos || [];
+  if (!todos.length) return null;
+
+  const completed = todos.filter((item) => item.status?.toLowerCase() === "completed").length;
+  const progressPercentage = (completed / todos.length) * 100;
+
+  return (
+    <div className="p-3">
+      <div className="max-w-3xl mx-auto">
+        <div className="bg-white rounded-lg border border-gray-200 p-3">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-medium text-gray-700 flex items-center gap-2">
+              <span className="text-sm">📋</span>
+              Current Plan
+            </h3>
+            <span className="px-2 py-1 rounded text-xs bg-indigo-100 text-indigo-700">
+              {completed}/{todos.length} done
+            </span>
+          </div>
+
+          <div className="mb-3">
+            <div className="flex-1 bg-gray-200 rounded-full h-1.5">
+              <div
+                className="bg-indigo-500 h-1.5 rounded-full transition-all duration-300"
+                style={{ width: `${progressPercentage}%` }}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            {todos.map((item, index) => (
+              <div
+                key={`${item.text}-${index}`}
+                className="flex items-start gap-2 p-2 bg-gray-50 rounded border border-gray-100"
+              >
+                <span className="text-sm mt-0.5">{getStatusIcon(item.status)}</span>
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs text-gray-700 leading-relaxed">{item.text}</p>
+                </div>
+                <span className={`px-1.5 py-0.5 rounded text-xs ${getStatusColor(item.status)}`}>
+                  {item.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/unit/test_issue_325_reflection_todos_stream.py
+++ b/tests/unit/test_issue_325_reflection_todos_stream.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+
+from langchain_core.messages import HumanMessage
+
+from cuga.backend.cuga_graph.utils.agent_loop import (
+    StreamEvent,
+    _sandbox_stream_events,
+    _split_sandbox_execution_output,
+)
+from cuga.backend.server.manage_routes import _extract_agent_feature_overrides
+
+
+def test_split_sandbox_execution_output_splits_reflection():
+    raw = "tool ran ok\n\n---\n\nSummary:\nReflect on next step"
+    execution, reflection = _split_sandbox_execution_output(raw)
+    assert execution == "tool ran ok"
+    assert reflection == "Reflect on next step"
+
+
+def test_sandbox_stream_events_emits_reflection_and_task_todos():
+    state_data = {
+        "chat_messages": [
+            HumanMessage(content="Execution output:\nresult=1\n\n---\n\nSummary:\nContinue with step 2")
+        ],
+        "variables_storage": {"result": 1},
+        "task_todos": [
+            {"text": "Fetch data", "status": "completed"},
+            {"text": "Summarize", "status": "in_progress"},
+        ],
+    }
+
+    events = _sandbox_stream_events(state_data)
+    names = [event.name for event in events]
+
+    assert names == ["CodeAgent", "Reflection", "TaskTodos"]
+
+    code_agent = json.loads(events[0].data)
+    assert "Summary:" not in code_agent["execution_output"]
+    assert code_agent["execution_output"] == "result=1"
+    assert events[1].data == "Continue with step 2"
+
+    todos_payload = json.loads(events[2].data)
+    assert len(todos_payload["todos"]) == 2
+
+
+def test_sandbox_stream_events_emits_task_todos_without_execution_output():
+    state_data = {
+        "chat_messages": [],
+        "task_todos": [{"text": "Plan step", "status": "pending"}],
+    }
+
+    events = _sandbox_stream_events(state_data)
+    assert [event.name for event in events] == ["TaskTodos"]
+
+
+def test_extract_agent_feature_overrides_reads_demo_reflection_flag():
+    overrides = _extract_agent_feature_overrides(
+        {
+            "feature_flags": {
+                "enable_todos": True,
+                "reflection": True,
+            }
+        }
+    )
+    assert overrides["enable_todos"] is True
+    assert overrides["reflection_enabled"] is True
+
+
+def test_stream_event_list_formatting():
+    events = [
+        StreamEvent(name="Reflection", data="summary text"),
+        StreamEvent(name="TaskTodos", data='{"todos": []}'),
+    ]
+    formatted = [event.format() for event in events]
+    assert formatted[0].startswith("event: Reflection\n")
+    assert formatted[1].startswith("event: TaskTodos\n")


### PR DESCRIPTION
## Summary
- Emit dedicated `Reflection` and `TaskTodos` SSE events from CugaLite sandbox runs so `/chat` can render strategic reflection and plan updates during `demo_skills` sessions
- Sync todo state from `adapter._task_todos_ref` when skills mode strips confirmation-only variables, and persist `feature_flags.reflection = true` in demo manage config alongside `enable_todos`
- Add chat UI components for the new stream events and split embedded `Summary:` blocks in `CoderAgentOutput` as a fallback

Fixes #325

## Test plan
- [x] `uv run pytest tests/unit/test_issue_325_reflection_todos_stream.py -q` (5 passed)
- [ ] Start `cuga start demo_skills`, open `/chat`, run a multi-step task
- [ ] Confirm reflection appears as a **Code Reflection** card after sandbox execution
- [ ] Confirm todo plan updates appear as a **Current Plan** card when `create_update_todos` runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent reflection output with "Code Reflection" UI section, including character count and expandable display.
  * Introduced "Current Plan" UI displaying task todos with completion progress bar and status tracking.
  * Multiple stream events can now be emitted from agent execution, supporting reflection and task data together.

* **Tests**
  * Added comprehensive test coverage for reflection parsing and task streaming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->