### PR TITLE
feat: add full supervisor policy runtime for tool approval and output formatter

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/policy/tool_approval_handler.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/policy/tool_approval_handler.py
@@ -187,6 +187,7 @@ class ToolApprovalHandler:
             code_preview=preview_lines,
             full_code=code,
             approval_message=approval_msg,
+            return_to=adapter.sender_name,
         )
 
         final_answer_text = ToolApprovalHandler._generate_approval_message(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/policy/tool_approval_handler.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/policy/tool_approval_handler.py
@@ -79,7 +79,7 @@ class ToolApprovalHandler:
         """Handle resumption after user approval: run the approved code."""
         logger.info("Returning from tool approval - skipping code generation, executing approved code")
 
-        code = ToolApprovalHandler.extract_approved_code(adapter, state)
+        code = getattr(state, "script", None) or ToolApprovalHandler.extract_approved_code(adapter, state)
 
         if not code:
             logger.error("Could not extract code from last AI message after approval")

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/policy/test_tool_approval_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/policy/test_tool_approval_adapter.py
@@ -169,3 +169,30 @@ def test_handle_approval_resumption_supervisor_seams():
     assert cmd.goto == "execute_agent_tool"
     assert "supervisor_metadata" in cmd.update
     assert cmd.update["script"] == "print('go')"
+
+
+def _hitl_return_to(adapter, metadata_key, messages_key):
+    st = SimpleNamespace(
+        **{
+            messages_key: [],
+            metadata_key: {
+                "policy_name": "P",
+                "required_tools": ["t1"],
+                "approval_message": "Approve",
+            },
+            "step_count": 0,
+        }
+    )
+    cmd = ToolApprovalHandler._create_approval_interrupt(adapter, st, "print('x')", "content", ["print('x')"])
+    return cmd.update["hitl_action"].return_to
+
+
+def test_create_approval_interrupt_return_to_supervisor():
+    assert (
+        _hitl_return_to(SupLikeAdapter(), "supervisor_metadata", "supervisor_chat_messages")
+        == "CugaSupervisor"
+    )
+
+
+def test_create_approval_interrupt_return_to_lite():
+    assert _hitl_return_to(LiteLikeAdapter(), "cuga_lite_metadata", "chat_messages") == "CugaLite"

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/nodes/prepare_agents_and_prompt.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/nodes/prepare_agents_and_prompt.py
@@ -266,6 +266,8 @@ def create_prepare_agents_and_prompt_node(adapter: Any) -> Callable:
                 for agent in agent_list
             },
         }
+        if adapter.get_metadata(state):
+            update_payload[adapter.metadata_key] = adapter.get_metadata(state)
         if is_fresh_conversation:
             update_payload["task_todos"] = None
 

--- a/src/cuga/backend/cuga_graph/nodes/human_in_the_loop/followup_model.py
+++ b/src/cuga/backend/cuga_graph/nodes/human_in_the_loop/followup_model.py
@@ -121,6 +121,7 @@ def create_tool_approval_action(
     code_preview: List[str],
     full_code: str,
     approval_message: str = None,
+    return_to: str = "CugaLite",
 ) -> FollowUpAction:
     """
     Create a tool approval follow-up action.
@@ -156,7 +157,7 @@ def create_tool_approval_action(
     return FollowUpAction(
         action_name=f"Approve Tool Execution - {policy_name}",
         action_id=ActionIds.TOOL_APPROVAL,
-        return_to="CugaLite",
+        return_to=return_to,
         additional_data=AdditionalData(
             tool={
                 "required_tools": required_tools,

--- a/src/cuga/backend/cuga_graph/policy/configurable.py
+++ b/src/cuga/backend/cuga_graph/policy/configurable.py
@@ -267,9 +267,13 @@ class PolicyConfigurable:
         """
         configurable = config.get("configurable", {}) if config else {}
 
-        # Extract common fields from state
-        user_input = getattr(state, "intent", None) or getattr(state, "goal", None)
-        chat_messages = getattr(state, "chat_messages", None)
+        # Extract common fields from state (supervisor uses input + supervisor_chat_messages)
+        user_input = (
+            getattr(state, "intent", None) or getattr(state, "goal", None) or getattr(state, "input", None)
+        )
+        chat_messages = getattr(state, "chat_messages", None) or getattr(
+            state, "supervisor_chat_messages", None
+        )
 
         # If no user_input but we have chat_messages, extract the last user message
         # Skip messages that contain execution output (for OUTPUT_FORMATTER policies)

