### PR TITLE
fix: propagate auth query params to MCP transport URLs (#213)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-05-26T10:33:05Z",
+  "generated_at": "2026-06-24T07:27:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -614,7 +614,7 @@
       {
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 97,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
@@ -29,12 +29,19 @@ from cuga.backend.tools_env.registry.mcp_manager.adapter import (
 )
 import threading
 from collections import defaultdict
-from urllib.parse import parse_qsl, urlencode, urlparse
+from urllib.parse import parse_qsl, quote, urlencode, urlparse
 from loguru import logger
 from cuga.backend.tools_env.registry.mcp_manager.openapi_parser_v0 import OpenAPITransformer
 from cuga.backend.tools_env.registry.mcp_manager.response_schema import extract_response_schema
 import yaml
 from cuga.backend.utils.consts import ServiceType, LOCAL_ORCHESTRATE_URL, LOCAL_TRM_URL
+
+
+def _merge_auth_query_params(base_url: str, auth_params: dict[str, str]) -> str:
+    parsed = urlparse(base_url)
+    merged = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    merged.update(auth_params)
+    return parsed._replace(query=urlencode(merged, quote_via=quote)).geturl()
 
 
 class MCPManager:
@@ -980,10 +987,7 @@ class MCPManager:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
                 if query_params:
-                    parsed = urlparse(config.url)
-                    merged = dict(parse_qsl(parsed.query, keep_blank_values=True))
-                    merged.update(query_params)
-                    url = parsed._replace(query=urlencode(merged)).geturl()
+                    url = _merge_auth_query_params(config.url, query_params)
 
             return SSETransport(url=url, headers=headers if headers else None)
 
@@ -1004,10 +1008,7 @@ class MCPManager:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
                 if query_params:
-                    parsed = urlparse(config.url)
-                    merged = dict(parse_qsl(parsed.query, keep_blank_values=True))
-                    merged.update(query_params)
-                    url = parsed._replace(query=urlencode(merged)).geturl()
+                    url = _merge_auth_query_params(config.url, query_params)
 
             return StreamableHttpTransport(url=url, headers=headers if headers else None)
 

--- a/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
@@ -29,7 +29,7 @@ from cuga.backend.tools_env.registry.mcp_manager.adapter import (
 )
 import threading
 from collections import defaultdict
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 from loguru import logger
 from cuga.backend.tools_env.registry.mcp_manager.openapi_parser_v0 import OpenAPITransformer
 from cuga.backend.tools_env.registry.mcp_manager.response_schema import extract_response_schema
@@ -975,11 +975,14 @@ class MCPManager:
 
             # Build headers from auth config if available
             headers = {}
+            url = config.url
             if config.auth:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
+                if query_params:
+                    url = f"{config.url}?{urlencode(query_params)}"
 
-            return SSETransport(url=config.url, headers=headers if headers else None)
+            return SSETransport(url=url, headers=headers if headers else None)
 
         elif transport_type == 'http':
             if not StreamableHttpTransport:
@@ -993,11 +996,14 @@ class MCPManager:
 
             # Build headers from auth config if available
             headers = {}
+            url = config.url
             if config.auth:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
+                if query_params:
+                    url = f"{config.url}?{urlencode(query_params)}"
 
-            return StreamableHttpTransport(url=config.url, headers=headers if headers else None)
+            return StreamableHttpTransport(url=url, headers=headers if headers else None)
 
         else:
             raise Exception(f"Unknown transport type: {transport_type}")

--- a/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/mcp_manager.py
@@ -29,7 +29,7 @@ from cuga.backend.tools_env.registry.mcp_manager.adapter import (
 )
 import threading
 from collections import defaultdict
-from urllib.parse import urlencode, urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 from loguru import logger
 from cuga.backend.tools_env.registry.mcp_manager.openapi_parser_v0 import OpenAPITransformer
 from cuga.backend.tools_env.registry.mcp_manager.response_schema import extract_response_schema
@@ -980,7 +980,10 @@ class MCPManager:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
                 if query_params:
-                    url = f"{config.url}?{urlencode(query_params)}"
+                    parsed = urlparse(config.url)
+                    merged = dict(parse_qsl(parsed.query, keep_blank_values=True))
+                    merged.update(query_params)
+                    url = parsed._replace(query=urlencode(merged)).geturl()
 
             return SSETransport(url=url, headers=headers if headers else None)
 
@@ -1001,7 +1004,10 @@ class MCPManager:
                 query_params = {}
                 apply_authentication(config.auth, headers, query_params)
                 if query_params:
-                    url = f"{config.url}?{urlencode(query_params)}"
+                    parsed = urlparse(config.url)
+                    merged = dict(parse_qsl(parsed.query, keep_blank_values=True))
+                    merged.update(query_params)
+                    url = parsed._replace(query=urlencode(merged)).geturl()
 
             return StreamableHttpTransport(url=url, headers=headers if headers else None)
 

--- a/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
@@ -7,6 +7,7 @@ the HTTP/streamable-http branch does.
 """
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -167,6 +168,52 @@ class TestSSETransportAuth:
         assert call_kwargs["url"] == "https://example.com/sse?auth_token=token456"
         assert result is fake_transport
 
+    def test_api_key_auth_merges_with_existing_query_params(self):
+        manager = _make_manager()
+        config = _sse_config(
+            auth=Auth(type="api-key", value="key123", key="api_key"),
+            url="https://example.com/sse?existing=1",
+        )
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            manager._create_transport("test_server", config)
+
+        parsed = urlparse(MockSSE.call_args.kwargs["url"])
+        assert parse_qs(parsed.query) == {"existing": ["1"], "api_key": ["key123"]}
+
+    def test_query_auth_merges_with_existing_query_params(self):
+        manager = _make_manager()
+        config = _sse_config(
+            auth=Auth(type="query", value="token456", key="auth_token"),
+            url="https://example.com/sse?existing=1",
+        )
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            manager._create_transport("test_server", config)
+
+        parsed = urlparse(MockSSE.call_args.kwargs["url"])
+        assert parse_qs(parsed.query) == {"existing": ["1"], "auth_token": ["token456"]}
+
     def test_missing_url_raises(self):
         """SSE transport without a URL must raise immediately."""
         manager = _make_manager()
@@ -235,3 +282,49 @@ class TestHTTPTransportAuth:
         assert call_kwargs["headers"] is None
         assert call_kwargs["url"] == "https://example.com/mcp?api_key=key123"
         assert result is fake_transport
+
+    def test_api_key_auth_merges_with_existing_query_params(self):
+        manager = _make_manager()
+        config = self._http_config(
+            auth=Auth(type="api-key", value="key123", key="api_key"),
+            url="https://example.com/mcp?existing=1",
+        )
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.StreamableHttpTransport",
+                return_value=fake_transport,
+            ) as MockHTTP,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            manager._create_transport("test_server", config)
+
+        parsed = urlparse(MockHTTP.call_args.kwargs["url"])
+        assert parse_qs(parsed.query) == {"existing": ["1"], "api_key": ["key123"]}
+
+    def test_query_auth_merges_with_existing_query_params(self):
+        manager = _make_manager()
+        config = self._http_config(
+            auth=Auth(type="query", value="token456", key="auth_token"),
+            url="https://example.com/mcp?existing=1",
+        )
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.StreamableHttpTransport",
+                return_value=fake_transport,
+            ) as MockHTTP,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            manager._create_transport("test_server", config)
+
+        parsed = urlparse(MockHTTP.call_args.kwargs["url"])
+        assert parse_qs(parsed.query) == {"existing": ["1"], "auth_token": ["token456"]}

--- a/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
@@ -214,6 +214,28 @@ class TestSSETransportAuth:
         parsed = urlparse(MockSSE.call_args.kwargs["url"])
         assert parse_qs(parsed.query) == {"existing": ["1"], "auth_token": ["token456"]}
 
+    def test_api_key_auth_encodes_plus_in_value_with_quote(self):
+        """Base64-like secrets with + must use %2B, not rely on quote_plus semantics."""
+        manager = _make_manager()
+        config = _sse_config(
+            auth=Auth(type="api-key", value="abc+def/ghi=", key="api_key"),
+        )
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            manager._create_transport("test_server", config)
+
+        assert MockSSE.call_args.kwargs["url"] == "https://example.com/sse?api_key=abc%2Bdef%2Fghi%3D"
+
     def test_missing_url_raises(self):
         """SSE transport without a URL must raise immediately."""
         manager = _make_manager()

--- a/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
+++ b/src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py
@@ -121,8 +121,8 @@ class TestSSETransportAuth:
         assert call_kwargs["headers"] == {"Authorization": f"Basic {expected}"}
         assert result is fake_transport
 
-    def test_api_key_auth_does_not_set_headers(self):
-        """api-key auth goes into query params, not headers — headers should be None."""
+    def test_api_key_auth_appends_query_params_to_url(self):
+        """api-key auth must be URL-encoded and appended to the transport URL."""
         manager = _make_manager()
         config = _sse_config(auth=Auth(type="api-key", value="key123", key="api_key"))
 
@@ -139,9 +139,32 @@ class TestSSETransportAuth:
         ):
             result = manager._create_transport("test_server", config)
 
-        # api-key goes to query_params, not headers — so headers dict is empty → None
         call_kwargs = MockSSE.call_args.kwargs
         assert call_kwargs["headers"] is None
+        assert call_kwargs["url"] == "https://example.com/sse?api_key=key123"
+        assert result is fake_transport
+
+    def test_query_auth_appends_custom_param_to_url(self):
+        """query auth must append the named query parameter to the transport URL."""
+        manager = _make_manager()
+        config = _sse_config(auth=Auth(type="query", value="token456", key="auth_token"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport",
+                return_value=fake_transport,
+            ) as MockSSE,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        call_kwargs = MockSSE.call_args.kwargs
+        assert call_kwargs["headers"] is None
+        assert call_kwargs["url"] == "https://example.com/sse?auth_token=token456"
         assert result is fake_transport
 
     def test_missing_url_raises(self):
@@ -161,3 +184,54 @@ class TestSSETransportAuth:
         with patch("cuga.backend.tools_env.registry.mcp_manager.mcp_manager.SSETransport", None):
             with pytest.raises(Exception, match="SSETransport not available"):
                 manager._create_transport("test_server", config)
+
+
+class TestHTTPTransportAuth:
+    """_create_transport('http') must forward auth headers and query params."""
+
+    def _http_config(self, auth: Auth | None = None, url: str = "https://example.com/mcp") -> ServiceConfig:
+        return ServiceConfig(url=url, transport="http", auth=auth)
+
+    def test_bearer_auth_sets_authorization_header(self):
+        manager = _make_manager()
+        config = self._http_config(auth=Auth(type="bearer", value="my-secret-token"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.StreamableHttpTransport",
+                return_value=fake_transport,
+            ) as MockHTTP,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        call_kwargs = MockHTTP.call_args.kwargs
+        assert call_kwargs["headers"] == {"Authorization": "Bearer my-secret-token"}
+        assert call_kwargs["url"] == config.url
+        assert result is fake_transport
+
+    def test_api_key_auth_appends_query_params_to_url(self):
+        manager = _make_manager()
+        config = self._http_config(auth=Auth(type="api-key", value="key123", key="api_key"))
+
+        fake_transport = MagicMock()
+        with (
+            patch(
+                "cuga.backend.tools_env.registry.mcp_manager.mcp_manager.StreamableHttpTransport",
+                return_value=fake_transport,
+            ) as MockHTTP,
+            patch(
+                "cuga.backend.secrets.resolve_secret",
+                side_effect=lambda v: v,
+            ),
+        ):
+            result = manager._create_transport("test_server", config)
+
+        call_kwargs = MockHTTP.call_args.kwargs
+        assert call_kwargs["headers"] is None
+        assert call_kwargs["url"] == "https://example.com/mcp?api_key=key123"
+        assert result is fake_transport


### PR DESCRIPTION
## Summary

Fixes #213

PR #208 added auth header support to `_create_transport` for SSE and HTTP transports, but `query_params` populated by `apply_authentication` (for `api-key` and `query` auth types) were never appended to the transport URL. This caused API-key-in-URL authentication to silently fail.

- URL-encode and append `query_params` to `config.url` before constructing `SSETransport` and `StreamableHttpTransport`
- Matches the existing pattern in `_call_mcp_server_tool`
- Extended regression tests to assert query params appear in the transport URL for both SSE and HTTP branches

## Test plan

- [x] `uv run pytest src/cuga/backend/tools_env/registry/mcp_manager/tests/test_sse_auth.py -v` (10 passed)
- [ ] Verify an MCP server configured with `api-key` auth connects successfully over SSE/HTTP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Authentication handling was corrected so auth-derived parameters are honored for both SSE and HTTP transport requests.
* API-key and query-based auth are now URL-encoded and appended/merged into existing transport URLs, while bearer auth is sent via request headers (leaving headers unset where applicable).

## Tests
* Added/expanded regression tests for SSE and HTTP transport authentication, including URL encoding and merging with pre-existing query parameters.

## Chores
* Updated the secrets baseline metadata/timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->