### PR TITLE
fix(tracing): make TraceScopedLangfuseCallbackHandler override reachable

### DIFF
--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -168,9 +168,8 @@ def sync_langfuse_callbacks_from_config(config: Any = None) -> None:
         return
     _langgraph_run_config.set(config)
     configurable = config.get("configurable") or {}
-    trace_id = configurable.get("langfuse_trace_id")
-    if trace_id:
-        set_langfuse_trace_id(trace_id)
+    trace_id = configurable.get("langfuse_trace_id") or None
+    set_langfuse_trace_id(trace_id)
     callbacks = collect_langfuse_callbacks_from_config(config)
     if callbacks:
         _remember_primary_handler(callbacks)
@@ -179,6 +178,8 @@ def sync_langfuse_callbacks_from_config(config: Any = None) -> None:
         if handler:
             _langfuse_primary_handler.set(handler)
             callbacks = [handler]
+    else:
+        _langfuse_primary_handler.set(None)
     set_langfuse_callbacks(callbacks or None)
 
 

--- a/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
+++ b/src/cuga/backend/cuga_graph/utils/langfuse_tracing.py
@@ -93,47 +93,47 @@ def _trace_scoped_handler_class() -> type | None:
     base_cls = base_classes[0]
 
     class TraceScopedLangfuseCallbackHandler(base_cls):  # type: ignore[misc,valid-type]
-        def __on_llm_action(
-            self,
-            serialized: Any,
-            run_id: Any,
-            prompts: list[Any],
-            parent_run_id: Any = None,
-            tags: Any = None,
-            metadata: Any = None,
-            **kwargs: Any,
-        ) -> None:
+        # NOTE: the real handler dispatches on_llm_start/on_chat_model_start to a
+        # name-mangled private method (``__on_llm_action``). Overriding that name
+        # here would itself be mangled to this class's own name and never get
+        # called by the base class, so we override the public entry points
+        # instead and temporarily swap ``_trace_context`` around the super() call.
+        def _scoped_trace_context(self, parent_run_id: Any) -> dict[str, str] | None:
             trace_ctx = getattr(self, "_trace_context", None)
             if trace_ctx is None:
                 tid = _langfuse_trace_id.get()
                 if tid:
                     trace_ctx = _trace_context_for_id(tid)
             parent_missing = parent_run_id is None or parent_run_id not in getattr(self, "_runs", {})
-            if trace_ctx is not None and parent_missing:
-                original = self._trace_context
-                self._trace_context = trace_ctx
-                try:
-                    super().__on_llm_action(
-                        serialized,
-                        run_id,
-                        prompts,
-                        parent_run_id=parent_run_id,
-                        tags=tags,
-                        metadata=metadata,
-                        **kwargs,
-                    )
-                finally:
-                    self._trace_context = original
-                return
-            super().__on_llm_action(
-                serialized,
-                run_id,
-                prompts,
-                parent_run_id=parent_run_id,
-                tags=tags,
-                metadata=metadata,
-                **kwargs,
-            )
+            return trace_ctx if (trace_ctx is not None and parent_missing) else None
+
+        def on_llm_start(self, serialized: Any, prompts: Any, *, parent_run_id: Any = None, **kwargs: Any):
+            scoped = self._scoped_trace_context(parent_run_id)
+            if scoped is None:
+                return super().on_llm_start(serialized, prompts, parent_run_id=parent_run_id, **kwargs)
+            original = self._trace_context
+            self._trace_context = scoped
+            try:
+                return super().on_llm_start(serialized, prompts, parent_run_id=parent_run_id, **kwargs)
+            finally:
+                self._trace_context = original
+
+        def on_chat_model_start(
+            self, serialized: Any, messages: Any, *, parent_run_id: Any = None, **kwargs: Any
+        ):
+            scoped = self._scoped_trace_context(parent_run_id)
+            if scoped is None:
+                return super().on_chat_model_start(
+                    serialized, messages, parent_run_id=parent_run_id, **kwargs
+                )
+            original = self._trace_context
+            self._trace_context = scoped
+            try:
+                return super().on_chat_model_start(
+                    serialized, messages, parent_run_id=parent_run_id, **kwargs
+                )
+            finally:
+                self._trace_context = original
 
     TraceScopedLangfuseCallbackHandler.__name__ = "TraceScopedLangfuseCallbackHandler"
     _TRACE_SCOPED_HANDLER_CLASS = TraceScopedLangfuseCallbackHandler

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -1796,11 +1796,16 @@ class CugaAgent:
                 return []
             return list(value) if isinstance(value, list) else [value]
 
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import is_langfuse_callback_handler
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import (
+            collect_langfuse_callbacks_from_config,
+            is_langfuse_callback_handler,
+            sync_langfuse_callbacks_from_config,
+        )
 
-        existing = _as_list(run_config.get("callbacks"))
+        caller_callbacks = run_config.get("callbacks")
+        existing = _as_list(caller_callbacks)
         trace_id = run_config["configurable"].get("langfuse_trace_id")
