### PR TITLE
feat: make LLM HTTP timeouts configurable (#257)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ AGENT_SETTING_CONFIG="settings.groq.toml"
 # Optional: E2B sandbox
 # E2B_API_KEY="e2b_xxx"
 
-# Optional: LLM HTTP timeout (seconds) for slow/reasoning models
+# Optional: LLM HTTP timeout (seconds) for slow/reasoning models (OpenAI, Azure, OpenRouter only)
 # CUGA_LLM_HTTP_TIMEOUT=120
 
 # Knowledge engine is built-in — no external services needed.

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ AGENT_SETTING_CONFIG="settings.groq.toml"
 # Optional: E2B sandbox
 # E2B_API_KEY="e2b_xxx"
 
+# Optional: LLM HTTP timeout (seconds) for slow/reasoning models
+# CUGA_LLM_HTTP_TIMEOUT=120
+
 # Knowledge engine is built-in — no external services needed.
 # Configuration: see src/cuga/configurations/knowledge/knowledge_settings.toml
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-06-18T11:00:55Z",
+  "generated_at": "2026-06-22T08:29:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 662,
+        "line_number": 666,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-06-11T22:23:22Z",
+  "generated_at": "2026-06-18T11:00:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 662,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/cuga/backend/llm/config.py
+++ b/src/cuga/backend/llm/config.py
@@ -50,6 +50,12 @@ class LLMConfig(BaseModel):
         default=16000, gt=0, description="Maximum number of tokens in the response"
     )
 
+    timeout: Optional[float] = Field(
+        default=None,
+        gt=0,
+        description="HTTP timeout in seconds for LLM API requests (overrides global setting)",
+    )
+
     disable_ssl: bool = Field(
         default=False, description="Whether to disable SSL verification for API requests"
     )

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -1,3 +1,4 @@
+import math
 import re
 import threading
 from datetime import date
@@ -17,7 +18,7 @@ from loguru import logger
 
 from cuga.backend.llm.load_test_mock import clone_load_test_mock_chat_model, is_mock_llm_enabled
 from cuga.backend.secrets import resolve_secret
-from cuga.config import settings
+from cuga.config import DEFAULT_LLM_HTTP_TIMEOUT, settings
 
 
 class ReasoningChatOpenAI(ChatOpenAI):
@@ -75,7 +76,7 @@ except ImportError:
     ReasoningChatLiteLLM = None  # type: ignore[misc, assignment]
 
 _ENV_REF_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
-_DEFAULT_LLM_HTTP_TIMEOUT = 61
+_DEFAULT_LLM_HTTP_TIMEOUT = DEFAULT_LLM_HTTP_TIMEOUT
 
 
 def _parse_timeout(value: Any) -> Optional[float]:
@@ -85,7 +86,7 @@ def _parse_timeout(value: Any) -> Optional[float]:
         timeout = float(value)
     except (TypeError, ValueError):
         return None
-    if timeout <= 0:
+    if timeout <= 0 or not math.isfinite(timeout):
         return None
     return timeout
 
@@ -572,7 +573,10 @@ class LLMManager:
         return True
 
     def _get_http_timeout(self, model_settings: Dict[str, Any]) -> float:
-        """Return HTTP timeout (seconds) for LLM API clients.
+        """Return HTTP timeout (seconds) for OpenAI, Azure, and OpenRouter clients.
+
+        Other platforms (groq, watsonx, rits, google-genai, litellm) ignore this
+        setting until wired separately.
 
         Priority:
         1. timeout in model_settings (per-agent TOML)
@@ -595,8 +599,8 @@ class LLMManager:
             toml_timeout = _parse_timeout(settings.connections.llm_http_timeout)
             if toml_timeout is not None:
                 return toml_timeout
-        except Exception:
-            pass
+        except (AttributeError, TypeError) as exc:
+            logger.debug(f"Could not read connections.llm_http_timeout from settings: {exc}")
 
         return _DEFAULT_LLM_HTTP_TIMEOUT
 

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -75,6 +75,19 @@ except ImportError:
     ReasoningChatLiteLLM = None  # type: ignore[misc, assignment]
 
 _ENV_REF_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