--- a/src/cuga/backend/cuga_graph/policy/output_formatter_utils.py
+++ b/src/cuga/backend/cuga_graph/policy/output_formatter_utils.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 async def apply_output_formatter_policies(
-    state: AgentState, config: Optional[RunnableConfig] = None, context: str = "unknown"
+    state: AgentState,
+    config: Optional[RunnableConfig] = None,
+    context: str = "unknown",
+    metadata_key: str = "cuga_lite_metadata",
 ) -> None:
     """
     Apply OutputFormatter policies to the final answer.
@@ -54,18 +57,23 @@ async def apply_output_formatter_policies(
             state.final_answer = formatted_response
 
             # Store consistent metadata structure for UI display
-            _update_output_formatter_metadata(state, metadata)
+            _update_output_formatter_metadata(state, metadata, metadata_key=metadata_key)
 
         elif metadata:
             logger.debug(f"{context}: OutputFormatter metadata returned but no formatted_response")
             # Store metadata even if no formatted_response (for UI display)
-            _update_output_formatter_metadata(state, metadata, applied=False)
+            _update_output_formatter_metadata(state, metadata, applied=False, metadata_key=metadata_key)
 
     except Exception as e:
         logger.warning(f"{context}: Error checking OutputFormatter policies: {e}", exc_info=True)
 
 
-def _update_output_formatter_metadata(state: AgentState, metadata: dict, applied: bool = True) -> None:
+def _update_output_formatter_metadata(
+    state: AgentState,
+    metadata: dict,
+    applied: bool = True,
+    metadata_key: str = "cuga_lite_metadata",
+) -> None:
     """
     Update state metadata with OutputFormatter policy information.
 
@@ -74,9 +82,8 @@ def _update_output_formatter_metadata(state: AgentState, metadata: dict, applied
         metadata: Policy enactment metadata
         applied: Whether the formatter was actually applied (True) or just matched (False)
     """
-    # Initialize cuga_lite_metadata if it doesn't exist
-    if not hasattr(state, 'cuga_lite_metadata') or state.cuga_lite_metadata is None:
-        state.cuga_lite_metadata = {}
+    if not hasattr(state, metadata_key) or getattr(state, metadata_key) is None:
+        setattr(state, metadata_key, {})
 
     # Base metadata that's always included
     base_metadata = {
@@ -101,5 +108,4 @@ def _update_output_formatter_metadata(state: AgentState, metadata: dict, applied
             }
         )
 
-    # Update the state metadata
-    state.cuga_lite_metadata.update(base_metadata)
+    getattr(state, metadata_key).update(base_metadata)

--- a/src/cuga/backend/cuga_graph/policy/output_formatter_utils.py
+++ b/src/cuga/backend/cuga_graph/policy/output_formatter_utils.py
@@ -32,6 +32,9 @@ async def apply_output_formatter_policies(
         state: Current agent state with final_answer set
         config: Optional LangGraph config (may contain policy_system)
         context: Context identifier for logging ("sdk", "cuga_lite", etc.)
+        metadata_key: State attribute for policy metadata. Default matches legacy
+            ``AgentState.cuga_lite_metadata``; callers (e.g. supervisor) should pass
+            their own key (``supervisor_metadata``).
     """
     if not settings.policy.enabled or not hasattr(state, 'final_answer') or not state.final_answer:
         return

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -2911,6 +2911,7 @@ class CugaSupervisor:
                         f"**{policy_name}**. The supervisor will not proceed with this task."
                     )
                     state.execution_complete = True
+                    state.hitl_action = None
                     state.hitl_response = None
                     state.sender = callback_name
                     return Command(update=state.model_dump(), goto=END)
@@ -3013,21 +3014,21 @@ class CugaSupervisor:
         import uuid
         from langchain_core.messages import HumanMessage
 
-        # Setup config
-        if not thread_id:
-            thread_id = f"supervisor_{uuid.uuid4().hex[:8]}"
-            logger.debug(f"Auto-generated thread_id: {thread_id}")
+        is_resume = message is None or action_response is not None
+        if is_resume and not thread_id:
+            raise ValueError(
+                "thread_id is required when resuming execution (message=None or action_response provided)"
+            )
 