-        per_call_langfuse = any(is_langfuse_callback_handler(cb) for cb in existing)
+        per_call_langfuse = bool(collect_langfuse_callbacks_from_config({"callbacks": caller_callbacks}))
 
         if trace_id or per_call_langfuse:
             built_callbacks = [cb for cb in built_callbacks if not is_langfuse_callback_handler(cb)]
@@ -1808,8 +1813,6 @@ class CugaAgent:
         merged = built_callbacks + existing
         run_config["callbacks"] = merged
         run_config["configurable"]["callbacks"] = merged
-
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import sync_langfuse_callbacks_from_config
 
         sync_langfuse_callbacks_from_config(run_config)
 

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -98,6 +98,20 @@ class TestLangfuseTracingHelpers:
             sync_langfuse_callbacks_from_config({"configurable": {"langfuse_trace_id": "abc123"}})
             assert get_langfuse_invoke_config() == {"callbacks": [handler]}
 
+    def test_sync_clears_stale_trace_state_when_next_config_has_no_trace(self):
+        """A later invocation in the same async context with no trace id must not
+        reattach nested LLM calls to the previous invocation's trace."""
+        handler = _fake_langfuse_handler()
+        with patch(
+            "cuga.backend.cuga_graph.utils.langfuse_tracing.create_trace_langfuse_handler",
+            return_value=handler,
+        ):
+            sync_langfuse_callbacks_from_config({"configurable": {"langfuse_trace_id": "trace-A"}})
+            assert get_langfuse_invoke_config() == {"callbacks": [handler]}
+
+            sync_langfuse_callbacks_from_config({"configurable": {}})
+            assert get_langfuse_invoke_config() == {}
+
     def test_get_invoke_config_ignores_non_langfuse_callbacks(self):
         set_langfuse_callbacks([_RecordingCallback("stale")])
         set_langfuse_trace_id("trace-99")
@@ -267,6 +281,26 @@ class TestSdkCallbackDedup:
         assert caller in run_config["callbacks"]
         assert config_only not in run_config["callbacks"]
         assert run_config["configurable"]["callbacks"] == run_config["callbacks"]
+
+    def test_apply_callbacks_detects_langfuse_handler_inside_callback_manager(self):
+        """A Langfuse handler nested inside a caller-supplied callback manager (not a
+        bare list) must still be detected so the agent-level handler is dropped."""
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import _flatten_callbacks
+        from cuga.sdk import CugaAgent
+
+        agent_level = _fake_langfuse_handler()
+        per_call_lf = _fake_langfuse_handler()
+        manager = type("AsyncCallbackManager", (), {"handlers": [per_call_lf]})()
+
+        agent = CugaAgent.__new__(CugaAgent)
+        agent._callbacks = [agent_level]
+
+        run_config = {"callbacks": manager, "configurable": {}}
+        agent._apply_callbacks(run_config)
+
+        flattened_ids = [id(c) for c in _flatten_callbacks(run_config["callbacks"])]
+        assert id(per_call_lf) in flattened_ids
+        assert id(agent_level) not in flattened_ids
 
 
 class TestNestedCallSites:

--- a/tests/unit/test_langfuse_tracing.py
+++ b/tests/unit/test_langfuse_tracing.py
@@ -157,6 +157,79 @@ class TestLangfuseTracingHelpers:
             assert get_langfuse_invoke_config() == {"callbacks": [existing]}
 
 
