### PR TITLE
docs: date AppWorld and WebArena #1 benchmark claims in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Building a domain-specific enterprise agent from scratch is complex and requires
 [![Documentation](https://shields.io/badge/Documentation-Available-blue?logo=gitbook&style=for-the-badge)](https://docs.cuga.dev)
 [![Discord](https://shields.io/badge/Discord-Join-blue?logo=discord&style=for-the-badge)](https://discord.gg/aH6rAEEW)
 
-[![AppWorld](https://img.shields.io/badge/%F0%9F%A5%88%20%232%20on-AppWorld-silver?style=for-the-badge)](https://appworld.dev/leaderboard)
-[![WebArena](https://img.shields.io/badge/Top--tier%20on-WebArena-silver?style=for-the-badge)](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ/edit?gid=0#gid=0)
+[![AppWorld](https://img.shields.io/badge/%F0%9F%A5%87%20%231%20(07%2F25-02%2F26)%20on-AppWorld-gold?style=for-the-badge)](https://appworld.dev/leaderboard)
+[![WebArena](https://img.shields.io/badge/%F0%9F%A5%87%20%231%20(02%2F25-09%2F25)%20on-WebArena-gold?style=for-the-badge)](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ/edit?gid=0#gid=0)
 
 </div>
 
@@ -56,8 +56,8 @@ Building a domain-specific enterprise agent from scratch is complex and requires
 
 CUGA achieves state-of-the-art performance on leading benchmarks:
 
-- **#2 on [AppWorld](https://appworld.dev/leaderboard)** — a benchmark with 750 real-world tasks across 457 APIs
-- **Top-tier on [WebArena](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ/edit?gid=0#gid=0)** (#1 from 02/25 - 09/25) — a complex benchmark for autonomous web agents across application domains
+- **#1 on [AppWorld](https://appworld.dev/leaderboard)** (#1 from 07/25 - 02/26) — a benchmark with 750 real-world tasks across 457 APIs
+- **#1 on [WebArena](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ/edit?gid=0#gid=0)** (#1 from 02/25 - 09/25) — a complex benchmark for autonomous web agents across application domains
 
 ### Key Features & Capabilities
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Building a domain-specific enterprise agent from scratch is complex and requires
 [![Documentation](https://shields.io/badge/Documentation-Available-blue?logo=gitbook&style=for-the-badge)](https://docs.cuga.dev)
 [![Discord](https://shields.io/badge/Discord-Join-blue?logo=discord&style=for-the-badge)](https://discord.gg/aH6rAEEW)
 
-[![AppWorld](https://img.shields.io/badge/%F0%9F%A5%87%20%231%20on-AppWorld-gold?style=for-the-badge)](https://appworld.dev/leaderboard)
+[![AppWorld](https://img.shields.io/badge/%F0%9F%A5%88%20%232%20on-AppWorld-silver?style=for-the-badge)](https://appworld.dev/leaderboard)
 [![WebArena](https://img.shields.io/badge/Top--tier%20on-WebArena-silver?style=for-the-badge)](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ/edit?gid=0#gid=0)
 
 </div>
@@ -56,7 +56,7 @@ Building a domain-specific enterprise agent from scratch is complex and requires
 
 CUGA achieves state-of-the-art performance on leading benchmarks:
 
-- **#1 on [AppWorld](https://appworld.dev/leaderboard)** — a benchmark with 750 real-world tasks across 457 APIs
+- **#2 on [AppWorld](https://appworld.dev/leaderboard)** — a benchmark with 750 real-world tasks across 457 APIs
 - **Top-tier on [WebArena](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ/edit?gid=0#gid=0)** (#1 from 02/25 - 09/25) — a complex benchmark for autonomous web agents across application domains
 
 ### Key Features & Capabilities

--- a/src/cuga/demo_tools/huggingface/cuga_knowledge.md
+++ b/src/cuga/demo_tools/huggingface/cuga_knowledge.md
@@ -124,8 +124,8 @@ Customize:
 
 ### Performance
 
-* **🥇 #1 on AppWorld** (750 tasks, 457 APIs)
-* **Top-tier on WebArena**, #1 from Feb–Sep 2025
+* **🥇 #1 on AppWorld** (#1 from 07/25 - 02/26; 750 tasks, 457 APIs)
+* **🥇 #1 on WebArena** (#1 from 02/25 - 09/25)
 
 ### Why It Matters
 


### PR DESCRIPTION
## Summary
- Date the AppWorld claim as **#1 from 07/25 - 02/26** (CUGA submitted 2025-07-12; overtaken 2026-02-15 per [AppWorld leaderboard](https://appworld.dev/leaderboard.json))
- Align the WebArena claim as **#1 from 02/25 - 09/25** in both the badge and benchmark section
- Use dated periods instead of a current rank so README stays accurate as leaderboards change

## Test plan
- [x] Verified AppWorld period against leaderboard.json submission dates
- [x] Verified WebArena period matches existing documented range
- [x] Badge URLs encode date ranges correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the leaderboard ranking badges and references in the main README status strip, including rank and date-range qualifiers.
  * Refreshed the “Benchmark Performance” section to reflect the latest AppWorld and WebArena `#1` entries with the correct date ranges.
  * Adjusted the CUGA knowledge base performance benchmark bullets with the updated AppWorld/WebArena `#1` formatting and date-range details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->