### PR TITLE
fix: propagate auth query_params to SSE and HTTP transport URLs (#213)

### DIFF
--- a/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
@@ -29,7 +29,7 @@ from cuga.backend.tools_env.registry.mcp_manager.adapter import (
 )
 import threading
 from collections import defaultdict
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 from loguru import logger
 from cuga.backend.tools_env.registry.mcp_manager.openapi_parser_v0 import OpenAPITransformer
 from cuga.backend.tools_env.registry.mcp_manager.response_schema import extract_response_schema
@@ -973,13 +973,16 @@ class MCPManager:
 
             print(f"Connecting to MCP server '{name}' via SSE at {config.url}")
 
-            # Build headers from auth config if available
+            # Build headers and URL query params from auth config if available
             headers = {}
+            url = config.url
             if config.auth:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
+                if query_params:
+                    url = f"{config.url}?{urlencode(query_params)}"
 
-            return SSETransport(url=config.url, headers=headers if headers else None)
+            return SSETransport(url=url, headers=headers if headers else None)
 
         elif transport_type == 'http':
             if not StreamableHttpTransport:
@@ -991,13 +994,16 @@ class MCPManager:
 
             print(f"Connecting to MCP server '{name}' via HTTP at {config.url}")
 
-            # Build headers from auth config if available
+            # Build headers and URL query params from auth config if available
             headers = {}
+            url = config.url
             if config.auth:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
+                if query_params:
+                    url = f"{config.url}?{urlencode(query_params)}"
 
-            return StreamableHttpTransport(url=config.url, headers=headers if headers else None)
+            return StreamableHttpTransport(url=url, headers=headers if headers else None)
 
         else:
             raise Exception(f"Unknown transport type: {transport_type}")

--- a/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
@@ -121,8 +121,8 @@ class TestSSETransportAuth:
         assert call_kwargs["headers"] == {"Authorization": f"Basic {expected}"}
         assert result is fake_transport
 
-    def test_api_key_auth_does_not_set_headers(self):
-        """api-key auth goes into query params, not headers — headers should be None."""
+    def test_api_key_auth_appends_query_params_to_url(self):
+        """api-key auth must be URL-encoded and appended to the transport URL."""
         manager = _make_manager()
         config = _sse_config(auth=Auth(type="api-key", value="key123", key="api_key"))
 
@@ -139,9 +139,9 @@ class TestSSETransportAuth:
         ):
             result = manager._create_transport("test_server", config)
 
-        # api-key goes to query_params, not headers — so headers dict is empty → None
         call_kwargs = MockSSE.call_args.kwargs
         assert call_kwargs["headers"] is None
+        assert call_kwargs["url"] == "https://example.com/sse?api_key=key123"
         assert result is fake_transport
 
     def test_missing_url_raises(self):
@@ -161,3 +161,34 @@ class TestSSETransportAuth:
         with patch("cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport", None):
             with pytest.raises(Exception, match="SSETransport not available"):
                 manager._create_transport("test_server", config)
+
+
+def _http_config(auth: Auth | None = None, url: str = "https://example.com/mcp") -> ServiceConfig:
+    return ServiceConfig(url=url, transport="http", auth=auth)
+
+
+class TestHttpTransportAuth:
+    """_create_transport('http') must forward auth as headers and query params."""
+
+    def test_api_key_auth_appends_query_params_to_url(self):
+        """api-key auth must be URL-encoded and appended to the transport URL."""
+        manager = _make_manager()
+        config = _http_config(auth=Auth(type="api-key", value="key123", key="api_key"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.StreamableHttpTransport",
+                return_value=fake_transport,
+            ) as MockHTTP,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        call_kwargs = MockHTTP.call_args.kwargs
+        assert call_kwargs["headers"] is None
+        assert call_kwargs["url"] == "https://example.com/mcp?api_key=key123"
+        assert result is fake_transport


### PR DESCRIPTION
## Summary
- Fixes a bug where `apply_authentication` query params (e.g. `api-key` auth) were silently discarded in `_create_transport` for SSE and HTTP transports
- URL-encodes and appends `query_params` to the transport URL, consistent with the existing pattern in `_call_mcp_server_tool`
- Adds regression tests for both SSE and HTTP transports

Fixes #213

## Test plan
- [x] `uv run pytest src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py -v` — 8 passed
- [ ] Verify MCP server connections with `api-key` / `query` auth type over SSE and HTTP transports in a live environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication handling to properly include API credentials in transport URLs for both SSE and HTTP connections when authentication is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->