+_DEFAULT_LLM_HTTP_TIMEOUT = 61
+
+
+def _parse_timeout(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return None
+    if timeout <= 0:
+        return None
+    return timeout
 
 
 def _normalize_secret(val: Optional[str]) -> Optional[str]:
@@ -255,6 +268,7 @@ class LLMManager:
             d['resolved_model_name'] = self._get_model_name(model_settings, platform)
             d['resolved_api_version'] = self._get_api_version(model_settings, platform)
             d['resolved_base_url'] = self._get_base_url(model_settings, platform)
+            d['resolved_http_timeout'] = self._get_http_timeout(model_settings)
 
         settings_str = json.dumps(d, sort_keys=True)
         return hashlib.md5(settings_str.encode()).hexdigest()
@@ -557,6 +571,35 @@ class LLMManager:
 
         return True
 
+    def _get_http_timeout(self, model_settings: Dict[str, Any]) -> float:
+        """Return HTTP timeout (seconds) for LLM API clients.
+
+        Priority:
+        1. timeout in model_settings (per-agent TOML)
+        2. CUGA_LLM_HTTP_TIMEOUT env var
+        3. LLM_HTTP_TIMEOUT env var
+        4. settings.connections.llm_http_timeout (TOML)
+        5. Default (_DEFAULT_LLM_HTTP_TIMEOUT)
+        """
+        per_model = _parse_timeout(model_settings.get("timeout"))
+        if per_model is not None:
+            return per_model
+
+        for env_var in ("CUGA_LLM_HTTP_TIMEOUT", "LLM_HTTP_TIMEOUT"):
+            env_val = _parse_timeout(os.environ.get(env_var))
+            if env_val is not None:
+                logger.debug(f"Using {env_var} from environment: {env_val}")
+                return env_val
+
+        try:
+            toml_timeout = _parse_timeout(settings.connections.llm_http_timeout)
+            if toml_timeout is not None:
+                return toml_timeout
+        except Exception:
+            pass
+
+        return _DEFAULT_LLM_HTTP_TIMEOUT
+
     def _is_reasoning_model(self, model_name: str) -> bool:
         """Check if model is a reasoning model that doesn't support temperature
 
@@ -577,6 +620,7 @@ class LLMManager:
         model_name = self._get_model_name(model_settings, platform)
         api_version = self._get_api_version(model_settings, platform)
         base_url = self._get_base_url(model_settings, platform)
+        http_timeout = self._get_http_timeout(model_settings)
         if platform == "azure":
             api_version = str(model_settings.get('api_version'))
             is_reasoning = self._is_reasoning_model(model_name)
@@ -585,7 +629,7 @@ class LLMManager:
                 logger.debug(f"Creating AzureChatOpenAI reasoning model: {model_name} (no temperature)")
                 llm = AzureChatOpenAI(
                     model_version=api_version,
-                    timeout=61,
+                    timeout=http_timeout,
                     api_version="2025-04-01-preview",
                     azure_deployment=model_name + "-" + api_version,
                     max_completion_tokens=max_tokens,
@@ -593,7 +637,7 @@ class LLMManager:
             else:
                 logger.debug(f"Creating AzureChatOpenAI model: {model_name} - {api_version}")
                 llm = AzureChatOpenAI(
-                    timeout=61,
+                    timeout=http_timeout,
                     azure_deployment=model_name + "-" + api_version,
                     temperature=temperature,
                     max_tokens=max_tokens,
@@ -604,7 +648,7 @@ class LLMManager:
             openai_params: Dict[str, Any] = {
                 "model_name": model_name,
                 "max_tokens": max_tokens,
-                "timeout": 61,
+                "timeout": http_timeout,
             }
 
             if not is_reasoning:
@@ -739,7 +783,7 @@ class LLMManager:
             openrouter_params: Dict[str, Any] = {
                 "model_name": model_name,
                 "max_tokens": max_tokens,
-                "timeout": 61,
+                "timeout": http_timeout,
                 "openai_api_key": api_key,
                 "openai_api_base": base_url,
             }

--- a/src/cuga/config.py
+++ b/src/cuga/config.py
@@ -200,6 +200,7 @@ validators = [
     Validator("evolve.save_on_failure", default=True),
     Validator("evolve.async_save", default=True),
     Validator("evolve.timeout", default=30.0),
+    Validator("connections.llm_http_timeout", default=61),
 ]
 
 EVAL_CONFIG_TOML_PATH = _find_config_file("eval_config.toml", "EVAL_CONFIG_TOML_PATH")

--- a/src/cuga/config.py
+++ b/src/cuga/config.py
@@ -12,6 +12,10 @@ from dotenv import find_dotenv, load_dotenv
 from dynaconf import Dynaconf, Validator
 from loguru import logger
 
+# Default HTTP timeout for OpenAI/Azure/OpenRouter LLM clients (seconds).
+# One second above common 60s gateway limits so the client fails cleanly first.
+DEFAULT_LLM_HTTP_TIMEOUT = 61
+
 # ---------------------------------------------------------------------------
 # Package root & path helper (must be defined BEFORE first use)
 # ---------------------------------------------------------------------------
@@ -200,7 +204,7 @@ validators = [
     Validator("evolve.save_on_failure", default=True),
     Validator("evolve.async_save", default=True),
     Validator("evolve.timeout", default=30.0),
-    Validator("connections.llm_http_timeout", default=61),
+    Validator("connections.llm_http_timeout", default=DEFAULT_LLM_HTTP_TIMEOUT),
 ]
 
 EVAL_CONFIG_TOML_PATH = _find_config_file("eval_config.toml", "EVAL_CONFIG_TOML_PATH")

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -207,6 +207,7 @@ trigger_fraction = 0.75  # Trigger at 75% of context window (recommended for pro
 [connections]
 inference_ca_cert = ""  # Path to a CA certificate for LLM inference HTTP clients (e.g. "vault-root-ca.crt"). Applied to OpenAI and LiteLLM. Env: CUGA_INFERENCE_CA_CERT
 inference_disable_ssl = false  # Disable SSL verification for all inference connections (overrides inference_ca_cert). Env: CUGA_DISABLE_SSL
+llm_http_timeout = 61  # HTTP timeout in seconds for LLM API requests (OpenAI, Azure, OpenRouter). Env: CUGA_LLM_HTTP_TIMEOUT or LLM_HTTP_TIMEOUT
 
 [observability]
 openlit = false  # Enable OpenLit LLM observability via OpenTelemetry (OTLP). Requires: pip install cuga[observability]

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -207,7 +207,7 @@ trigger_fraction = 0.75  # Trigger at 75% of context window (recommended for pro
 [connections]
 inference_ca_cert = ""  # Path to a CA certificate for LLM inference HTTP clients (e.g. "vault-root-ca.crt"). Applied to OpenAI and LiteLLM. Env: CUGA_INFERENCE_CA_CERT
 inference_disable_ssl = false  # Disable SSL verification for all inference connections (overrides inference_ca_cert). Env: CUGA_DISABLE_SSL
-llm_http_timeout = 61  # HTTP timeout in seconds for LLM API requests (OpenAI, Azure, OpenRouter). Env: CUGA_LLM_HTTP_TIMEOUT or LLM_HTTP_TIMEOUT
+llm_http_timeout = 61  # Seconds; OpenAI/Azure/OpenRouter only (see DEFAULT_LLM_HTTP_TIMEOUT in config.py). Env: CUGA_LLM_HTTP_TIMEOUT or LLM_HTTP_TIMEOUT
 
 [observability]
 openlit = false  # Enable OpenLit LLM observability via OpenTelemetry (OTLP). Requires: pip install cuga[observability]

--- a/tests/unit/test_llm_http_timeout.py
+++ b/tests/unit/test_llm_http_timeout.py
@@ -65,11 +65,13 @@ class TestGetHttpTimeout:
         mgr = LLMManager()
         assert mgr._get_http_timeout({}) == 150.0
 
-    def test_invalid_timeout_values_fall_back_to_default(self):
+    def test_invalid_timeout_values_fall_back_to_default(self, monkeypatch):
         mgr = LLMManager()
-        assert mgr._get_http_timeout({"timeout": "not-a-number"}) == _DEFAULT_LLM_HTTP_TIMEOUT
-        assert mgr._get_http_timeout({"timeout": 0}) == _DEFAULT_LLM_HTTP_TIMEOUT
-        assert mgr._get_http_timeout({"timeout": -5}) == _DEFAULT_LLM_HTTP_TIMEOUT
+        for invalid in ("not-a-number", 0, -5, "NaN", "inf", "Infinity"):
+            assert mgr._get_http_timeout({"timeout": invalid}) == _DEFAULT_LLM_HTTP_TIMEOUT
+        for env_val in ("NaN", "inf"):
+            monkeypatch.setenv("CUGA_LLM_HTTP_TIMEOUT", env_val)
+            assert mgr._get_http_timeout({}) == _DEFAULT_LLM_HTTP_TIMEOUT
 
 
 class TestHttpTimeoutPassedToClients:

--- a/tests/unit/test_llm_http_timeout.py
+++ b/tests/unit/test_llm_http_timeout.py
@@ -1,0 +1,115 @@
+"""Tests for configurable LLM HTTP timeout in LLMManager."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cuga.backend.llm.models import (
+    LLMManager,
+    _DEFAULT_LLM_HTTP_TIMEOUT,
+    set_current_llm_override,
+)
+
+BASE_MODEL_SETTINGS = {
+    "platform": "openai",
+    "model": "gpt-4o-mini",
+    "max_tokens": 100,
+    "temperature": 0.1,
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_llm_state():
+    mgr = LLMManager()
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+    for key in ("CUGA_LLM_HTTP_TIMEOUT", "LLM_HTTP_TIMEOUT"):
+        os.environ.pop(key, None)
+    yield
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+    for key in ("CUGA_LLM_HTTP_TIMEOUT", "LLM_HTTP_TIMEOUT"):
+        os.environ.pop(key, None)
+
+
+class TestGetHttpTimeout:
+    def test_default_timeout(self):
+        mgr = LLMManager()
+        assert mgr._get_http_timeout({}) == _DEFAULT_LLM_HTTP_TIMEOUT
+
+    def test_model_settings_timeout(self):
+        mgr = LLMManager()
+        assert mgr._get_http_timeout({"timeout": 120}) == 120.0
+
+    def test_model_settings_timeout_beats_env(self, monkeypatch):
+        monkeypatch.setenv("CUGA_LLM_HTTP_TIMEOUT", "180")
+        mgr = LLMManager()
+        assert mgr._get_http_timeout({"timeout": 90}) == 90.0
+
+    def test_cuga_env_var(self, monkeypatch):
+        monkeypatch.setenv("CUGA_LLM_HTTP_TIMEOUT", "180")
+        mgr = LLMManager()
+        assert mgr._get_http_timeout({}) == 180.0
+
+    def test_llm_http_timeout_env_var(self, monkeypatch):
+        monkeypatch.setenv("LLM_HTTP_TIMEOUT", "240")
+        mgr = LLMManager()
+        assert mgr._get_http_timeout({}) == 240.0
+
+    def test_cuga_env_beats_llm_http_timeout_env(self, monkeypatch):
+        monkeypatch.setenv("CUGA_LLM_HTTP_TIMEOUT", "150")
+        monkeypatch.setenv("LLM_HTTP_TIMEOUT", "240")
+        mgr = LLMManager()
+        assert mgr._get_http_timeout({}) == 150.0
+
+    def test_invalid_timeout_values_fall_back_to_default(self):
+        mgr = LLMManager()
+        assert mgr._get_http_timeout({"timeout": "not-a-number"}) == _DEFAULT_LLM_HTTP_TIMEOUT
+        assert mgr._get_http_timeout({"timeout": 0}) == _DEFAULT_LLM_HTTP_TIMEOUT
+        assert mgr._get_http_timeout({"timeout": -5}) == _DEFAULT_LLM_HTTP_TIMEOUT
+
+
+class TestHttpTimeoutPassedToClients:
+    def test_openai_client_receives_timeout(self):
+        with patch("cuga.backend.llm.models.ReasoningChatOpenAI") as mock_openai:
+            with patch.object(LLMManager, "_get_auth_headers", return_value={"Authorization": "Bearer x"}):
+                mock_openai.return_value = object()
+                mgr = LLMManager()
+                mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "timeout": 120})
+
+        assert mock_openai.call_args.kwargs["timeout"] == 120.0
+
+    def test_openrouter_client_receives_timeout(self):
+        with patch("cuga.backend.llm.models.resolve_secret", return_value="dummy"):
+            with patch("cuga.backend.llm.models.ReasoningChatOpenAI") as mock_openai:
+                mock_openai.return_value = object()
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {
+                        **BASE_MODEL_SETTINGS,
+                        "platform": "openrouter",
+                        "model": "anthropic/claude-3.5-sonnet",
+                        "timeout": 200,
+                    }
+                )
+
+        assert mock_openai.call_args.kwargs["timeout"] == 200.0
+
+    def test_azure_client_receives_timeout(self):
+        with patch("cuga.backend.llm.models.AzureChatOpenAI") as mock_azure:
+            mock_azure.return_value = object()
+            mgr = LLMManager()
+            mgr._create_llm_instance(
+                {
+                    **BASE_MODEL_SETTINGS,
+                    "platform": "azure",
+                    "model": "gpt-4o",
+                    "api_version": "2024-08-06",
+                    "timeout": 300,
+                }
+            )
+
+        assert mock_azure.call_args.kwargs["timeout"] == 300.0