+class _FakeLangfuseLikeHandler:
+    """Mirrors the real langfuse.langchain.CallbackHandler's dispatch shape:
+    on_llm_start/on_chat_model_start call a *name-mangled* private method.
+    Used to prove TraceScopedLangfuseCallbackHandler's override is actually
+    reachable through inheritance, not just present in source.
+    """
+
+    def __init__(self, trace_context=None):
+        self._trace_context = trace_context
+        self._runs: dict = {}
+        self.recorded_trace_ids: list = []
+
+    def on_llm_start(self, serialized, prompts, *, run_id=None, parent_run_id=None, **kwargs):
+        self.__on_llm_action(serialized, run_id, prompts, parent_run_id, **kwargs)
+
+    def on_chat_model_start(self, serialized, messages, *, run_id=None, parent_run_id=None, **kwargs):
+        self.__on_llm_action(serialized, run_id, messages, parent_run_id, **kwargs)
+
+    def __on_llm_action(self, serialized, run_id, prompts, parent_run_id=None, **kwargs):
+        ctx = self._trace_context or {}
+        self.recorded_trace_ids.append(ctx.get("trace_id"))
+        self._runs[run_id] = parent_run_id
+
+
+class TestTraceScopedHandler:
+    @pytest.fixture(autouse=True)
+    def _reset_handler_cache(self):
+        from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
+        mod._TRACE_SCOPED_HANDLER_CLASS = None
+        yield
+        mod._TRACE_SCOPED_HANDLER_CLASS = None
+
+    def test_attaches_orphan_llm_start_to_eval_trace(self):
+        from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
+        with patch.object(mod, "_langfuse_handler_classes", return_value=(_FakeLangfuseLikeHandler,)):
+            handler_cls = mod._trace_scoped_handler_class()
+            handler = handler_cls(trace_context=None)
+
+        set_langfuse_trace_id("eval-trace-7")
+        handler.on_llm_start({}, ["hi"], run_id="run-1", parent_run_id=None)
+
+        assert handler.recorded_trace_ids == ["eval-trace-7"]
+        assert handler._trace_context is None  # restored after the call
+
+    def test_attaches_orphan_chat_model_start_to_eval_trace(self):
+        from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
+        with patch.object(mod, "_langfuse_handler_classes", return_value=(_FakeLangfuseLikeHandler,)):
+            handler_cls = mod._trace_scoped_handler_class()
+            handler = handler_cls(trace_context=None)
+
+        set_langfuse_trace_id("eval-trace-8")
+        handler.on_chat_model_start({}, [["hi"]], run_id="run-2", parent_run_id=None)
+
+        assert handler.recorded_trace_ids == ["eval-trace-8"]
+        assert handler._trace_context is None
+
+    def test_does_not_override_tracked_nested_calls(self):
+        from cuga.backend.cuga_graph.utils import langfuse_tracing as mod
+
+        with patch.object(mod, "_langfuse_handler_classes", return_value=(_FakeLangfuseLikeHandler,)):
+            handler_cls = mod._trace_scoped_handler_class()
+            handler = handler_cls(trace_context={"trace_id": "fixed-trace"})
+
+        handler._runs["parent-1"] = None
+        handler.on_llm_start({}, ["hi"], run_id="run-3", parent_run_id="parent-1")
+
+        assert handler.recorded_trace_ids == ["fixed-trace"]
+        assert handler._trace_context == {"trace_id": "fixed-trace"}
+
+
 class TestSdkCallbackDedup:
     def test_apply_callbacks_drops_agent_langfuse_when_trace_id_set(self):
         from cuga.sdk import CugaAgent


### PR DESCRIPTION
## Summary

While preparing a follow-up PR for #276/#288 (already merged via #277), I found that `TraceScopedLangfuseCallbackHandler` in `langfuse_tracing.py` has been silently broken since it was introduced — it currently ships in `main`. CodeRabbit's review of this PR additionally surfaced two more real bugs in the same already-merged code (#359), fixed here too.

### 1. `TraceScopedLangfuseCallbackHandler` override never runs (#357)

It subclasses `langfuse.langchain.CallbackHandler` and was meant to attach orphan LLM calls (no tracked parent run) to the eval trace id, via a `__on_llm_action` override. `__on_llm_action` is a double-underscore name, so Python mangles it to the *defining class's* name — the base class's `on_llm_start`/`on_chat_model_start` call `self.__on_llm_action(...)`, fixed at the base class's compile time to `self._LangchainCallbackHandler__on_llm_action(...)`. The subclass's method mangles to a different attribute, so the override never runs; the class behaves identically to the unmodified base handler.

**Fix:** override the public `on_llm_start`/`on_chat_model_start` entry points directly, swapping `_trace_context` around the `super()` call.

### 2. Stale trace state persists across invocations (#359)

`sync_langfuse_callbacks_from_config` only updated `_langfuse_trace_id`/`_langfuse_primary_handler` when the new config had a truthy trace id, leaving old state in place for a later invocation in the same async context with no trace id (e.g. an eval-harness worker reusing one asyncio task) — nested LLM calls could reattach to the stale previous trace.

**Fix:** always set (or explicitly clear) the trace id and primary handler.

### 3. Callback managers not flattened before Langfuse dedup (#359)

`CugaAgent._apply_callbacks`'s `per_call_langfuse` check used `_as_list`, which wraps a non-list `callbacks` value (e.g. a LangChain callback manager) in a single-item list without flattening it — a Langfuse handler nested inside a manager was never detected, so the agent-level Langfuse handler wasn't dropped, duplicating root traces. Same bug class as #276.

**Fix:** use `collect_langfuse_callbacks_from_config`, which already flattens via `_flatten_callbacks`.

## Test plan

- [x] Added regression tests for all three fixes, each verified to fail before the fix and pass after
- [x] `pytest tests/unit/test_langfuse_tracing.py tests/unit/test_cuga_lite_bind_tools.py` — 45 passed
- [x] `ruff check` / `ruff format` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace context handling for nested AI operations to ensure accurate tracing across auto-continue classification, output formatting, tool selection, and context summarization
  * Enhanced callback synchronization and trace ID propagation
  * Fixed orphaned trace event attachment in complex scenarios

* **Tests**
  * Added comprehensive unit test coverage for Langfuse tracing and callback propagation in nested AI invocations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->