-        config = {"configurable": {"thread_id": thread_id}}
+        config = {"configurable": {}}
         if self._callbacks:
             config["callbacks"] = self._callbacks
         if self._policy_system:
             config["configurable"]["policy_system"] = self._policy_system
 
         # Handle resume case
-        if message is None or action_response is not None:
-            if not thread_id:
-                raise ValueError("thread_id is required when resuming execution")
+        if is_resume:
+            config["configurable"]["thread_id"] = thread_id
 
             # Set session.id for OpenLit observability (if enabled)
             set_session_attribute(thread_id)
@@ -3045,6 +3046,12 @@ class CugaSupervisor:
             else:
                 result = await self.graph.ainvoke(None, config=config)
         else:
+            if not thread_id:
+                thread_id = f"supervisor_{uuid.uuid4().hex[:8]}"
+                logger.debug(f"Auto-generated thread_id: {thread_id}")
+
+            config["configurable"]["thread_id"] = thread_id
+
             # Normal invocation
             from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_state import (
                 CugaSupervisorState,

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -2861,6 +2861,103 @@ class CugaSupervisor:
             await self.policies._ensure_policy_system()
             logger.debug("Supervisor policy system initialized during initialize()")
 
+    def _create_supervisor_hitl_wrapper_graph(self):
+        """Wrap the supervisor subgraph with HITL + output-formatter callback (parity with CugaAgent)."""
+        from typing import Literal
+
+        from langgraph.graph import END, START, StateGraph
+        from langgraph.types import Command
+
+        from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_graph import (
+            create_cuga_supervisor_graph,
+        )
+        from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_state import (
+            CugaSupervisorState,
+        )
+        from cuga.backend.cuga_graph.nodes.human_in_the_loop.suggest_actions import SuggestHumanActions
+        from cuga.backend.cuga_graph.nodes.human_in_the_loop.wait_for_response import WaitForResponse
+        from cuga.backend.cuga_graph.utils.nodes_names import ActionIds, NodeNames
+
+        callback_name = "SupervisorSDKCallback"
+
+        supervisor_subgraph = create_cuga_supervisor_graph(
+            supervisor_model=self._model,
+            agents=self._agents,
+            special_instructions=self._special_instructions,
+            tool_provider=self.tool_provider,
+            callbacks=self._callbacks,
+        )
+        compiled_subgraph = supervisor_subgraph.compile()
+
+        async def supervisor_sdk_callback(
+            state: CugaSupervisorState,
+            config: Optional[RunnableConfig] = None,
+        ) -> Command[Literal["SupervisorSubgraph", "SuggestHumanActions", "__end__"]]:
+            if state.sender == NodeNames.WAIT_FOR_RESPONSE and state.hitl_response:
+                if state.hitl_response.action_id == ActionIds.TOOL_APPROVAL:
+                    if state.hitl_response.confirmed:
+                        md = dict(state.supervisor_metadata or {})
+                        md.update({"approval_required": False, "user_approved": True})
+                        state.supervisor_metadata = md
+                        state.hitl_action = None
+                        state.hitl_response = None
+                        state.final_answer = ""
+                        state.execution_complete = False
+                        state.sender = callback_name
+                        return Command(update=state.model_dump(), goto="SupervisorSubgraph")
+                    policy_name = (state.supervisor_metadata or {}).get("policy_name", "Tool Approval")
+                    state.final_answer = (
+                        f"❌ **Execution Cancelled**\n\nYou denied execution required by "
+                        f"**{policy_name}**. The supervisor will not proceed with this task."
+                    )
+                    state.execution_complete = True
+                    state.hitl_response = None
+                    state.sender = callback_name
+                    return Command(update=state.model_dump(), goto=END)
+
+            if state.hitl_action and state.hitl_action.action_id == ActionIds.TOOL_APPROVAL:
+                state.sender = callback_name
+                return Command(update=state.model_dump(), goto=NodeNames.SUGGEST_HUMAN_ACTIONS)
+
+            from cuga.backend.cuga_graph.policy.output_formatter_utils import apply_output_formatter_policies
+
+            await apply_output_formatter_policies(
+                state,
+                config,
+                context="Supervisor SDK Callback",
+                metadata_key="supervisor_metadata",
+            )
+
+            state.sender = callback_name
+            return Command(update=state.model_dump(), goto=END)
+
+        suggest_actions = SuggestHumanActions()
+        wait_for_response = WaitForResponse()
+
+        async def dummy_route_to_callback(
+            state: CugaSupervisorState,
+            config: Optional[RunnableConfig] = None,
+        ) -> Command:
+            return Command(update=state.model_dump(), goto=callback_name)
+
+        wrapper = StateGraph(CugaSupervisorState)
+        wrapper.add_node("SupervisorSubgraph", compiled_subgraph)
+        wrapper.add_node(callback_name, supervisor_sdk_callback)
+        wrapper.add_node(suggest_actions.name, suggest_actions.node)
+        wrapper.add_node(wait_for_response.name, wait_for_response.node)
+        for node_name in (
+            "FinalAnswerAgent",
+            NodeNames.CHAT_AGENT,
+            NodeNames.API_PLANNER_AGENT,
+            NodeNames.CUGA_LITE,
+        ):
+            wrapper.add_node(node_name, dummy_route_to_callback)
+
+        wrapper.add_edge(START, "SupervisorSubgraph")
+        wrapper.add_edge("SupervisorSubgraph", callback_name)
+
+        return wrapper
+
     @property
     def graph(self):
         """
@@ -2870,24 +2967,19 @@ class CugaSupervisor:
             Compiled LangGraph graph
         """
         if self._compiled_graph is None:
-            from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_graph import (
-                create_cuga_supervisor_graph,
-            )
             from langgraph.checkpoint.memory import MemorySaver
 
-            # Create supervisor subgraph
-            supervisor_subgraph = create_cuga_supervisor_graph(
-                supervisor_model=self._model,
-                agents=self._agents,
-                special_instructions=self._special_instructions,
-                tool_provider=self.tool_provider,
-                callbacks=self._callbacks,
-            )
+            from cuga.backend.cuga_graph.utils.nodes_names import NodeNames
 
-            # Compile with checkpointer
+            if self._graph is None:
+                self._graph = self._create_supervisor_hitl_wrapper_graph()
+
             checkpointer = MemorySaver()
-            self._compiled_graph = supervisor_subgraph.compile(checkpointer=checkpointer)
-            logger.debug("Compiled supervisor graph with checkpointer")
+            self._compiled_graph = self._graph.compile(
+                checkpointer=checkpointer,
+                interrupt_before=[NodeNames.WAIT_FOR_RESPONSE],
+            )
+            logger.debug("Compiled supervisor graph with HITL wrapper and checkpointer")
 
         return self._compiled_graph
 
@@ -2940,13 +3032,18 @@ class CugaSupervisor:
             # Set session.id for OpenLit observability (if enabled)
             set_session_attribute(thread_id)
 
+            from langgraph.types import Command
+
             if action_response:
-                self.graph.update_state(config, {"hitl_response": action_response})
                 logger.info(
                     f"Resuming execution after HITL response (action_id: {action_response.action_id})"
                 )
-
-            result = await self.graph.ainvoke(None, config=config)
+                result = await self.graph.ainvoke(
+                    Command(resume=action_response.model_dump()),
+                    config=config,
+                )
+            else:
+                result = await self.graph.ainvoke(None, config=config)
         else:
             # Normal invocation
             from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_state import (
@@ -2977,6 +3074,18 @@ class CugaSupervisor:
         if not final_answer and result.get("error"):
             error_msg = result["error"]
             final_answer = f"Error: {error_msg}"
+
+        if not final_answer:
+            try:
+                state = self.graph.get_state(config)
+                if state.next:
+                    logger.info("Supervisor graph interrupted for human-in-the-loop interaction")
+                    final_answer = (
+                        "⏸️ Execution paused for approval. "
+                        "Use supervisor.invoke(None, thread_id=..., action_response=...) to resume."
+                    )
+            except Exception as e:
+                logger.debug(f"Could not check supervisor interrupt state: {e}")
 
         # Get tool calls if available
         tool_calls = (

--- a/src/cuga/sdk_core/tests/test_supervisor_policies.py
+++ b/src/cuga/sdk_core/tests/test_supervisor_policies.py
@@ -1,20 +1,28 @@
 """SDK policy tests for CugaSupervisor.
 
-Mirrors ``test_sdk_policies.py`` to verify the supervisor exposes the same
-policy management API as CugaAgent.
+Mirrors ``test_sdk_policies.py`` for CRUD parity and adds invoke-level e2e tests
+that verify each policy type is enforced during supervisor execution (intent guard,
+playbook sub-agent orchestration, tool guide, tool approval, output formatter CRUD).
 """
 
 import pytest
 import pytest_asyncio
+from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 
-from cuga import CugaSupervisor
+from cuga import CugaAgent, CugaSupervisor
+from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_state import CugaSupervisorState
+from cuga.backend.cuga_graph.policy.configurable import PolicyConfigurable
 
 
 @pytest_asyncio.fixture(autouse=True, scope="function")
 async def clean_policy_storage():
     """Clean up policy storage before each test to ensure isolation."""
-    supervisor = CugaSupervisor(agents={})
+    supervisor = CugaSupervisor(
+        agents={},
+        auto_load_policies=False,
+        filesystem_sync=False,
+    )
 
     policies = await supervisor.policies.list()
     for policy in policies:
@@ -45,10 +53,62 @@ def calculate_sum(a: int, b: int) -> int:
     return a + b
 
 
+@tool
+def get_user_id(name: str) -> str:
+    """Get the internal user ID for a given name."""
+    if name.lower() == "alice":
+        return "user_alice_99"
+    return "unknown_user"
+
+
+@tool
+def get_user_account_value(user_id: str) -> int:
+    """Get the account value for a specific user ID."""
+    if user_id == "user_alice_99":
+        return 1500
+    return 0
+
+
+def _isolated_supervisor(**kwargs) -> CugaSupervisor:
+    """Supervisor with an isolated policy store (no auto-load from .cuga)."""
+    return CugaSupervisor(
+        auto_load_policies=False,
+        reset_policy_storage=True,
+        filesystem_sync=False,
+        cuga_lite_max_steps=120,
+        **kwargs,
+    )
+
+
+def _graph_values(supervisor: CugaSupervisor, thread_id: str) -> dict:
+    state = supervisor.graph.get_state({"configurable": {"thread_id": thread_id}})
+    return state.values if state else {}
+
+
+def _onboarding_agents() -> dict[str, CugaAgent]:
+    user_finder = CugaAgent(
+        tools=[get_user_id],
+        auto_load_policies=False,
+        reset_policy_storage=True,
+        filesystem_sync=False,
+    )
+    user_finder.description = "Agent that finds user IDs"
+
+    account_manager = CugaAgent(
+        tools=[get_user_account_value],
+        auto_load_policies=False,
+        reset_policy_storage=True,
+        filesystem_sync=False,
+    )
+    account_manager.description = "Agent that finds account values"
+
+    return {"user_finder": user_finder, "account_manager": account_manager}
+
+
 class TestSupervisorToolApprovalPolicy:
     @pytest.mark.asyncio
     async def test_tool_approval_policy_basic(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
 
         policy_id = await supervisor.policies.add_tool_approval(
             name="Approve Delete Operations",
@@ -68,7 +128,7 @@ class TestSupervisorToolApprovalPolicy:
 class TestSupervisorPlaybookPolicy:
     @pytest.mark.asyncio
     async def test_playbook_policy_with_keywords(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
 
         policy_id = await supervisor.policies.add_playbook(
             name="Customer Onboarding",
@@ -88,7 +148,7 @@ class TestSupervisorPlaybookPolicy:
 class TestSupervisorIntentGuardPolicy:
     @pytest.mark.asyncio
     async def test_intent_guard_with_keywords(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
 
         policy_id = await supervisor.policies.add_intent_guard(
             name="Block Delete Operations",
@@ -107,7 +167,7 @@ class TestSupervisorIntentGuardPolicy:
 class TestSupervisorToolGuidePolicy:
     @pytest.mark.asyncio
     async def test_tool_guide_basic(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
 
         policy_id = await supervisor.policies.add_tool_guide(
             name="Email Security Guidelines",
@@ -126,7 +186,7 @@ class TestSupervisorToolGuidePolicy:
 class TestSupervisorOutputFormatterPolicy:
     @pytest.mark.asyncio
     async def test_output_formatter_basic(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
 
         policy_id = await supervisor.policies.add_output_formatter(
             name="Summary Formatter",
@@ -142,7 +202,7 @@ class TestSupervisorOutputFormatterPolicy:
 class TestSupervisorPolicyManagement:
     @pytest.mark.asyncio
     async def test_list_multiple_policy_types(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
 
         await supervisor.policies.add_intent_guard(
             name="Guard 1",
@@ -184,7 +244,7 @@ class TestSupervisorPolicyManagement:
 
     @pytest.mark.asyncio
     async def test_delete_policy(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
 
         policy_id = await supervisor.policies.add_intent_guard(
             name="Temporary Guard",
@@ -198,12 +258,12 @@ class TestSupervisorPolicyManagement:
 
     @pytest.mark.asyncio
     async def test_get_nonexistent_policy(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
         assert await supervisor.policies.get("nonexistent_policy_id") is None
 
     @pytest.mark.asyncio
     async def test_policies_property_returns_same_manager(self):
-        supervisor = CugaSupervisor(agents={})
+        supervisor = _isolated_supervisor(agents={})
         assert supervisor.policies is supervisor.policies
 
 
@@ -235,3 +295,172 @@ class TestSupervisorPolicyInitialization:
         monkeypatch.setattr(supervisor.policies, "_ensure_policy_system", fake_ensure)
         await supervisor.initialize()
         assert called["value"] is False
+
+
+class TestSupervisorPolicyContext:
+    def test_create_context_from_supervisor_state(self):
+        """Supervisor state uses input + supervisor_chat_messages for policy matching."""
+        state = CugaSupervisorState(
+            supervisor_chat_messages=[HumanMessage(content="delete all records")],
+            input="delete all records",
+            thread_id="ctx_test",
+            url="",
+        )
+        context = PolicyConfigurable.create_context_from_state(state, {"configurable": {}})
+        assert context.user_input == "delete all records"
+        assert context.chat_messages == ["delete all records"]
+
+
+class TestSupervisorPolicyE2E:
+    """Invoke-level e2e tests: policies must affect supervisor runtime, not just CRUD."""
+
+    @pytest.mark.asyncio
+    async def test_e2e_intent_guard_blocks_invoke(self):
+        worker = CugaAgent(
+            tools=[delete_record],
+            auto_load_policies=False,
+            reset_policy_storage=True,
+            filesystem_sync=False,
+        )
+        supervisor = _isolated_supervisor(agents={"worker": worker})
+
+        await supervisor.policies.add_intent_guard(
+            name="Block Delete Operations",
+            keywords=["delete", "remove"],
+            response="POLICY_BLOCK: Deletion operations are not permitted.",
+        )
+
+        result = await supervisor.invoke("delete all customer records")
+        values = _graph_values(supervisor, result.thread_id)
+        metadata = values.get("supervisor_metadata") or {}
+
+        assert "POLICY_BLOCK" in result.answer
+        assert metadata.get("policy_blocked") is True
+        assert metadata.get("policy_type") == "intent_guard"
+        assert values.get("selected_agents") == []
+
+    @pytest.mark.asyncio
+    async def test_e2e_playbook_orchestrates_sub_agents(self):
+        supervisor = _isolated_supervisor(
+            agents=_onboarding_agents(),
+            special_instructions=(
+                "When onboarding, delegate to user_finder first, then account_manager. "
+                "Do not ask clarifying questions."
+            ),
+        )
+
+        await supervisor.policies.add_playbook(
+            name="Onboarding Playbook",
+            content="""# Customer Onboarding
+1. Delegate to user_finder to get Alice's user ID
+2. Delegate to account_manager to get her account value using that user ID
+""",
+            keywords=["onboard"],
+        )
+
+        result = await supervisor.invoke(
+            "Onboard Alice: find the user ID for Alice, then get her account value."
+        )
+        values = _graph_values(supervisor, result.thread_id)
+        metadata = values.get("supervisor_metadata") or {}
+        selected = values.get("selected_agents") or []
+        delegation_count = (values.get("metrics") or {}).get("delegation_count", 0)
+
+        assert metadata.get("policy_type") == "playbook"
+        assert metadata.get("playbook_guidance") or metadata.get("playbook_guidance_added")
+        assert len(selected) >= 1 or delegation_count >= 1
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_e2e_tool_guide_applies_on_invoke(self):
+        user_finder = CugaAgent(
+            tools=[get_user_id],
+            auto_load_policies=False,
+            reset_policy_storage=True,
+            filesystem_sync=False,
+        )
+        user_finder.description = "Finds user IDs"
+        supervisor = _isolated_supervisor(agents={"user_finder": user_finder})
+
+        await supervisor.policies.add_tool_guide(
+            name="Delegation Guide",
+            content="Always include the full customer name in the delegation task.",
+            target_tools=["delegate_to_user_finder"],
+            keywords=["alice"],
+        )
+
+        result = await supervisor.invoke("Get Alice's user id")
+        metadata = (_graph_values(supervisor, result.thread_id).get("supervisor_metadata")) or {}
+        guides = metadata.get("guides") or []
+
+        assert guides
+        assert any(g.get("policy_name") == "Delegation Guide" for g in guides)
+
+    @pytest.mark.asyncio
+    async def test_e2e_tool_approval_requests_approval(self):
+        from datetime import datetime
+
+        from cuga.backend.cuga_graph.nodes.human_in_the_loop.followup_model import (
+            ActionResponse,
+            ActionType,
+        )
+
+        user_finder = CugaAgent(
+            tools=[get_user_id],
+            auto_load_policies=False,
+            reset_policy_storage=True,
+            filesystem_sync=False,
+        )
+        user_finder.description = "Finds user IDs"
+        supervisor = _isolated_supervisor(agents={"user_finder": user_finder})
+
+        await supervisor.policies.add_tool_approval(
+            name="Approve Delegation",
+            required_tools=["delegate_to_user_finder"],
+            approval_message="Delegation requires approval.",
+        )
+
+        thread_id = "supervisor_tool_approval_e2e"
+        config = {"configurable": {"thread_id": thread_id}}
+        result = await supervisor.invoke(
+            "Find Alice's user id using the user_finder agent",
+            thread_id=thread_id,
+        )
+        values = _graph_values(supervisor, thread_id)
+        metadata = values.get("supervisor_metadata") or {}
+        steps_before = values.get("step_count", 0)
+
+        assert metadata.get("policy_type") == "tool_approval"
+        answer_lower = result.answer.lower()
+        assert "approve" in answer_lower or "approval" in answer_lower or "paused" in answer_lower
+        state_before = supervisor.graph.get_state(config)
+        assert "WaitForResponse" in (state_before.next or ())
+
+        approval = ActionResponse(
+            action_id="tool_approval",
+            response_type=ActionType.CONFIRMATION,
+            confirmed=True,
+            timestamp=datetime.now().isoformat(),
+            user_id=thread_id,
+            session_id=thread_id,
+        )
+        await supervisor.invoke(None, thread_id=thread_id, action_response=approval)
+        values_after = _graph_values(supervisor, thread_id)
+        assert values_after.get("step_count", 0) > steps_before
+
+    @pytest.mark.asyncio
+    async def test_e2e_output_formatter_applies_on_invoke(self):
+        supervisor = _isolated_supervisor(agents={})
+
+        await supervisor.policies.add_output_formatter(
+            name="Hello Formatter",
+            format_config="FORMATTED_HELLO_RESPONSE",
+            format_type="direct",
+            keywords=["hello"],
+        )
+
+        result = await supervisor.invoke("hello", thread_id="supervisor_formatter_e2e")
+        assert result.answer == "FORMATTED_HELLO_RESPONSE"
+
+        metadata = (_graph_values(supervisor, "supervisor_formatter_e2e").get("supervisor_metadata")) or {}
+        assert metadata.get("output_formatter_applied") is True

--- a/src/cuga/sdk_core/tests/test_supervisor_policies.py
+++ b/src/cuga/sdk_core/tests/test_supervisor_policies.py
@@ -436,6 +436,17 @@ class TestSupervisorPolicyE2E:
         state_before = supervisor.graph.get_state(config)
         assert "WaitForResponse" in (state_before.next or ())
 
+        hitl = values.get("hitl_action")
+        assert hitl is not None
+        if hasattr(hitl, "action_id"):
+            hitl = hitl.model_dump()
+        assert hitl["action_id"] == "tool_approval"
+        assert hitl["return_to"] == "CugaSupervisor"
+        tool_data = hitl["additional_data"]["tool"]
+        assert "delegate_to_user_finder" in tool_data["required_tools"]
+        assert tool_data.get("policy_name") == "Approve Delegation"
+        assert tool_data.get("full_code")
+
         approval = ActionResponse(
             action_id="tool_approval",
             response_type=ActionType.CONFIRMATION,
@@ -447,6 +458,59 @@ class TestSupervisorPolicyE2E:
         await supervisor.invoke(None, thread_id=thread_id, action_response=approval)
         values_after = _graph_values(supervisor, thread_id)
         assert values_after.get("step_count", 0) > steps_before
+
+    @pytest.mark.asyncio
+    async def test_e2e_tool_approval_denial_cancels_execution(self):
+        from datetime import datetime
+
+        from cuga.backend.cuga_graph.nodes.human_in_the_loop.followup_model import (
+            ActionResponse,
+            ActionType,
+        )
+
+        user_finder = CugaAgent(
+            tools=[get_user_id],
+            auto_load_policies=False,
+            reset_policy_storage=True,
+            filesystem_sync=False,
+        )
+        user_finder.description = "Finds user IDs"
+        supervisor = _isolated_supervisor(agents={"user_finder": user_finder})
+
+        await supervisor.policies.add_tool_approval(
+            name="Approve Delegation",
+            required_tools=["delegate_to_user_finder"],
+            approval_message="Delegation requires approval.",
+        )
+
+        thread_id = "supervisor_tool_approval_denial_e2e"
+        config = {"configurable": {"thread_id": thread_id}}
+        await supervisor.invoke(
+            "Find Alice's user id using the user_finder agent",
+            thread_id=thread_id,
+        )
+        values = _graph_values(supervisor, thread_id)
+        steps_before = values.get("step_count", 0)
+        delegation_before = (values.get("metrics") or {}).get("delegation_count", 0)
+
+        denial = ActionResponse(
+            action_id="tool_approval",
+            response_type=ActionType.CONFIRMATION,
+            confirmed=False,
+            timestamp=datetime.now().isoformat(),
+            user_id=thread_id,
+            session_id=thread_id,
+        )
+        result = await supervisor.invoke(None, thread_id=thread_id, action_response=denial)
+        values_after = _graph_values(supervisor, thread_id)
+
+        assert "cancel" in result.answer.lower()
+        assert values_after.get("execution_complete") is True
+        assert values_after.get("hitl_action") is None
+        assert values_after.get("step_count", 0) == steps_before
+        assert (values_after.get("metrics") or {}).get("delegation_count", 0) == delegation_before
+        state_after = supervisor.graph.get_state(config)
+        assert not state_after.next or state_after.next == ()
 
     @pytest.mark.asyncio
     async def test_e2e_output_formatter_applies_on_invoke(self):


### PR DESCRIPTION
## Feature

Part of #100 · Epic #75

Relevant docs PR: https://github.com/cuga-project/docs/pull/3/changes

### Goal

Bring **full policy runtime support** to the standalone `CugaSupervisor` SDK so it matches `CugaAgent`: policies are not just stored via CRUD, they are **enforced at invoke time** — blocking bad intents, injecting playbooks/tool guides, pausing for human tool approval, and formatting output.

Before this PR, supervisor policies were only partially wired (intent guard / playbook / tool guide worked; tool approval could prompt but not resume; output formatter was storage-only). This closes that gap and adds e2e coverage for every policy type on the supervisor graph.

### Summary

- Wrap `CugaSupervisor` graph with HITL nodes (`SupervisorSDKCallback`, `SuggestHumanActions`, `WaitForResponse`) so tool approval pause/resume works via `invoke(..., action_response=...)`
- Apply output formatter policies at runtime in the supervisor callback (using `supervisor_metadata`)
- Fix policy context extraction for supervisor state (`input`, `supervisor_chat_messages`) and persist `supervisor_metadata` from prepare step
- Prefer existing `state.script` on tool approval resume
- Add invoke-level e2e tests for all supervisor policy types (intent guard, playbook, tool guide, tool approval, output formatter)

### Testing
- [x] Tested locally; tests pass
- [x] `uv run pytest src/cuga/sdk_core/tests/test_supervisor_policies.py -v` (17 passed, 3 consecutive runs)

### Docs
- Companion docs PR: https://github.com/cuga-project/docs/pull/3 (supervisor policies quick start + updated support matrix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool approval execution now prefers existing script content when available.
  * Conversation context now uses additional fallbacks for user input and chat history.

* **New Features**
  * Output formatting supports configurable metadata storage and writes formatted answers plus formatter status to state.
  * Human-in-the-loop tool approval routing now returns to the correct UI surface and improves approval/resume behavior.

* **Tests**
  * Expanded supervisor policy end-to-end coverage, including approval confirm/deny and output-formatter transformation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->