### PR DESCRIPTION
## Summary
- Adds `_get_http_timeout()` to `LLMManager` so OpenAI, Azure, and OpenRouter clients no longer use a hardcoded 61s timeout
- Supports configuration via per-model `timeout` in agent TOML, `CUGA_LLM_HTTP_TIMEOUT` / `LLM_HTTP_TIMEOUT` env vars, or global `connections.llm_http_timeout` in `settings.toml`
- Includes unit tests covering resolution priority and client wiring

Fixes #257

## Test plan
- [x] `uv run pytest tests/unit/test_llm_http_timeout.py -v` (10 passed)
- [ ] Set `CUGA_LLM_HTTP_TIMEOUT=120` and confirm slow/reasoning model calls no longer time out at 61s
- [ ] Optionally set per-agent timeout in model TOML, e.g. `[agent.code.model] timeout = 180`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP timeouts for LLM API requests, with a 61-second default.
  * Timeout can be set via model `timeout`, environment variables (`CUGA_LLM_HTTP_TIMEOUT`, `LLM_HTTP_TIMEOUT`), or `connections.llm_http_timeout`, with the effective value passed to supported LLM providers.

* **Tests**
  * Added unit coverage for timeout precedence, parsing/validation of invalid values, and verification that clients receive the resolved timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->