### PR TITLE
fix(272): probe weak/missing tool output schemas, isolate probe blocks (Stage 1+2)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-weak-tool-schema-probing-stage1.md
+++ b/docs/superpowers/plans/2026-06-23-weak-tool-schema-probing-stage1.md
@@ -1,0 +1,637 @@
+# Weak Tool Output Schema Probing — Stage 1 (A+C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give CugaLite a per-tool directive that tells the model to probe weak-schema tools in isolation, and surface the real observed output shape back into the prompt for the rest of the session once a probe happens.
+
+**Architecture:** Two independent, additive pieces wired through existing seams — no new abstractions, no shared-loop changes. (A) `PromptUtils.get_tool_docs` renders a probing directive instead of an empty/placeholder schema block when a tool has no real declared output schema. (C) `sandbox_node.py` captures the real shape of a weak-schema tool's first successful result into a per-session dict on the adapter; `AgentGraphAdapter.prepare_system_content` (already called before every `call_model` turn) appends it as a small note once populated.
+
+**Tech Stack:** Python 3.12, pytest, pytest-asyncio, LangGraph, LangChain `StructuredTool`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-23-weak-tool-schema-probing-design.md`. This plan covers Stage 1 (components A and C) only.
+- CugaLite only. Do **not** touch `shared_nodes.py`, `code_extraction.py`, or `graph_nodes.py` (`CoreGraphAdapter` ABC) — those belong to Stage 2 (component B), planned and implemented separately on its own branch.
+- Every new piece of state defaults to empty/falsy. Behavior for tools with a real declared output schema must be byte-identical to today — verify this with an explicit regression test in Task 1.
+- Match existing code style: plain `hasattr`/`getattr` duck-typing (no new Protocols/ABCs), `SimpleNamespace`-based test fixtures (matches `test_agent_graph_adapter.py` and `test_prepare_node_task_todos_reset.py`), no docstring bloat.
+- Run the full suite for any file you touch before committing it: `uv run pytest <test file> -v`.
+
+## File Structure
+
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py` — weak-schema detection + probing directive text.
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py` — compute the weak-schema tool-name set once per session.
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py` — new per-session state + per-turn enrichment note.
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py` — capture the first observed shape per weak-schema tool.
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py` (new)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py` (new)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py` (new)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py` (extend existing `prepare_system_content` section)
+
+---
+
+### Task 1: Weak-schema detection + probing directive in `get_tool_docs`
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py:16-17` (new module constant), `:149-150` (new method), `:163-174` (directive branch)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py`
+
+**Interfaces:**
+- Produces: `PromptUtils.is_weak_schema_tool(tool: StructuredTool) -> bool` (static method) — used by Task 2.
+- Produces: module constant `_WEAK_SCHEMA_PROBE_DIRECTIVE: str` in `prompt_utils.py` (not exported elsewhere).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py`:
+
+```python
+"""Weak-schema detection and probing directive in PromptUtils.get_tool_docs (issue #272)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+
+def _make_tool(response_schemas=None, has_response_schemas_attr=True):
+    func = SimpleNamespace(_response_schemas=response_schemas) if has_response_schemas_attr else object()
+    return SimpleNamespace(name="some_tool", func=func, args_schema=None)
+
+
+def test_is_weak_schema_tool_true_when_empty_dict():
+    tool = _make_tool(response_schemas={})
+    assert PromptUtils.is_weak_schema_tool(tool) is True
+
+
+def test_is_weak_schema_tool_true_when_attr_missing():
+    tool = _make_tool(has_response_schemas_attr=False)
+    assert PromptUtils.is_weak_schema_tool(tool) is True
+
+
+def test_is_weak_schema_tool_true_when_generic_mcp_placeholder():
+    tool = _make_tool(response_schemas={"success": {"type": "string"}, "failure": {"type": "string"}})
+    assert PromptUtils.is_weak_schema_tool(tool) is True
+
+
+def test_is_weak_schema_tool_false_when_real_schema_declared():
+    tool = _make_tool(
+        response_schemas={"success": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+    )
+    assert PromptUtils.is_weak_schema_tool(tool) is False
+
+
+def test_get_tool_docs_renders_probing_directive_for_weak_schema_tool():
+    tool = _make_tool(response_schemas={})
+    _params_doc, response_doc = PromptUtils.get_tool_docs(tool)
+    assert "No declared output schema" in response_doc
+    assert "ALONE" in response_doc
+
+
+def test_get_tool_docs_renders_probing_directive_for_mcp_placeholder_schema():
+    tool = _make_tool(response_schemas={"success": {"type": "string"}, "failure": {"type": "string"}})
+    _params_doc, response_doc = PromptUtils.get_tool_docs(tool)
+    assert "No declared output schema" in response_doc
+
+
+def test_get_tool_docs_renders_real_schema_for_known_schema_tool():
+    """Regression: tools with a real schema must render exactly as before."""
+    tool = _make_tool(
+        response_schemas={"success": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+    )
+    _params_doc, response_doc = PromptUtils.get_tool_docs(tool)
+    assert "Returns (on success) - Response Schema" in response_doc
+    assert "No declared output schema" not in response_doc
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py -v`
+Expected: 6 failed, 1 passed. The 4 `is_weak_schema_tool` tests fail with `AttributeError: type object 'PromptUtils' has no attribute 'is_weak_schema_tool'`. The 2 `get_tool_docs` probing-directive tests fail with a plain `assert` failure (old code doesn't render the directive yet). `test_get_tool_docs_renders_real_schema_for_known_schema_tool` already passes — it's a regression guard for existing behavior, not new behavior; it stays green through Step 4 too.
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py`, after the existing imports (current lines 1-16, ending `from cuga.backend.cuga_graph.nodes.cuga_lite.model_runtime_profile import runtime_defaults_for_model`), add the module constant:
+
+```python
+_WEAK_SCHEMA_PROBE_DIRECTIVE = (
+    "\n    \n    ⚠️ No declared output schema for this tool. Call it ALONE in its own "
+    "```python block and print() the raw result — don't write code in the same block "
+    "that indexes, slices, or assumes its shape. Write follow-up code using the real "
+    "shape once you see it on your next turn."
+)
+```
+
+In the `PromptUtils` class, immediately before the existing `get_tool_docs` method (currently starting at line 150 with `@staticmethod` / line 151 `def get_tool_docs(...)`), add:
+
+```python
+    @staticmethod
+    def is_weak_schema_tool(tool: StructuredTool) -> bool:
+        """True when a tool has no real declared output schema.
+
+        Covers both the OpenAPI-derived case (empty ``response_schemas``) and
+        the MCP fallback case, where ``response_schemas`` is present but its
+        ``success`` entry is the generic synthetic placeholder MCP tools get
+        when they declare no ``outputSchema`` (see mcp_manager.py).
+        """
+        response_schemas = {}
+        if hasattr(tool, 'func') and hasattr(tool.func, '_response_schemas'):
+            response_schemas = tool.func._response_schemas
+
+        if not response_schemas or not isinstance(response_schemas, dict):
+            return True
+
+        return response_schemas.get('success') == {'type': 'string'}
+
+```
+
+Then replace the existing schema-rendering block (current lines 171-174):
+
+```python
+        if response_schemas and isinstance(response_schemas, dict):
+            if 'success' in response_schemas:
+                success_schema = json.dumps(response_schemas['success'], indent=4)
+                response_doc = f"\n    \n    Returns (on success) - Response Schema:\n{success_schema}"
+```
+
+with:
+
+```python
+        if PromptUtils.is_weak_schema_tool(tool):
+            response_doc = _WEAK_SCHEMA_PROBE_DIRECTIVE
+        elif response_schemas and isinstance(response_schemas, dict) and 'success' in response_schemas:
+            success_schema = json.dumps(response_schemas['success'], indent=4)
+            response_doc = f"\n    \n    Returns (on success) - Response Schema:\n{success_schema}"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py -v`
+Expected: 7 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py
+git commit -m "feat(272): detect weak-schema tools and inject a probing directive"
+```
+
+---
+
+### Task 2: Compute the weak-schema tool-name set once per session
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py:36-41` (import), `:594-599` (computation)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py`
+
+**Interfaces:**
+- Consumes: `PromptUtils.is_weak_schema_tool(tool) -> bool` (Task 1).
+- Produces: `adapter._weak_schema_tool_names: frozenset[str]`, set once per `prepare_tools_and_apps` run — consumed by Task 4 (`sandbox_node.py`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py`:
+
+```python
+"""prepare_tools_and_apps computes adapter._weak_schema_tool_names (issue #272)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+
+def _make_fake_tool(name: str, response_schemas: dict):
+    func = SimpleNamespace(_response_schemas=response_schemas)
+    return SimpleNamespace(name=name, func=func, description="d", args_schema=None)
+
+
+def _build_mock_adapter(tools: list) -> MagicMock:
+    adapter = MagicMock()
+    adapter._task_todos_ref = []
+    adapter._tools_context = {}
+    adapter._instructions = ""
+    adapter._special_instructions = None
+    adapter._static_prompt = None
+    adapter._thread_id = "test-thread"
+    adapter._model = MagicMock()
+    adapter._weak_schema_tool_names = frozenset()
+    adapter.set_metadata = MagicMock()
+
+    adapter._base_tool_provider = MagicMock()
+    adapter._base_tool_provider.get_all_tools = AsyncMock(return_value=tools)
+    adapter._base_tool_provider.get_apps = AsyncMock(return_value=[])
+    adapter._base_tool_provider.get_tools = AsyncMock(return_value=[])
+
+    rendered = MagicMock()
+    rendered.to_string = MagicMock(return_value="")
+    adapter._prompt_template = MagicMock()
+    adapter._prompt_template.invoke = MagicMock(return_value=rendered)
+    return adapter
+
+
+def _make_state():
+    return SimpleNamespace(
+        chat_messages=[HumanMessage(content="task")],
+        task_todos=None,
+        sub_task=None,
+        sub_task_app=None,
+        api_intent_relevant_apps=None,
+        cuga_lite_metadata=None,
+        thread_id="test-thread",
+    )
+
+
+@pytest.mark.asyncio
+async def test_weak_schema_tool_names_populated_from_tools_for_prompt():
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
+        create_prepare_tools_and_apps_node,
+    )
+
+    weak_tool = _make_fake_tool("file_readfile", {})
+    placeholder_tool = _make_fake_tool("get_browser_state", {"success": {"type": "string"}})
+    known_tool = _make_fake_tool("get_weather", {"success": {"type": "object"}})
+    adapter = _build_mock_adapter([weak_tool, placeholder_tool, known_tool])
+    state = _make_state()
+
+    configurable = {"enable_todos": False, "shortlisting_tool_threshold": 35}
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
+        new=False,
+    ):
+        node = create_prepare_tools_and_apps_node(adapter, lc_bind_tools_meta={})
+        await node(state, config={"configurable": configurable})
+
+    assert adapter._weak_schema_tool_names == frozenset({"file_readfile", "get_browser_state"})
+
+
+@pytest.mark.asyncio
+async def test_weak_schema_tool_names_empty_when_all_tools_have_real_schemas():
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
+        create_prepare_tools_and_apps_node,
+    )
+
+    known_tool = _make_fake_tool("get_weather", {"success": {"type": "object"}})
+    adapter = _build_mock_adapter([known_tool])
+    state = _make_state()
+
+    configurable = {"enable_todos": False, "shortlisting_tool_threshold": 35}
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
+        new=False,
+    ):
+        node = create_prepare_tools_and_apps_node(adapter, lc_bind_tools_meta={})
+        await node(state, config={"configurable": configurable})
+
+    assert adapter._weak_schema_tool_names == frozenset()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py -v`
+Expected: 1 failed, 1 passed. `test_weak_schema_tool_names_populated_from_tools_for_prompt` fails (`assert frozenset() == frozenset({'file_readfile', 'get_browser_state'})`, since nothing sets the attribute yet). `test_weak_schema_tool_names_empty_when_all_tools_have_real_schemas` already passes — both sides are `frozenset()` before implementation too; it's a regression guard for the all-real-schemas case, not a red/green check.
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py`, add `PromptUtils` to the existing import (current lines 36-41):
+
+```python
+from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import (
+    PromptUtils,
+    create_mcp_prompt,
+    format_apps_for_prompt,
+    normalize_mcp_few_shot_examples,
+    resolve_cuga_lite_few_shots_enabled,
+)
+```
+
+Then, right before the `# Create prompt dynamically` comment (current line 599), insert:
+
+```python
+        adapter._weak_schema_tool_names = frozenset(
+            t.name
+            for t in (tools_for_prompt or [])
+            if getattr(t, "name", None) and PromptUtils.is_weak_schema_tool(t)
+        )
+
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py -v`
+Expected: 2 passed
+
+Also re-run the pre-existing regression suite for this file to confirm nothing broke:
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_task_todos_reset.py -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py
+git commit -m "feat(272): compute weak-schema tool-name set in prepare_tools_and_apps"
+```
+
+---
+
+### Task 3: Per-session observed-shape state + per-turn enrichment note
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py:33-34` (new module function, placed after imports), `:69-71` (new instance attributes), `:91-97` (`prepare_system_content`)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py` (extend)
+
+**Interfaces:**
+- Produces: `AgentGraphAdapter._weak_schema_tool_names: frozenset[str]` (default `frozenset()`), `AgentGraphAdapter._observed_tool_shapes: dict[str, str]` (default `{}`) — both consumed by Task 4 (`sandbox_node.py`).
+- Produces: module-level `_format_observed_tool_shapes_block(shapes: dict[str, str]) -> str` in `graph_adapter.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the end of `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py` (after the existing `# ── 9. prepare_system_content hook` section, before `test_resolve_max_steps_uses_override_when_given`):
+
+```python
+def test_prepare_system_content_appends_observed_tool_shapes_when_present():
+    adapter = _make_adapter(task_todos_ref=[])
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    state = SimpleNamespace(task_todos=None)
+    result = adapter.prepare_system_content(state, {}, "You are an agent.")
+    assert result.startswith("You are an agent.")
+    assert "file_readfile" in result
+    assert "list of 3 items" in result
+
+
+def test_prepare_system_content_omits_observed_shapes_block_when_empty():
+    adapter = _make_adapter(task_todos_ref=[])
+    state = SimpleNamespace(task_todos=None)
+    result = adapter.prepare_system_content(state, {}, "You are an agent.")
+    assert result == "You are an agent."
+
+
+def test_prepare_system_content_combines_todos_and_observed_shapes():
+    todos = [{"title": "Step 1", "status": "pending"}]
+    adapter = _make_adapter(task_todos_ref=todos)
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    state = SimpleNamespace(task_todos=None)
+    result = adapter.prepare_system_content(state, {}, "You are an agent.")
+    assert "file_readfile" in result
+    assert "list of 3 items" in result
+    assert result.startswith("You are an agent.")
+
+
+def test_new_adapter_has_empty_weak_schema_state_by_default():
+    adapter = _make_adapter()
+    assert adapter._weak_schema_tool_names == frozenset()
+    assert adapter._observed_tool_shapes == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py -v -k "observed_tool_shapes or weak_schema_state"`
+Expected: all 4 fail. `test_new_adapter_has_empty_weak_schema_state_by_default` fails with `AttributeError: 'AgentGraphAdapter' object has no attribute '_weak_schema_tool_names'` (nothing sets it in `__init__` yet). The other three fail with a plain `assert` failure — ad-hoc-assigning `adapter._observed_tool_shapes = {...}` in the test works fine (Python allows arbitrary attribute assignment), but the current `prepare_system_content` doesn't read it back yet, so the expected text never appears in `result`.
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py`, after the existing imports (current line 33 `from cuga.config import settings`), before `class AgentGraphAdapter(CoreGraphAdapter):`, add:
+
+```python
+def _format_observed_tool_shapes_block(shapes: Dict[str, str]) -> str:
+    lines = ["", "---", "", "## Observed tool output shapes (this session)", ""]
+    for name, description in shapes.items():
+        lines.append(f"- `{name}`: {description}. Use this shape directly — no need to probe again.")
+    return "\n".join(lines) + "\n"
+
+```
+
+In `__init__`, after the existing `self._thread_id = thread_id` line (current line 71), add:
+
+```python
+        self._weak_schema_tool_names: frozenset = frozenset()
+        self._observed_tool_shapes: Dict[str, str] = {}
+```
+
+Replace the existing `prepare_system_content` method (current lines 91-97):
+
+```python
+    def prepare_system_content(self, state: Any, configurable: dict, base_prompt: str) -> str:
+        if self._task_todos_ref:
+            return base_prompt + format_task_todos_system_block(self._task_todos_ref)
+        task_todos = getattr(state, "task_todos", None)
+        if task_todos:
+            return base_prompt + format_current_plan_section(task_todos)
+        return base_prompt
+```
+
+with:
+
+```python
+    def prepare_system_content(self, state: Any, configurable: dict, base_prompt: str) -> str:
+        if self._task_todos_ref:
+            content = base_prompt + format_task_todos_system_block(self._task_todos_ref)
+        else:
+            task_todos = getattr(state, "task_todos", None)
+            content = base_prompt + format_current_plan_section(task_todos) if task_todos else base_prompt
+
+        if self._observed_tool_shapes:
+            content += _format_observed_tool_shapes_block(self._observed_tool_shapes)
+        return content
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py -v`
+Expected: all passed (existing + 4 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
+git commit -m "feat(272): add per-session observed-tool-shape state and prompt enrichment"
+```
+
+---
+
+### Task 4: Capture the first observed shape per weak-schema tool in the sandbox
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py:30-33` (new helpers, placed after `_llm_manager = LLMManager()`), `:181` (success path), `:212` (exception path)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py`
+
+**Interfaces:**
+- Consumes: `adapter._weak_schema_tool_names` and `adapter._observed_tool_shapes` (Task 3).
+- Produces: `_describe_observed_shape(result: Any) -> str` and `_record_weak_schema_shapes(adapter: Any, tool_calls: list) -> None` (both private to `sandbox_node.py`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py`:
+
+```python
+"""Observed-shape capture for weak-schema tools in the sandbox node (issue #272)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node import (
+    _describe_observed_shape,
+    _record_weak_schema_shapes,
+)
+
+
+def test_describe_observed_shape_dict():
+    assert "dict with keys" in _describe_observed_shape({"a": 1, "b": 2})
+
+
+def test_describe_observed_shape_list():
+    assert "list of 3 items" in _describe_observed_shape(["x", "y", "z"])
+
+
+def test_describe_observed_shape_empty_list():
+    assert _describe_observed_shape([]) == "empty list"
+
+
+def test_describe_observed_shape_str():
+    assert "str of 11 chars" in _describe_observed_shape("hello world")
+
+
+def test_describe_observed_shape_other_type():
+    assert _describe_observed_shape(42) == "int"
+
+
+def test_record_weak_schema_shapes_stores_first_observation():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset({"file_readfile"}), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": ["a", "b"], "error": None}])
+    assert "file_readfile" in adapter._observed_tool_shapes
+
+
+def test_record_weak_schema_shapes_skips_non_weak_tools():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset({"file_readfile"}), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "other_tool", "result": "x", "error": None}])
+    assert adapter._observed_tool_shapes == {}
+
+
+def test_record_weak_schema_shapes_first_observation_wins():
+    adapter = SimpleNamespace(
+        _weak_schema_tool_names=frozenset({"file_readfile"}),
+        _observed_tool_shapes={"file_readfile": "old"},
+    )
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": ["z"], "error": None}])
+    assert adapter._observed_tool_shapes["file_readfile"] == "old"
+
+
+def test_record_weak_schema_shapes_skips_errored_calls():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset({"file_readfile"}), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": None, "error": "boom"}])
+    assert adapter._observed_tool_shapes == {}
+
+
+def test_record_weak_schema_shapes_noop_when_no_weak_schema_tools():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset(), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": ["a"], "error": None}])
+    assert adapter._observed_tool_shapes == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py -v`
+Expected: FAIL — `ImportError: cannot import name '_describe_observed_shape' from 'cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node'`
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py`, after the existing `_llm_manager = LLMManager()` line (current line 30), add:
+
+```python
+def _describe_observed_shape(result: Any) -> str:
+    """Render a short, human-readable description of an observed tool result."""
+    if isinstance(result, dict):
+        keys = list(result.keys())[:8]
+        suffix = ", ..." if len(result) > len(keys) else ""
+        return f"dict with keys [{', '.join(repr(k) for k in keys)}{suffix}]"
+    if isinstance(result, (list, tuple)):
+        kind = type(result).__name__
+        if result:
+            return (
+                f"{kind} of {len(result)} items, e.g. first item: "
+                f"{type(result[0]).__name__} {str(result[0])[:120]!r}"
+            )
+        return f"empty {kind}"
+    if isinstance(result, str):
+        return f"str of {len(result)} chars, e.g. {result[:120]!r}"
+    return type(result).__name__
+
+
+def _record_weak_schema_shapes(adapter: Any, tool_calls: list) -> None:
+    """Stash the first observed output shape for any weak-schema tool this session."""
+    weak_schema_tool_names = getattr(adapter, "_weak_schema_tool_names", frozenset())
+    if not weak_schema_tool_names:
+        return
+    observed = adapter._observed_tool_shapes
+    for call in tool_calls:
+        name = call.get("name")
+        if name not in weak_schema_tool_names or name in observed or call.get("error"):
+            continue
+        observed[name] = _describe_observed_shape(call.get("result"))
+
+```
+
+Then, in the success path, replace the current line 181:
+
+```python
+            execution_tool_calls = ToolCallTracker.stop_tracking()
+```
+
+with:
+
+```python
+            execution_tool_calls = ToolCallTracker.stop_tracking()
+            _record_weak_schema_shapes(adapter, execution_tool_calls)
+```
+
+And in the exception path, replace the current line 212 (identical text, second occurrence):
+
+```python
+            execution_tool_calls = ToolCallTracker.stop_tracking()
+```
+
+with:
+
+```python
+            execution_tool_calls = ToolCallTracker.stop_tracking()
+            _record_weak_schema_shapes(adapter, execution_tool_calls)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py -v`
+Expected: 9 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py
+git commit -m "feat(272): capture first observed output shape for weak-schema tool calls"
+```
+
+---
+
+### Task 5: Full-suite regression check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full CugaLite test directory**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/ -v`
+Expected: all passed, no new failures relative to the pre-Task-1 baseline.
+
+- [ ] **Step 2: Run ruff on all touched files**
+
+Run: `uv run ruff check --fix src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py`
+Expected: no remaining issues (auto-fixed or clean)
+
+- [ ] **Step 3: Commit if ruff made changes**
+
+```bash
+git add -u
+git commit -m "style(272): ruff fixes for weak-schema probing changes" --allow-empty
+```

--- a/docs/superpowers/plans/2026-06-23-weak-tool-schema-probing-stage2.md
+++ b/docs/superpowers/plans/2026-06-23-weak-tool-schema-probing-stage2.md
@@ -1,0 +1,477 @@
+# Weak Tool Output Schema Probing — Stage 2 (B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Structurally enforce the probing directive Stage 1 only recommends — when an LLM turn contains multiple fenced code blocks and an early one calls a tool that still needs probing, drop the later blocks instead of executing all of them combined, so the model is forced to see the tool's real result before it can write code that depends on it.
+
+**Architecture:** A new optional parameter on the existing shared code-extraction function (`code_extraction.py`) does the actual truncation. A new `CoreGraphAdapter` hook (`graph_nodes.py`), defaulting to a no-op, lets `shared_nodes.py`'s `call_model` ask "which tools still need isolation this turn" without CugaSupervisor having to know anything changed. `AgentGraphAdapter` (CugaLite) implements the hook using the state Stage 1 already built (`_weak_schema_tool_names`, `_observed_tool_shapes`).
+
+**Tech Stack:** Python 3.12, pytest, pytest-asyncio, LangGraph.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-23-weak-tool-schema-probing-design.md` (see "Deferred work (Stage 2)"). Branch: `feat/272-stage2-block-isolation`, branched off `feat/272-tool-output-schema-probing` (Stage 1, already merged into this branch's history).
+- Every new parameter/hook defaults to empty (`frozenset()`). Behavior for any existing caller that doesn't pass `tools_needing_probing` — including `tool_approval_handler.py`'s call to `extract_and_combine_codeblocks` — must be byte-identical to today. Do not modify `tool_approval_handler.py`; its call site intentionally keeps the default (approval-resumption code re-derivation is out of scope for probing enforcement).
+- CugaSupervisor must require zero changes — the new hook's default (`frozenset()`) on `CoreGraphAdapter` covers it.
+- Match existing code style: this codebase favors regex-based lightweight parsing over AST for code-extraction (see `_recover_non_closing_python_fence` in `code_extraction.py`) — use the same approach for the new truncation logic, not an AST-based one.
+- `code_extraction.py`, `graph_nodes.py`, and `shared_nodes.py` already have `from __future__ import annotations`, so bare generic type hints like `frozenset[str]` are safe to use without quoting.
+
+## File Structure
+
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/code_extraction.py` — truncation logic.
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py` — new `CoreGraphAdapter.get_tools_needing_probing()` hook.
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py` — wire the hook into the code-extraction call.
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py` — `AgentGraphAdapter`'s override.
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py` (extend existing)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py` (extend existing)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py` (extend existing)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py` (extend existing)
+
+---
+
+### Task 1: Truncate multi-block responses around a probing-required tool call
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/code_extraction.py:23-56` (the two functions; new helper inserted between them)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py` (extend)
+
+**Interfaces:**
+- Produces: `extract_and_combine_codeblocks(text: str, tools_needing_probing: frozenset[str] = frozenset()) -> str` (new optional 2nd param, default preserves old behavior exactly).
+- Produces: `extract_code_from_model_response(content, reasoning_content, tools_needing_probing: frozenset[str] = frozenset()) -> str` (same).
+- Both consumed by Task 3 (`shared_nodes.py`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the end of `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py` (the import block at the top already brings in `extract_and_combine_codeblocks` and `extract_code_from_model_response` — no import changes needed):
+
+```python
+def test_truncates_after_first_block_referencing_probing_tool():
+    text = (
+        "```python\nres = await file_readfile('x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0]\nprint(res_2)\n```"
+    )
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"file_readfile"}))
+    assert code == "res = await file_readfile('x')\nprint(res)"
+
+
+def test_keeps_all_blocks_when_no_probing_tool_referenced():
+    text = (
+        "```python\nres = await file_readfile('x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0]\nprint(res_2)\n```"
+    )
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"some_other_tool"}))
+    assert code == "res = await file_readfile('x')\nprint(res)\n\nres_2 = res[0]\nprint(res_2)"
+
+
+def test_default_tools_needing_probing_preserves_old_combine_behavior():
+    text = "```python\na = 1\n```\n```python\nb = 2\n```"
+    assert extract_and_combine_codeblocks(text) == "a = 1\n\nb = 2"
+
+
+def test_truncation_keeps_prefix_blocks_before_the_matching_one():
+    text = (
+        "```python\nx = 1\nprint(x)\n```\n"
+        "```python\nres = await file_readfile('x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0]\n```"
+    )
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"file_readfile"}))
+    assert code == "x = 1\nprint(x)\n\nres = await file_readfile('x')\nprint(res)"
+
+
+def test_truncation_is_word_boundary_safe():
+    """A tool name that's a prefix of a longer identifier must not false-match."""
+    text = "```python\nfile_readfile_v2('x')\n```\n```python\ny = 2\n```"
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"file_readfile"}))
+    assert code == "file_readfile_v2('x')\n\ny = 2"
+
+
+def test_extract_code_from_model_response_threads_tools_needing_probing_through():
+    content = (
+        "```python\nres = await file_readfile('x')\nprint(res)\n```\n```python\nres_2 = res[0]\n```"
+    )
+    code = extract_code_from_model_response(
+        content, None, tools_needing_probing=frozenset({"file_readfile"})
+    )
+    assert code == "res = await file_readfile('x')\nprint(res)"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py -v -k "truncat or probing"`
+Expected: 5 of 6 fail with `TypeError: extract_and_combine_codeblocks() got an unexpected keyword argument 'tools_needing_probing'` (or the equivalent for `extract_code_from_model_response`) — every test that passes the new kwarg. `test_default_tools_needing_probing_preserves_old_combine_behavior` already passes — it calls the function with only the original `text` argument, which works under the current signature too; it's a regression guard for the no-arg case, not a red/green check.
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/code_extraction.py`, replace the current `extract_and_combine_codeblocks` (lines 23-43):
+
+```python
+def extract_and_combine_codeblocks(text: str) -> str:
+    """Extract all ```python codeblocks from text and combine them."""
+    code_blocks = re.findall(BACKTICK_PATTERN, text, re.DOTALL)
+
+    if code_blocks:
+        return "\n\n".join(block.strip() for block in code_blocks)
+
+    recovered = _recover_non_closing_python_fence(text)
+    if recovered:
+        return recovered
+
+    stripped_text = text.strip()
+
+    if "print(" not in stripped_text:
+        return ""
+
+    try:
+        compile(stripped_text.replace("await ", ""), "<string>", "exec")
+        return stripped_text
+    except SyntaxError:
+        return ""
+```
+
+with:
+
+```python
+def extract_and_combine_codeblocks(text: str, tools_needing_probing: frozenset[str] = frozenset()) -> str:
+    """Extract all ```python codeblocks from text and combine them.
+
+    When ``tools_needing_probing`` is non-empty, fenced blocks are scanned in
+    order and only kept up to and including the first block whose code calls
+    one of those tool names — the rest are dropped. This forces a fresh model
+    turn (with the real tool result visible) before any later block runs,
+    instead of running a blind guess in the same execution.
+    """
+    code_blocks = re.findall(BACKTICK_PATTERN, text, re.DOTALL)
+
+    if code_blocks:
+        blocks = [block.strip() for block in code_blocks]
+        if tools_needing_probing:
+            blocks = _truncate_after_first_probing_block(blocks, tools_needing_probing)
+        return "\n\n".join(blocks)
+
+    recovered = _recover_non_closing_python_fence(text)
+    if recovered:
+        return recovered
+
+    stripped_text = text.strip()
+
+    if "print(" not in stripped_text:
+        return ""
+
+    try:
+        compile(stripped_text.replace("await ", ""), "<string>", "exec")
+        return stripped_text
+    except SyntaxError:
+        return ""
+
+
+def _truncate_after_first_probing_block(blocks: list[str], tools_needing_probing: frozenset[str]) -> list[str]:
+    pattern = re.compile(r"\b(" + "|".join(re.escape(name) for name in tools_needing_probing) + r")\s*\(")
+    for i, block in enumerate(blocks):
+        if pattern.search(block):
+            return blocks[: i + 1]
+    return blocks
+```
+
+Then replace the current `extract_code_from_model_response` (lines 46-56):
+
+```python
+def extract_code_from_model_response(content: Optional[str], reasoning_content: Optional[str]) -> str:
+    """Extract code from a model response, falling back to reasoning.
+
+    Tries fenced/raw code in ``content`` first; only if that yields nothing
+    does it look at ``reasoning_content``. Mirrors the (previously
+    duplicated) logic in the Lite and Supervisor loop nodes.
+    """
+    code = extract_and_combine_codeblocks(content) if content else ""
+    if not code and reasoning_content:
+        code = extract_and_combine_codeblocks(reasoning_content)
+    return code
+```
+
+with:
+
+```python
+def extract_code_from_model_response(
+    content: Optional[str],
+    reasoning_content: Optional[str],
+    tools_needing_probing: frozenset[str] = frozenset(),
+) -> str:
+    """Extract code from a model response, falling back to reasoning.
+
+    Tries fenced/raw code in ``content`` first; only if that yields nothing
+    does it look at ``reasoning_content``. Mirrors the (previously
+    duplicated) logic in the Lite and Supervisor loop nodes.
+    """
+    code = extract_and_combine_codeblocks(content, tools_needing_probing) if content else ""
+    if not code and reasoning_content:
+        code = extract_and_combine_codeblocks(reasoning_content, tools_needing_probing)
+    return code
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py -v`
+Expected: all passed (existing + 6 new)
+
+Also run the sibling suite that exercises the same functions under different names, to confirm the default-argument change didn't regress it:
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_extract_codeblocks.py -v`
+Expected: all passed, unchanged
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/code_extraction.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py
+git commit -m "feat(272): truncate multi-block responses around a probing-required tool call"
+```
+
+---
+
+### Task 2: `CoreGraphAdapter.get_tools_needing_probing()` hook
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py:140-142` (insert between `normalize_response` and `on_response_processed`)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py` (extend)
+
+**Interfaces:**
+- Produces: `CoreGraphAdapter.get_tools_needing_probing(self) -> frozenset[str]` (default `frozenset()`) — consumed by Task 3 (`shared_nodes.py`) and overridden by Task 4 (`AgentGraphAdapter`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py`, in the "1. Default hook values" section (after `test_default_prepare_system_content_returns_base_prompt`, before `test_default_normalize_response_extracts_content_and_reasoning`):
+
+```python
+def test_default_get_tools_needing_probing_returns_empty_frozenset():
+    adapter = _MinimalAdapter()
+    assert adapter.get_tools_needing_probing() == frozenset()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py -v -k get_tools_needing_probing`
+Expected: FAIL — `AttributeError: '_MinimalAdapter' object has no attribute 'get_tools_needing_probing'`
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py`, the current `normalize_response` method ends at line 140 (`return content, reasoning`) and `on_response_processed` starts at line 142. Insert between them:
+
+```python
+
+    def get_tools_needing_probing(self) -> frozenset[str]:
+        """Tool names that must be called alone in their own code block this
+        turn (no declared output schema, not yet observed this session).
+        Default: empty (Supervisor and any adapter that hasn't opted in)."""
+        return frozenset()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py -v`
+Expected: all passed (existing + 1 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py
+git commit -m "feat(272): add CoreGraphAdapter.get_tools_needing_probing hook"
+```
+
+---
+
+### Task 3: Wire the hook into `call_model`'s code extraction
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py:185`
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py` (extend)
+
+**Interfaces:**
+- Consumes: `extract_code_from_model_response(..., tools_needing_probing=...)` (Task 1), `adapter.get_tools_needing_probing()` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py`, after the `_TestAdapter` class definition (after line 41, before `_make_state`):
+
+```python
+class _ProbingAdapter(_TestAdapter):
+    def get_tools_needing_probing(self) -> frozenset:
+        return frozenset({"file_readfile"})
+```
+
+Then add these two tests at the end of the file (after `test_configurable_llm_overrides_base_model`):
+
+```python
+# ── 8. Multi-block response truncated when a probing tool is referenced ───
+
+
+@pytest.mark.asyncio
+@patch(
+    "cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.shared_nodes.apply_context_summarization",
+    new_callable=AsyncMock,
+)
+async def test_multi_block_response_truncated_when_probing_tool_referenced(mock_summarize):
+    mock_summarize.side_effect = lambda messages, *args, **kwargs: messages
+
+    adapter = _ProbingAdapter()
+    state = _make_state()
+    model = _mock_model(
+        "```python\nres = await file_readfile('./x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0][0:15]\nprint(res_2)\n```"
+    )
+    settings = _mock_settings()
+
+    node = _get_factory()(adapter, model, settings)
+    result = await node(state, config=None)
+
+    assert result.update["script"] == "res = await file_readfile('./x')\nprint(res)"
+
+
+@pytest.mark.asyncio
+@patch(
+    "cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.shared_nodes.apply_context_summarization",
+    new_callable=AsyncMock,
+)
+async def test_multi_block_response_not_truncated_when_no_probing_tools(mock_summarize):
+    """Regression guard: an adapter with no probing-required tools (the
+    default, e.g. Supervisor or Lite before any weak-schema tool appears)
+    must keep combining all blocks exactly as before this change."""
+    mock_summarize.side_effect = lambda messages, *args, **kwargs: messages
+
+    adapter = _TestAdapter()
+    state = _make_state()
+    model = _mock_model(
+        "```python\nres = await file_readfile('./x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0][0:15]\nprint(res_2)\n```"
+    )
+    settings = _mock_settings()
+
+    node = _get_factory()(adapter, model, settings)
+    result = await node(state, config=None)
+
+    assert result.update["script"] == (
+        "res = await file_readfile('./x')\nprint(res)\n\nres_2 = res[0][0:15]\nprint(res_2)"
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py -v -k truncat`
+Expected: `test_multi_block_response_truncated_when_probing_tool_referenced` FAILS (`assert "res = await file_readfile('./x')\nprint(res)\n\nres_2 = res[0][0:15]\nprint(res_2)" == "res = await file_readfile('./x')\nprint(res)"` — both blocks still combined, since nothing reads the hook yet). `test_multi_block_response_not_truncated_when_no_probing_tools` already passes (current behavior already combines everything; this test is a regression guard, not a red/green check).
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py`, replace the current line 185:
+
+```python
+        code = extract_code_from_model_response(content, reasoning)
+```
+
+with:
+
+```python
+        code = extract_code_from_model_response(
+            content, reasoning, tools_needing_probing=adapter.get_tools_needing_probing()
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py -v`
+Expected: all passed (existing 7 + 2 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py
+git commit -m "feat(272): wire get_tools_needing_probing into call_model code extraction"
+```
+
+---
+
+### Task 4: `AgentGraphAdapter.get_tools_needing_probing()` override
+
+**Files:**
+- Modify: `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py:109-111` (insert between `prepare_system_content` and `get_tracker`)
+- Test: `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py` (extend)
+
+**Interfaces:**
+- Consumes: `self._weak_schema_tool_names`, `self._observed_tool_shapes` (both already exist on `AgentGraphAdapter`, added in Stage 1).
+- Overrides: `CoreGraphAdapter.get_tools_needing_probing` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the end of `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py`:
+
+```python
+def test_get_tools_needing_probing_returns_unobserved_weak_schema_tools():
+    adapter = _make_adapter()
+    adapter._weak_schema_tool_names = frozenset({"file_readfile", "get_browser_state"})
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    assert adapter.get_tools_needing_probing() == frozenset({"get_browser_state"})
+
+
+def test_get_tools_needing_probing_empty_when_all_observed():
+    adapter = _make_adapter()
+    adapter._weak_schema_tool_names = frozenset({"file_readfile"})
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    assert adapter.get_tools_needing_probing() == frozenset()
+
+
+def test_get_tools_needing_probing_empty_by_default():
+    adapter = _make_adapter()
+    assert adapter.get_tools_needing_probing() == frozenset()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py -v -k get_tools_needing_probing`
+Expected: only `test_get_tools_needing_probing_returns_unobserved_weak_schema_tools` fails (`assert frozenset() == frozenset({'get_browser_state'})`) — `AgentGraphAdapter` already inherits `get_tools_needing_probing` from `CoreGraphAdapter` (Task 2, already on this branch), which unconditionally returns `frozenset()` regardless of `self`. The other two tests (`empty_when_all_observed`, `empty_by_default`) already pass — for those specific inputs the inherited stub's `frozenset()` happens to match the expected result too, so they're regression guards, not red/green checks; only the first test actually exercises the real set-difference logic.
+
+- [ ] **Step 3: Implement**
+
+In `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py`, the current `prepare_system_content` method ends at line 109 (`return content`) and `get_tracker` starts at line 111. Insert between them:
+
+```python
+
+    def get_tools_needing_probing(self) -> frozenset[str]:
+        return self._weak_schema_tool_names - self._observed_tool_shapes.keys()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py -v`
+Expected: all passed (existing + 3 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
+git commit -m "feat(272): implement get_tools_needing_probing for CugaLite"
+```
+
+---
+
+### Task 5: Full-suite regression check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full CugaLite and cuga_agent_core test directories**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/ src/cuga/backend/cuga_graph/nodes/cuga_agent_core/ -q`
+Expected: all passed except the 3 pre-existing, unrelated `test_e2b_lite.py` failures (`RuntimeError: e2b-code-interpreter package not installed`) — do not attempt to fix those.
+
+- [ ] **Step 2: Run the CugaSupervisor test directory**
+
+Run: `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_supervisor/ -q`
+Expected: all passed — this is the explicit check that the new hook's default didn't change Supervisor behavior at all.
+
+- [ ] **Step 3: Run ruff on all touched files**
+
+Run: `uv run ruff check --fix src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/code_extraction.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py`
+Expected: no remaining issues (auto-fixed or clean)
+
+- [ ] **Step 4: Commit if ruff made changes**
+
+```bash
+git add -u
+git commit -m "style(272): ruff fixes for Stage 2 block-isolation changes" --allow-empty
+```

--- a/docs/superpowers/specs/2026-06-23-weak-tool-schema-probing-design.md
+++ b/docs/superpowers/specs/2026-06-23-weak-tool-schema-probing-design.md
@@ -1,0 +1,222 @@
+---
+title: "Weak tool output schema probing (issue #272, Stage 1)"
+status: draft
+issue: 272
+date: 2026-06-23
+---
+
+# Weak tool output schema probing
+
+## Problem
+
+Issue #272: CugaLite's CodeAct loop assumes tools declare a clean output
+schema so the model can plan over the result. When a tool has no real
+output schema (raw text, loose `dict`/`Any`, no `responseSchema`), the
+model mis-parses or over-shapes results — wrong key paths, unsafe
+indexing, hallucinated structure. The Vakra(M3) eval traced this to
+catastrophic thrash: a task expecting 2 tool calls burned 245–732 calls
+before failing, because the model kept re-guessing the shape of the same
+poorly-described tool response.
+
+A prior fix (2026-06-03 bundle: tool-naming fix + a generic system-prompt
+instruction telling the model to "probe tools with no declared output
+schema") moved Vakra(M3) pass rate from 20.0% to 33.5% — a real
+improvement, but still leaves most tasks failing. This spec covers a
+more targeted Stage 1 fix. A second mechanism (structural enforcement,
+"Stage 2") is named but deliberately deferred — see [Deferred work](#deferred-work-stage-2).
+
+## Current-state audit (issue acceptance criterion #2)
+
+This section captures what we found tracing the actual render path —
+fulfilling the "validate schema presentation" audit called out in the
+issue and the design deck (`docs/issues/272-tool-output-schema-design.md`,
+solution #3).
+
+**The tool-docs block is rendered once per session, not per turn.**
+`PromptUtils.get_tool_docs` (`src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py:150-212`)
+is called from `create_mcp_prompt`, which is called from
+`prepare_tools_and_apps` (`.../adapter/prepare_node.py:54-660`), the
+LangGraph node with the *only* inbound edge from `START`
+(`shared_graph.py:56`). There is no edge back into `prepare`. The
+resulting prompt is cached as `state.prepared_prompt` and read verbatim
+by `call_model` on every turn (`shared_nodes.py:72`). Mutating a tool's
+schema attribute mid-session does **not** change what the model sees —
+the tool-docs text was already baked into the cached prompt.
+
+The one mechanism that *does* run before every `call_model` invocation
+is `adapter.prepare_system_content(state, configurable, base_prompt)`
+(`shared_nodes.py:73`). Today `AgentGraphAdapter.prepare_system_content`
+(`graph_adapter.py:91-97`) uses this to append a "current plan" block
+built from a mutable, closure-scoped ref (`self._task_todos_ref`) that
+gets written to elsewhere in the session. This is the existing seam this
+spec reuses for "updating" schema knowledge mid-session.
+
+**"No output schema" is actually two distinct runtime shapes**, not one:
+
+- OpenAPI-derived tools with nothing in `responses.200/201.content.application/json.schema`
+  get a **literally empty** `response_schemas == {}`
+  (`tools_env/registry/mcp_manager/response_schema.py:177-249`).
+- MCP tools with no `outputSchema` on the tool descriptor get a
+  **generic synthetic fallback already injected today**:
+  `{"success": {"type": "string"}, "failure": {"type": "string"}}`
+  (`tools_env/registry/mcp_manager/mcp_manager.py:643-647`). This is
+  *truthy* and passes `get_tool_docs`'s existing
+  `if response_schemas and 'success' in response_schemas` check
+  (`prompt_utils.py:171`), so today it renders a "Response Schema:
+  `{"type": "string"}`" block that looks present but conveys nothing
+  useful. `file_readfile` and `get_browser_state` — the two tools named
+  in the issue's failure trace — are both in this bucket.
+
+Both shapes need to be treated as "weak schema" for this fix to cover
+the tools the issue actually names.
+
+## Goal
+
+When a tool has no real declared output schema, give the model a
+**targeted, per-tool** instruction to probe it in isolation, and once
+that probe happens, **surface the real observed shape** back into the
+prompt for the rest of the session — so the model stops re-guessing the
+same tool's shape every time it's called.
+
+Scope: CugaLite only. No changes to CugaSupervisor, execution modes, or
+native function calling (explicitly out of scope per the issue text).
+
+## Design
+
+Components are labeled A/B/C to match the candidate solutions explored
+while writing this spec. **B (structural enforcement of the block
+split) is deferred — see [Deferred work](#deferred-work-stage-2)** — so
+Stage 1 below covers only A and C.
+
+### A — Weak-schema detection + per-tool probing directive
+
+New helper, `is_weak_schema_tool(tool) -> bool` in `prompt_utils.py`,
+true when `tool.func._response_schemas` is empty/missing **or** its
+`success` entry is exactly the generic MCP placeholder
+`{"type": "string"}`.
+
+In `get_tool_docs` (`prompt_utils.py:150-212`), when
+`is_weak_schema_tool(tool)` is true, `response_doc` becomes a directive
+instead of the existing (empty or placeholder) schema text:
+
+> ⚠️ No declared output schema for this tool. Call it **alone** in its
+> own ```python block and `print()` the raw result — don't write code in
+> the same block that indexes, slices, or assumes its shape. Write
+> follow-up code using the real shape once you see it.
+
+This is a recommendation, not an enforced rule — nothing in this Stage 1
+slice stops the runner from combining multiple fenced blocks in one
+turn (see [Deferred work](#deferred-work-stage-2)). The copy must not
+imply enforcement that doesn't exist.
+
+In `prepare_tools_and_apps` (`prepare_node.py`), immediately before the
+existing `create_mcp_prompt(tools_for_prompt, ...)` call (~line 603),
+compute once:
+
+```python
+adapter._weak_schema_tool_names = frozenset(
+    t.name for t in tools_for_prompt if is_weak_schema_tool(t)
+)
+```
+
+### C — Post-probe session enrichment
+
+`AgentGraphAdapter.__init__` (`graph_adapter.py:44-71`) gains two plain
+instance attributes, initialized to empty defaults — no constructor
+signature change, no graph-construction-site changes:
+
+```python
+self._weak_schema_tool_names: frozenset[str] = frozenset()
+self._observed_tool_shapes: dict[str, str] = {}
+```
+
+In `sandbox_node.py`, after a script executes, for each call recorded by
+`ToolCallTracker` (`tracker.py:69-107`) whose tool name is in
+`adapter._weak_schema_tool_names` and not yet a key in
+`adapter._observed_tool_shapes`, derive a short shape description from
+the call's `result` and store it (first observation wins, per session
+only — lost when the session/process ends, same lifetime as
+`_tools_context`):
+
+- `dict` → top-level keys (truncated if many)
+- `list`/`tuple` → length + type of first element
+- `str` → length + a short excerpt
+- anything else → `type(result).__name__`
+
+Extend `AgentGraphAdapter.prepare_system_content`
+(`graph_adapter.py:91-97`) to append, after the existing todos block, one
+line per tool with a stored shape:
+
+> **Observed output (this session) — `file_readfile`:** list[str], 15
+> items, e.g. `"Total Wins,Team,..."`. Use this shape directly — no need
+> to probe again.
+
+This runs every turn (`shared_nodes.py:73`), so it reaches the model on
+the very next turn after a probe — without needing to re-render the
+one-shot tool-docs block.
+
+### Files touched (Stage 1)
+
+- `src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py` — `is_weak_schema_tool`, `get_tool_docs` directive branch.
+- `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py` — compute `_weak_schema_tool_names`.
+- `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py` — capture `_observed_tool_shapes`.
+- `src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py` — init new attributes, extend `prepare_system_content`.
+
+No changes to `shared_nodes.py`, `code_extraction.py`, or `graph_nodes.py`
+(`CoreGraphAdapter` ABC) — those are exactly the files Stage 2 would
+touch, deferred below.
+
+## Testing
+
+- `is_weak_schema_tool`: true for empty `{}`, true for the
+  `{"type": "string"}` placeholder, false for a real declared schema.
+- `get_tool_docs`: renders the probing directive (not the placeholder
+  schema text) for a weak-schema tool; unchanged for a tool with a real
+  schema.
+- `sandbox_node`: a tool call result for a weak-schema tool populates
+  `_observed_tool_shapes` exactly once, even across repeated calls to the
+  same tool in the same session; a call to a non-weak-schema tool never
+  populates it.
+- `prepare_system_content`: includes the observed-shape note once
+  populated, omits it before any probe has happened, and the existing
+  todos-block behavior is unchanged.
+
+## Deferred work (Stage 2)
+
+**Structural enforcement of the block split.** Today,
+`extract_and_combine_codeblocks` (`code_extraction.py:23-43`) joins
+*every* fenced python block in one LLM turn with `\n\n` and executes them
+as a single script — this is the literal mechanism behind the issue's
+motivating trace (a probe call and a slicing call written in the same
+completion, then run together before the model ever saw the probe's real
+result). Component A's directive cannot make the model comply; nothing
+in Stage 1 stops the runner from combining blocks regardless of what the
+prompt asks for.
+
+The deferred design: give `extract_and_combine_codeblocks` /
+`extract_code_from_model_response` an optional
+`tools_needing_probing: frozenset[str]` parameter (default empty —
+zero behavior change for any existing caller); scan fenced blocks in
+order and keep only up to and including the first block that
+regex-matches a name in that set, silently dropping the rest. Wire it
+through a new `CoreGraphAdapter.get_tools_needing_probing()` hook
+(default `frozenset()`, so CugaSupervisor is unaffected) computed as
+`adapter._weak_schema_tool_names - adapter._observed_tool_shapes.keys()`
+— once a tool has been observed, it drops out of the isolation
+requirement automatically, so the round-trip cost is paid at most once
+per weak-schema tool per session.
+
+**Trigger to revisit:** re-run the Vakra(M3) eval after Stage 1 ships.
+If pass rate and mean tool-calls-per-task on weak-schema tasks are still
+materially worse than tasks with well-described tools, build Stage 2 as
+a fast-follow. If Stage 1 alone closes most of the gap, Stage 2 may not
+be worth its larger surface area (it touches `shared_nodes.py`, shared
+with CugaSupervisor, and the core `code_extraction.py` function).
+
+**Also explicitly deferred, not part of Stage 1 or the named Stage 2:**
+tool guardrails / payload capping (solution #1 in the design deck).
+Stage 1's probing directive asks the model to `print()` a weak-schema
+tool's raw result to observe it, with no size cap — an oversized raw
+payload (e.g. a large browser-state snapshot) can still blow up context
+on a single probe call. This is a known residual risk on the token/time
+axis, not addressed by this spec.

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/code_extraction.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/code_extraction.py
@@ -20,12 +20,22 @@ from pydantic import BaseModel
 BACKTICK_PATTERN = r"```python(.*?)```"
 
 
-def extract_and_combine_codeblocks(text: str) -> str:
-    """Extract all ```python codeblocks from text and combine them."""
+def extract_and_combine_codeblocks(text: str, tools_needing_probing: frozenset[str] = frozenset()) -> str:
+    """Extract all ```python codeblocks from text and combine them.
+
+    When ``tools_needing_probing`` is non-empty, fenced blocks are scanned in
+    order and only kept up to and including the first block whose code calls
+    one of those tool names — the rest are dropped. This forces a fresh model
+    turn (with the real tool result visible) before any later block runs,
+    instead of running a blind guess in the same execution.
+    """
     code_blocks = re.findall(BACKTICK_PATTERN, text, re.DOTALL)
 
     if code_blocks:
-        return "\n\n".join(block.strip() for block in code_blocks)
+        blocks = [block.strip() for block in code_blocks]
+        if tools_needing_probing:
+            blocks = _truncate_after_first_probing_block(blocks, tools_needing_probing)
+        return "\n\n".join(blocks)
 
     recovered = _recover_non_closing_python_fence(text)
     if recovered:
@@ -43,16 +53,30 @@ def extract_and_combine_codeblocks(text: str) -> str:
         return ""
 
 
-def extract_code_from_model_response(content: Optional[str], reasoning_content: Optional[str]) -> str:
+def _truncate_after_first_probing_block(
+    blocks: list[str], tools_needing_probing: frozenset[str]
+) -> list[str]:
+    pattern = re.compile(r"\b(" + "|".join(re.escape(name) for name in tools_needing_probing) + r")\s*\(")
+    for i, block in enumerate(blocks):
+        if pattern.search(block):
+            return blocks[: i + 1]
+    return blocks
+
+
+def extract_code_from_model_response(
+    content: Optional[str],
+    reasoning_content: Optional[str],
+    tools_needing_probing: frozenset[str] = frozenset(),
+) -> str:
     """Extract code from a model response, falling back to reasoning.
 
     Tries fenced/raw code in ``content`` first; only if that yields nothing
     does it look at ``reasoning_content``. Mirrors the (previously
     duplicated) logic in the Lite and Supervisor loop nodes.
     """
-    code = extract_and_combine_codeblocks(content) if content else ""
+    code = extract_and_combine_codeblocks(content, tools_needing_probing) if content else ""
     if not code and reasoning_content:
-        code = extract_and_combine_codeblocks(reasoning_content)
+        code = extract_and_combine_codeblocks(reasoning_content, tools_needing_probing)
     return code
 
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
@@ -139,6 +139,12 @@ class CoreGraphAdapter(ABC):
         reasoning = (getattr(response, "additional_kwargs", None) or {}).get("reasoning_content")
         return content, reasoning
 
+    def get_tools_needing_probing(self) -> frozenset[str]:
+        """Tool names that must be called alone in their own code block this
+        turn (no declared output schema, not yet observed this session).
+        Default: empty (Supervisor and any adapter that hasn't opted in)."""
+        return frozenset()
+
     def on_response_processed(self, state: Any, code: Optional[str], content: str) -> None:
         """Side-effect hook called after code extraction.  Default: no-op.
         Lite uses this to record tracker steps."""

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -182,7 +182,9 @@ def create_call_model_node(
         content, reasoning = adapter.normalize_response(response)
 
         # ── Extract code ───────────────────────────────────────────────────
-        code = extract_code_from_model_response(content, reasoning)
+        code = extract_code_from_model_response(
+            content, reasoning, tools_needing_probing=adapter.get_tools_needing_probing()
+        )
 
         adapter.on_response_processed(state, code, content)
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_code_extraction.py
@@ -97,3 +97,49 @@ def test_pydantic_result_is_model_dumped_for_sync_and_async() -> None:
 
     assert asyncio.run(make_tool_awaitable(make_sync)()) == {"value": 7}
     assert asyncio.run(make_tool_awaitable(make_async)()) == {"value": 9}
+
+
+def test_truncates_after_first_block_referencing_probing_tool():
+    text = (
+        "```python\nres = await file_readfile('x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0]\nprint(res_2)\n```"
+    )
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"file_readfile"}))
+    assert code == "res = await file_readfile('x')\nprint(res)"
+
+
+def test_keeps_all_blocks_when_no_probing_tool_referenced():
+    text = (
+        "```python\nres = await file_readfile('x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0]\nprint(res_2)\n```"
+    )
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"some_other_tool"}))
+    assert code == "res = await file_readfile('x')\nprint(res)\n\nres_2 = res[0]\nprint(res_2)"
+
+
+def test_default_tools_needing_probing_preserves_old_combine_behavior():
+    text = "```python\na = 1\n```\n```python\nb = 2\n```"
+    assert extract_and_combine_codeblocks(text) == "a = 1\n\nb = 2"
+
+
+def test_truncation_keeps_prefix_blocks_before_the_matching_one():
+    text = (
+        "```python\nx = 1\nprint(x)\n```\n"
+        "```python\nres = await file_readfile('x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0]\n```"
+    )
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"file_readfile"}))
+    assert code == "x = 1\nprint(x)\n\nres = await file_readfile('x')\nprint(res)"
+
+
+def test_truncation_is_word_boundary_safe():
+    """A tool name that's a prefix of a longer identifier must not false-match."""
+    text = "```python\nfile_readfile_v2('x')\n```\n```python\ny = 2\n```"
+    code = extract_and_combine_codeblocks(text, tools_needing_probing=frozenset({"file_readfile"}))
+    assert code == "file_readfile_v2('x')\n\ny = 2"
+
+
+def test_extract_code_from_model_response_threads_tools_needing_probing_through():
+    content = "```python\nres = await file_readfile('x')\nprint(res)\n```\n```python\nres_2 = res[0]\n```"
+    code = extract_code_from_model_response(content, None, tools_needing_probing=frozenset({"file_readfile"}))
+    assert code == "res = await file_readfile('x')\nprint(res)"

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py
@@ -93,6 +93,11 @@ def test_default_normalize_response_none_reasoning():
     assert reasoning is None
 
 
+def test_default_get_tools_needing_probing_returns_empty_frozenset():
+    adapter = _MinimalAdapter()
+    assert adapter.get_tools_needing_probing() == frozenset()
+
+
 def test_default_get_invoke_config_returns_empty_dict():
     adapter = _MinimalAdapter()
     assert adapter.get_invoke_config({}) == {}

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_shared_call_model.py
@@ -41,6 +41,11 @@ class _TestAdapter(CoreGraphAdapter):
         return override if override is not None else getattr(state, "_max_steps", 50)
 
 
+class _ProbingAdapter(_TestAdapter):
+    def get_tools_needing_probing(self) -> frozenset:
+        return frozenset({"file_readfile"})
+
+
 # ── Test state factory ─────────────────────────────────────────────────────
 
 
@@ -300,3 +305,55 @@ async def test_configurable_llm_overrides_base_model(mock_summarize):
     override_model.ainvoke.assert_called_once()
     base_model.ainvoke.assert_not_called()
     assert result.update["final_answer"] == "The answer is 7."
+
+
+# ── 8. Multi-block response truncated when a probing tool is referenced ───
+
+
+@pytest.mark.asyncio
+@patch(
+    "cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.shared_nodes.apply_context_summarization",
+    new_callable=AsyncMock,
+)
+async def test_multi_block_response_truncated_when_probing_tool_referenced(mock_summarize):
+    mock_summarize.side_effect = lambda messages, *args, **kwargs: messages
+
+    adapter = _ProbingAdapter()
+    state = _make_state()
+    model = _mock_model(
+        "```python\nres = await file_readfile('./x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0][0:15]\nprint(res_2)\n```"
+    )
+    settings = _mock_settings()
+
+    node = _get_factory()(adapter, model, settings)
+    result = await node(state, config=None)
+
+    assert result.update["script"] == "res = await file_readfile('./x')\nprint(res)"
+
+
+@pytest.mark.asyncio
+@patch(
+    "cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.shared_nodes.apply_context_summarization",
+    new_callable=AsyncMock,
+)
+async def test_multi_block_response_not_truncated_when_no_probing_tools(mock_summarize):
+    """Regression guard: an adapter with no probing-required tools (the
+    default, e.g. Supervisor or Lite before any weak-schema tool appears)
+    must keep combining all blocks exactly as before this change."""
+    mock_summarize.side_effect = lambda messages, *args, **kwargs: messages
+
+    adapter = _TestAdapter()
+    state = _make_state()
+    model = _mock_model(
+        "```python\nres = await file_readfile('./x')\nprint(res)\n```\n"
+        "```python\nres_2 = res[0][0:15]\nprint(res_2)\n```"
+    )
+    settings = _mock_settings()
+
+    node = _get_factory()(adapter, model, settings)
+    result = await node(state, config=None)
+
+    assert result.update["script"] == (
+        "res = await file_readfile('./x')\nprint(res)\n\nres_2 = res[0][0:15]\nprint(res_2)"
+    )

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -108,6 +108,9 @@ class AgentGraphAdapter(CoreGraphAdapter):
             content += _format_observed_tool_shapes_block(self._observed_tool_shapes)
         return content
 
+    def get_tools_needing_probing(self) -> frozenset[str]:
+        return self._weak_schema_tool_names - self._observed_tool_shapes.keys()
+
     def get_tracker(self) -> Any:
         return self._tracker
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -33,6 +33,13 @@ from cuga.backend.llm.errors import extract_code_from_tool_use_failed
 from cuga.config import settings
 
 
+def _format_observed_tool_shapes_block(shapes: Dict[str, str]) -> str:
+    lines = ["", "---", "", "## Observed tool output shapes (this session)", ""]
+    for name, description in shapes.items():
+        lines.append(f"- `{name}`: {description}. Use this shape directly — no need to probe again.")
+    return "\n".join(lines) + "\n"
+
+
 class AgentGraphAdapter(CoreGraphAdapter):
     """CoreGraphAdapter implementation for the CugaLite single-agent graph."""
 
@@ -69,6 +76,8 @@ class AgentGraphAdapter(CoreGraphAdapter):
         self._tools_context = tools_context if tools_context is not None else {}
         self._static_prompt = static_prompt
         self._thread_id = thread_id
+        self._weak_schema_tool_names: frozenset = frozenset()
+        self._observed_tool_shapes: Dict[str, str] = {}
 
     def get_messages(self, state: Any) -> List[BaseMessage]:
         return list(state.chat_messages or [])
@@ -90,11 +99,14 @@ class AgentGraphAdapter(CoreGraphAdapter):
 
     def prepare_system_content(self, state: Any, configurable: dict, base_prompt: str) -> str:
         if self._task_todos_ref:
-            return base_prompt + format_task_todos_system_block(self._task_todos_ref)
-        task_todos = getattr(state, "task_todos", None)
-        if task_todos:
-            return base_prompt + format_current_plan_section(task_todos)
-        return base_prompt
+            content = base_prompt + format_task_todos_system_block(self._task_todos_ref)
+        else:
+            task_todos = getattr(state, "task_todos", None)
+            content = base_prompt + format_current_plan_section(task_todos) if task_todos else base_prompt
+
+        if self._observed_tool_shapes:
+            content += _format_observed_tool_shapes_block(self._observed_tool_shapes)
+        return content
 
     def get_tracker(self) -> Any:
         return self._tracker

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
@@ -34,6 +34,7 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.helpers.knowledge import (
 )
 from cuga.backend.cuga_graph.nodes.cuga_lite.model_runtime_profile import resolved_runtime_model_name
 from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import (
+    PromptUtils,
     create_mcp_prompt,
     format_apps_for_prompt,
     normalize_mcp_few_shot_examples,
@@ -595,6 +596,12 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
             lc_bind_tools_meta["_lc_bind_tools_overlay_structured_tools"] = [
                 t for t in (tools_for_prompt or []) if getattr(t, "name", None)
             ]
+
+        adapter._weak_schema_tool_names = frozenset(
+            t.name
+            for t in (tools_for_prompt or [])
+            if getattr(t, "name", None) and PromptUtils.is_weak_schema_tool(t)
+        )
 
         # Create prompt dynamically
         dynamic_prompt = adapter._static_prompt

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/prepare_node.py
@@ -597,9 +597,16 @@ def create_prepare_tools_and_apps_node(adapter: Any, lc_bind_tools_meta: dict) -
                 t for t in (tools_for_prompt or []) if getattr(t, "name", None)
             ]
 
+        # Use tools_for_execution, not tools_for_prompt: when find_tools shortlisting
+        # is active (the common case once an app has more than a handful of tools),
+        # tools_for_prompt is collapsed to just the find_tools meta-tool (~line 230),
+        # which would make this set permanently empty and silently disable the
+        # downstream block-isolation enforcement (graph_adapter.get_tools_needing_probing)
+        # and session shape-memory (sandbox_node._record_weak_schema_shapes) for every
+        # tool actually reachable through find_tools.
         adapter._weak_schema_tool_names = frozenset(
             t.name
-            for t in (tools_for_prompt or [])
+            for t in (tools_for_execution or [])
             if getattr(t, "name", None) and PromptUtils.is_weak_schema_tool(t)
         )
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
@@ -54,12 +54,19 @@ def _record_weak_schema_shapes(adapter: Any, tool_calls: list) -> None:
     weak_schema_tool_names = getattr(adapter, "_weak_schema_tool_names", frozenset())
     if not weak_schema_tool_names:
         return
-    observed = adapter._observed_tool_shapes
+    observed = getattr(adapter, "_observed_tool_shapes", {})
     for call in tool_calls:
         name = call.get("name")
         if name not in weak_schema_tool_names or name in observed or call.get("error"):
             continue
         observed[name] = _describe_observed_shape(call.get("result"))
+
+
+def _needs_shape_tracking(adapter: Any) -> bool:
+    """True when at least one weak-schema tool's shape hasn't been observed yet this session."""
+    weak_schema_tool_names = getattr(adapter, "_weak_schema_tool_names", frozenset())
+    observed = getattr(adapter, "_observed_tool_shapes", {})
+    return bool(weak_schema_tool_names - observed.keys())
 
 
 def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) -> Callable:
@@ -102,8 +109,9 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
         # Add tools to context
         context = {**existing_vars, **adapter._tools_context}
 
-        # Start tool call tracking (only if enabled via invoke parameter)
-        ToolCallTracker.start_tracking(enabled=track_tool_calls)
+        # Start tool call tracking (enabled via invoke parameter, or internally
+        # whenever a weak-schema tool's output shape hasn't been observed yet)
+        ToolCallTracker.start_tracking(enabled=track_tool_calls or _needs_shape_tracking(adapter))
 
         try:
             # Execute the script - pass the CugaLiteState itself since it has variables_manager
@@ -212,7 +220,9 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
             # Collect tool calls from this execution
             execution_tool_calls = ToolCallTracker.stop_tracking()
             _record_weak_schema_shapes(adapter, execution_tool_calls)
-            accumulated_tool_calls = (state.tool_calls or []) + execution_tool_calls
+            accumulated_tool_calls = (state.tool_calls or []) + (
+                execution_tool_calls if track_tool_calls else []
+            )
 
             if error_message:
                 return core_create_error_command(
@@ -244,7 +254,9 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
             # Collect tool calls even on error
             execution_tool_calls = ToolCallTracker.stop_tracking()
             _record_weak_schema_shapes(adapter, execution_tool_calls)
-            accumulated_tool_calls = (state.tool_calls or []) + execution_tool_calls
+            accumulated_tool_calls = (state.tool_calls or []) + (
+                execution_tool_calls if track_tool_calls else []
+            )
 
             error_msg = f"Error during execution: {str(e)}"
             logger.error(error_msg)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
@@ -30,6 +30,38 @@ from cuga.config import settings
 _llm_manager = LLMManager()
 
 
+def _describe_observed_shape(result: Any) -> str:
+    """Render a short, human-readable description of an observed tool result."""
+    if isinstance(result, dict):
+        keys = list(result.keys())[:8]
+        suffix = ", ..." if len(result) > len(keys) else ""
+        return f"dict with keys [{', '.join(repr(k) for k in keys)}{suffix}]"
+    if isinstance(result, (list, tuple)):
+        kind = type(result).__name__
+        if result:
+            return (
+                f"{kind} of {len(result)} items, e.g. first item: "
+                f"{type(result[0]).__name__} {str(result[0])[:120]!r}"
+            )
+        return f"empty {kind}"
+    if isinstance(result, str):
+        return f"str of {len(result)} chars, e.g. {result[:120]!r}"
+    return type(result).__name__
+
+
+def _record_weak_schema_shapes(adapter: Any, tool_calls: list) -> None:
+    """Stash the first observed output shape for any weak-schema tool this session."""
+    weak_schema_tool_names = getattr(adapter, "_weak_schema_tool_names", frozenset())
+    if not weak_schema_tool_names:
+        return
+    observed = adapter._observed_tool_shapes
+    for call in tool_calls:
+        name = call.get("name")
+        if name not in weak_schema_tool_names or name in observed or call.get("error"):
+            continue
+        observed[name] = _describe_observed_shape(call.get("result"))
+
+
 def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) -> Callable:
     async def sandbox(state: Any, config: Optional[RunnableConfig] = None):
         """Execute code in sandbox and return results."""
@@ -179,6 +211,7 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
 
             # Collect tool calls from this execution
             execution_tool_calls = ToolCallTracker.stop_tracking()
+            _record_weak_schema_shapes(adapter, execution_tool_calls)
             accumulated_tool_calls = (state.tool_calls or []) + execution_tool_calls
 
             if error_message:
@@ -210,6 +243,7 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
         except Exception as e:
             # Collect tool calls even on error
             execution_tool_calls = ToolCallTracker.stop_tracking()
+            _record_weak_schema_shapes(adapter, execution_tool_calls)
             accumulated_tool_calls = (state.tool_calls or []) + execution_tool_calls
 
             error_msg = f"Error during execution: {str(e)}"

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -15,6 +15,13 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.providers.base import AppDefinition
 from cuga.backend.llm.utils.helpers import create_chat_prompt_from_templates
 from cuga.backend.cuga_graph.nodes.cuga_lite.model_runtime_profile import runtime_defaults_for_model
 
+_WEAK_SCHEMA_PROBE_DIRECTIVE = (
+    "\n    \n    ⚠️ No declared output schema for this tool. Call it ALONE in its own "
+    "```python block and print() the raw result — don't write code in the same block "
+    "that indexes, slices, or assumes its shape. Write follow-up code using the real "
+    "shape once you see it on your next turn."
+)
+
 
 def _coerce_bool_setting(val: Any) -> bool:
     if isinstance(val, bool):
@@ -148,6 +155,24 @@ class PromptUtils:
             return "**kwargs"
 
     @staticmethod
+    def is_weak_schema_tool(tool: StructuredTool) -> bool:
+        """True when a tool has no real declared output schema.
+
+        Covers both the OpenAPI-derived case (empty ``response_schemas``) and
+        the MCP fallback case, where ``response_schemas`` is present but its
+        ``success`` entry is the generic synthetic placeholder MCP tools get
+        when they declare no ``outputSchema`` (see mcp_manager.py).
+        """
+        response_schemas = {}
+        if hasattr(tool, 'func') and hasattr(tool.func, '_response_schemas'):
+            response_schemas = tool.func._response_schemas
+
+        if not response_schemas or not isinstance(response_schemas, dict):
+            return True
+
+        return response_schemas.get('success') == {'type': 'string'}
+
+    @staticmethod
     def get_tool_docs(tool: StructuredTool) -> tuple[str, str]:
         """Extract params_doc and response_doc for a tool.
 
@@ -168,10 +193,11 @@ class PromptUtils:
         if hasattr(tool, 'func') and hasattr(tool.func, '_param_constraints'):
             param_constraints = tool.func._param_constraints
 
-        if response_schemas and isinstance(response_schemas, dict):
-            if 'success' in response_schemas:
-                success_schema = json.dumps(response_schemas['success'], indent=4)
-                response_doc = f"\n    \n    Returns (on success) - Response Schema:\n{success_schema}"
+        if PromptUtils.is_weak_schema_tool(tool):
+            response_doc = _WEAK_SCHEMA_PROBE_DIRECTIVE
+        elif response_schemas and isinstance(response_schemas, dict) and 'success' in response_schemas:
+            success_schema = json.dumps(response_schemas['success'], indent=4)
+            response_doc = f"\n    \n    Returns (on success) - Response Schema:\n{success_schema}"
 
         if hasattr(tool, 'args_schema') and tool.args_schema:
             try:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
@@ -282,6 +282,40 @@ def test_prepare_system_content_appends_todos_ref_when_present():
     assert len(result) > len("You are an agent.")
 
 
+def test_prepare_system_content_appends_observed_tool_shapes_when_present():
+    adapter = _make_adapter(task_todos_ref=[])
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    state = SimpleNamespace(task_todos=None)
+    result = adapter.prepare_system_content(state, {}, "You are an agent.")
+    assert result.startswith("You are an agent.")
+    assert "file_readfile" in result
+    assert "list of 3 items" in result
+
+
+def test_prepare_system_content_omits_observed_shapes_block_when_empty():
+    adapter = _make_adapter(task_todos_ref=[])
+    state = SimpleNamespace(task_todos=None)
+    result = adapter.prepare_system_content(state, {}, "You are an agent.")
+    assert result == "You are an agent."
+
+
+def test_prepare_system_content_combines_todos_and_observed_shapes():
+    todos = [{"title": "Step 1", "status": "pending"}]
+    adapter = _make_adapter(task_todos_ref=todos)
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    state = SimpleNamespace(task_todos=None)
+    result = adapter.prepare_system_content(state, {}, "You are an agent.")
+    assert "file_readfile" in result
+    assert "list of 3 items" in result
+    assert result.startswith("You are an agent.")
+
+
+def test_new_adapter_has_empty_weak_schema_state_by_default():
+    adapter = _make_adapter()
+    assert adapter._weak_schema_tool_names == frozenset()
+    assert adapter._observed_tool_shapes == {}
+
+
 def test_resolve_max_steps_uses_override_when_given():
     adapter = _make_adapter()
     state = SimpleNamespace(cuga_lite_max_steps=None)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
@@ -326,3 +326,25 @@ def test_resolve_max_steps_uses_state_when_set():
     adapter = _make_adapter()
     state = SimpleNamespace(cuga_lite_max_steps=25)
     assert adapter.resolve_max_steps(state, None) == 25
+
+
+# ── 10. get_tools_needing_probing hook ──────────────────────────────────────
+
+
+def test_get_tools_needing_probing_returns_unobserved_weak_schema_tools():
+    adapter = _make_adapter()
+    adapter._weak_schema_tool_names = frozenset({"file_readfile", "get_browser_state"})
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    assert adapter.get_tools_needing_probing() == frozenset({"get_browser_state"})
+
+
+def test_get_tools_needing_probing_empty_when_all_observed():
+    adapter = _make_adapter()
+    adapter._weak_schema_tool_names = frozenset({"file_readfile"})
+    adapter._observed_tool_shapes = {"file_readfile": "list of 3 items"}
+    assert adapter.get_tools_needing_probing() == frozenset()
+
+
+def test_get_tools_needing_probing_empty_by_default():
+    adapter = _make_adapter()
+    assert adapter.get_tools_needing_probing() == frozenset()

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py
@@ -51,7 +51,7 @@ def _make_state():
 
 
 @pytest.mark.asyncio
-async def test_weak_schema_tool_names_populated_from_tools_for_prompt():
+async def test_weak_schema_tool_names_populated_when_shortlisting_inactive():
     from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
         create_prepare_tools_and_apps_node,
     )
@@ -63,6 +63,36 @@ async def test_weak_schema_tool_names_populated_from_tools_for_prompt():
     state = _make_state()
 
     configurable = {"enable_todos": False, "shortlisting_tool_threshold": 35}
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
+        new=False,
+    ):
+        node = create_prepare_tools_and_apps_node(adapter, lc_bind_tools_meta={})
+        await node(state, config={"configurable": configurable})
+
+    assert adapter._weak_schema_tool_names == frozenset({"file_readfile", "get_browser_state"})
+
+
+@pytest.mark.asyncio
+async def test_weak_schema_tool_names_populated_when_find_tools_shortlisting_active():
+    """Regression (issue #272): when the tool catalog exceeds shortlisting_tool_threshold,
+    tools_for_prompt collapses to just the find_tools meta-tool (~prepare_node.py:230), but
+    _weak_schema_tool_names must still reflect every weak-schema tool reachable through
+    find_tools — not just what's literally listed in the prompt — or the downstream
+    block-isolation enforcement and session shape-memory silently never engage.
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
+        create_prepare_tools_and_apps_node,
+    )
+
+    weak_tool = _make_fake_tool("file_readfile", {})
+    placeholder_tool = _make_fake_tool("get_browser_state", {"success": {"type": "string"}})
+    known_tool = _make_fake_tool("get_weather", {"success": {"type": "object"}})
+    adapter = _build_mock_adapter([weak_tool, placeholder_tool, known_tool])
+    state = _make_state()
+
+    # threshold=1 with 3 tools forces enable_find_tools=True (tools_for_prompt -> [find_tool]).
+    configurable = {"enable_todos": False, "shortlisting_tool_threshold": 1}
     with patch(
         "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
         new=False,

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prepare_node_weak_schema_tools.py
@@ -1,0 +1,94 @@
+"""prepare_tools_and_apps computes adapter._weak_schema_tool_names (issue #272)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+
+def _make_fake_tool(name: str, response_schemas: dict):
+    func = SimpleNamespace(_response_schemas=response_schemas)
+    return SimpleNamespace(name=name, func=func, description="d", args_schema=None)
+
+
+def _build_mock_adapter(tools: list) -> MagicMock:
+    adapter = MagicMock()
+    adapter._task_todos_ref = []
+    adapter._tools_context = {}
+    adapter._instructions = ""
+    adapter._special_instructions = None
+    adapter._static_prompt = None
+    adapter._thread_id = "test-thread"
+    adapter._model = MagicMock()
+    adapter._weak_schema_tool_names = frozenset()
+    adapter.set_metadata = MagicMock()
+
+    adapter._base_tool_provider = MagicMock()
+    adapter._base_tool_provider.get_all_tools = AsyncMock(return_value=tools)
+    adapter._base_tool_provider.get_apps = AsyncMock(return_value=[])
+    adapter._base_tool_provider.get_tools = AsyncMock(return_value=[])
+
+    rendered = MagicMock()
+    rendered.to_string = MagicMock(return_value="")
+    adapter._prompt_template = MagicMock()
+    adapter._prompt_template.invoke = MagicMock(return_value=rendered)
+    return adapter
+
+
+def _make_state():
+    return SimpleNamespace(
+        chat_messages=[HumanMessage(content="task")],
+        task_todos=None,
+        sub_task=None,
+        sub_task_app=None,
+        api_intent_relevant_apps=None,
+        cuga_lite_metadata=None,
+        thread_id="test-thread",
+    )
+
+
+@pytest.mark.asyncio
+async def test_weak_schema_tool_names_populated_from_tools_for_prompt():
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
+        create_prepare_tools_and_apps_node,
+    )
+
+    weak_tool = _make_fake_tool("file_readfile", {})
+    placeholder_tool = _make_fake_tool("get_browser_state", {"success": {"type": "string"}})
+    known_tool = _make_fake_tool("get_weather", {"success": {"type": "object"}})
+    adapter = _build_mock_adapter([weak_tool, placeholder_tool, known_tool])
+    state = _make_state()
+
+    configurable = {"enable_todos": False, "shortlisting_tool_threshold": 35}
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
+        new=False,
+    ):
+        node = create_prepare_tools_and_apps_node(adapter, lc_bind_tools_meta={})
+        await node(state, config={"configurable": configurable})
+
+    assert adapter._weak_schema_tool_names == frozenset({"file_readfile", "get_browser_state"})
+
+
+@pytest.mark.asyncio
+async def test_weak_schema_tool_names_empty_when_all_tools_have_real_schemas():
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node import (
+        create_prepare_tools_and_apps_node,
+    )
+
+    known_tool = _make_fake_tool("get_weather", {"success": {"type": "object"}})
+    adapter = _build_mock_adapter([known_tool])
+    state = _make_state()
+
+    configurable = {"enable_todos": False, "shortlisting_tool_threshold": 35}
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.prepare_node.settings.policy.enabled",
+        new=False,
+    ):
+        node = create_prepare_tools_and_apps_node(adapter, lc_bind_tools_meta={})
+        await node(state, config={"configurable": configurable})
+
+    assert adapter._weak_schema_tool_names == frozenset()

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_prompt_utils_weak_schema.py
@@ -1,0 +1,57 @@
+"""Weak-schema detection and probing directive in PromptUtils.get_tool_docs (issue #272)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+
+def _make_tool(response_schemas=None, has_response_schemas_attr=True):
+    func = SimpleNamespace(_response_schemas=response_schemas) if has_response_schemas_attr else object()
+    return SimpleNamespace(name="some_tool", func=func, args_schema=None)
+
+
+def test_is_weak_schema_tool_true_when_empty_dict():
+    tool = _make_tool(response_schemas={})
+    assert PromptUtils.is_weak_schema_tool(tool) is True
+
+
+def test_is_weak_schema_tool_true_when_attr_missing():
+    tool = _make_tool(has_response_schemas_attr=False)
+    assert PromptUtils.is_weak_schema_tool(tool) is True
+
+
+def test_is_weak_schema_tool_true_when_generic_mcp_placeholder():
+    tool = _make_tool(response_schemas={"success": {"type": "string"}, "failure": {"type": "string"}})
+    assert PromptUtils.is_weak_schema_tool(tool) is True
+
+
+def test_is_weak_schema_tool_false_when_real_schema_declared():
+    tool = _make_tool(
+        response_schemas={"success": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+    )
+    assert PromptUtils.is_weak_schema_tool(tool) is False
+
+
+def test_get_tool_docs_renders_probing_directive_for_weak_schema_tool():
+    tool = _make_tool(response_schemas={})
+    _params_doc, response_doc = PromptUtils.get_tool_docs(tool)
+    assert "No declared output schema" in response_doc
+    assert "ALONE" in response_doc
+
+
+def test_get_tool_docs_renders_probing_directive_for_mcp_placeholder_schema():
+    tool = _make_tool(response_schemas={"success": {"type": "string"}, "failure": {"type": "string"}})
+    _params_doc, response_doc = PromptUtils.get_tool_docs(tool)
+    assert "No declared output schema" in response_doc
+
+
+def test_get_tool_docs_renders_real_schema_for_known_schema_tool():
+    """Regression: tools with a real schema must render exactly as before."""
+    tool = _make_tool(
+        response_schemas={"success": {"type": "object", "properties": {"id": {"type": "integer"}}}}
+    )
+    _params_doc, response_doc = PromptUtils.get_tool_docs(tool)
+    assert "Returns (on success) - Response Schema" in response_doc
+    assert "No declared output schema" not in response_doc

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node import (
     _describe_observed_shape,
+    _needs_shape_tracking,
     _record_weak_schema_shapes,
 )
 
@@ -61,3 +65,124 @@ def test_record_weak_schema_shapes_noop_when_no_weak_schema_tools():
     adapter = SimpleNamespace(_weak_schema_tool_names=frozenset(), _observed_tool_shapes={})
     _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": ["a"], "error": None}])
     assert adapter._observed_tool_shapes == {}
+
+
+def test_needs_shape_tracking_true_when_weak_tools_unobserved():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset({"file_readfile"}), _observed_tool_shapes={})
+    assert _needs_shape_tracking(adapter) is True
+
+
+def test_needs_shape_tracking_false_when_all_weak_tools_observed():
+    adapter = SimpleNamespace(
+        _weak_schema_tool_names=frozenset({"file_readfile"}),
+        _observed_tool_shapes={"file_readfile": "list of 3 items"},
+    )
+    assert _needs_shape_tracking(adapter) is False
+
+
+def test_needs_shape_tracking_false_when_no_weak_tools():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset(), _observed_tool_shapes={})
+    assert _needs_shape_tracking(adapter) is False
+
+
+def test_needs_shape_tracking_true_when_some_observed_some_not():
+    adapter = SimpleNamespace(
+        _weak_schema_tool_names=frozenset({"a", "b"}),
+        _observed_tool_shapes={"a": "observed"},
+    )
+    assert _needs_shape_tracking(adapter) is True
+
+
+def _build_mock_adapter_for_sandbox() -> MagicMock:
+    adapter = MagicMock()
+    adapter._tools_context = {}
+    adapter._weak_schema_tool_names = frozenset({"file_readfile"})
+    adapter._observed_tool_shapes = {}
+    adapter._tracker = MagicMock()
+    adapter._tracker.collect_step = MagicMock()
+    adapter.messages_key = "chat_messages"
+    adapter.get_messages = MagicMock(return_value=[])
+    adapter.resolve_max_steps = MagicMock(return_value=1000)
+    return adapter
+
+
+def _build_sandbox_state() -> SimpleNamespace:
+    variables_manager = MagicMock()
+    variables_manager.get_variable_names = MagicMock(return_value=[])
+    variables_manager.get_variable = MagicMock(return_value=None)
+    variables_manager.remove_variable = MagicMock()
+    variables_manager.add_variable = MagicMock()
+
+    return SimpleNamespace(
+        variables_manager=variables_manager,
+        chat_messages=[],
+        tool_calls=[],
+        step_count=0,
+        script="x = 1",
+        thread_id="test-thread",
+        variables_storage={},
+        variable_counter_state=0,
+        variable_creation_order=[],
+        reflection_apps=[],
+        reflection_enable_find_tools=False,
+        reflection_skills_enabled=False,
+        reflection_skills_prompt_section="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_sandbox_tracks_weak_schema_tool_without_exposing_tool_calls_when_opt_out_default():
+    """Reproduces and proves the fix for the dead-on-arrival Stage 1 bug:
+
+    With ``track_tool_calls`` absent from configurable (the production
+    default of ``False``) and a weak-schema tool name registered on the
+    adapter, the sandbox node must still internally enable tracking so
+    ``adapter._observed_tool_shapes`` gets populated -- while leaving the
+    returned ``tool_calls`` update untouched (empty) for callers who never
+    opted into tracking, so we don't grow their persisted state.
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node import create_sandbox_node
+    from cuga.backend.cuga_graph.nodes.cuga_lite.tracking.tracker import ToolCallTracker
+
+    adapter = _build_mock_adapter_for_sandbox()
+    state = _build_sandbox_state()
+
+    async def fake_eval_with_tools_async(*args, **kwargs):
+        # Side effect: simulate the executed script calling the weak-schema tool.
+        ToolCallTracker.record_call(
+            tool_name="file_readfile",
+            arguments={},
+            result=["line1", "line2"],
+            app_name=None,
+            operation_id=None,
+        )
+        return "ok", {}
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node.CodeExecutor.eval_with_tools_async",
+            new=AsyncMock(side_effect=fake_eval_with_tools_async),
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node.settings.policy.enabled",
+            new=False,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node.settings.advanced_features.reflection_enabled",
+            new=False,
+        ),
+    ):
+        node = create_sandbox_node(adapter, base_thread_id="base-thread", base_apps_list=[])
+        # configurable deliberately omits "track_tool_calls" -> defaults to False
+        result = await node(state, config={"configurable": {}})
+
+    # The bug: tracking never started, so this would stay empty without the fix.
+    assert adapter._observed_tool_shapes.get("file_readfile") is not None, (
+        "Weak-schema tool shape must be observed even when track_tool_calls is not opted into"
+    )
+
+    # Behavior-preservation: callers who never asked for tracking must not see
+    # the tracked call surface in the returned tool_calls update.
+    assert result["tool_calls"] == [], (
+        "tool_calls update must stay empty for callers who didn't opt into track_tool_calls"
+    )

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_sandbox_node_weak_schema_shapes.py
@@ -1,0 +1,63 @@
+"""Observed-shape capture for weak-schema tools in the sandbox node (issue #272)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.adapter.sandbox_node import (
+    _describe_observed_shape,
+    _record_weak_schema_shapes,
+)
+
+
+def test_describe_observed_shape_dict():
+    assert "dict with keys" in _describe_observed_shape({"a": 1, "b": 2})
+
+
+def test_describe_observed_shape_list():
+    assert "list of 3 items" in _describe_observed_shape(["x", "y", "z"])
+
+
+def test_describe_observed_shape_empty_list():
+    assert _describe_observed_shape([]) == "empty list"
+
+
+def test_describe_observed_shape_str():
+    assert "str of 11 chars" in _describe_observed_shape("hello world")
+
+
+def test_describe_observed_shape_other_type():
+    assert _describe_observed_shape(42) == "int"
+
+
+def test_record_weak_schema_shapes_stores_first_observation():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset({"file_readfile"}), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": ["a", "b"], "error": None}])
+    assert "file_readfile" in adapter._observed_tool_shapes
+
+
+def test_record_weak_schema_shapes_skips_non_weak_tools():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset({"file_readfile"}), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "other_tool", "result": "x", "error": None}])
+    assert adapter._observed_tool_shapes == {}
+
+
+def test_record_weak_schema_shapes_first_observation_wins():
+    adapter = SimpleNamespace(
+        _weak_schema_tool_names=frozenset({"file_readfile"}),
+        _observed_tool_shapes={"file_readfile": "old"},
+    )
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": ["z"], "error": None}])
+    assert adapter._observed_tool_shapes["file_readfile"] == "old"
+
+
+def test_record_weak_schema_shapes_skips_errored_calls():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset({"file_readfile"}), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": None, "error": "boom"}])
+    assert adapter._observed_tool_shapes == {}
+
+
+def test_record_weak_schema_shapes_noop_when_no_weak_schema_tools():
+    adapter = SimpleNamespace(_weak_schema_tool_names=frozenset(), _observed_tool_shapes={})
+    _record_weak_schema_shapes(adapter, [{"name": "file_readfile", "result": ["a"], "error": None}])
+    assert adapter._observed_tool_shapes == {}


### PR DESCRIPTION
## Summary

Implements a staged fix for #272 (CugaLite struggles with weak/missing tool output schemas), combining elements of candidate solutions #2, #3, and #5 from the original design deck (attached on the issue) into the smallest change set that closes the gap.

**Component A — weak-schema detection + per-tool probing directive**
Detects tools with no real declared output schema (both the genuinely-empty OpenAPI case and MCP's synthetic `{"success": {"type": "string"}}` placeholder) and replaces their rendered schema block with a directive telling the model to call the tool alone and `print()` the raw result before writing code that assumes its shape.

**Component C — post-probe session enrichment**
Captures the first observed shape of a weak-schema tool's result per session and surfaces it back into the prompt on every subsequent turn via the existing per-turn `prepare_system_content` hook, so the model stops re-probing a tool it has already seen.

**Component B — structural enforcement of the block split**
A+C alone are advisory: nothing stopped the runner from combining a probe call and a slicing call written in the same completion into one executed script, which is the literal mechanism behind the issue's failure trace. B adds a `CoreGraphAdapter.get_tools_needing_probing()` hook and truncates a multi-block response after the first block that references a still-unobserved weak-schema tool, discarding the rest so the model is forced to see the real result before writing dependent code. CugaSupervisor is unaffected (hook defaults to `frozenset()`).

Full design rationale: `docs/superpowers/specs/2026-06-23-weak-tool-schema-probing-design.md`
Implementation plans: `docs/superpowers/plans/2026-06-23-weak-tool-schema-probing-stage1.md`, `docs/superpowers/plans/2026-06-23-weak-tool-schema-probing-stage2.md`

## Staging

This PR is the union of two branches, kept separate during development so each component's contribution could be evaluated independently:

- `feat/272-tool-output-schema-probing` — Stage 1, Components A+C only
- `feat/272-stage2-block-isolation` (this branch, off Stage 1) — adds Component B

## Eval results (Vakra M3, 1 task, 5 runs each)

| Branch | Commit | Pass@1 | ExactMatch | Avg tokens | Avg LLM calls | Avg time |
|---|---|---|---|---|---|---|
| main | 8d3d3599 | 0.0% | 0.20 | 301,614 | 15.2 | 65.2s |
| feat/272-tool-output-schema-probing (A+C) | 2dc47738 | 0.0% | 0.80 | 205,719 | 11.2 | 25.2s |
| feat/272-stage2-block-isolation (A+B+C) | 4f623786 | 60.0% | 1.00 | 214,005 | 11.0 | 24.7s |

A+C alone already cuts tokens/calls/time roughly in half and raises ExactMatch substantially, but doesn't move Pass@1 — consistent with the design doc's prediction that advisory-only probing wouldn't close the gap on its own. Adding B (structural enforcement) is what converts that into actual task success.

## Test plan

- [x] Stage 1 unit tests (`prompt_utils`, `prepare_node`, `sandbox_node`, `graph_adapter`) — new + extended
- [x] Stage 2 unit tests (`code_extraction`, `graph_nodes`, `shared_nodes`, `graph_adapter`) — new + extended, including an end-to-end reproduction of the issue's literal original multi-block trace
- [x] Full regression: `cuga_lite` + `cuga_agent_core` + `cuga_supervisor` suites green (363 passed, 1 skipped, 3 pre-existing unrelated e2b-package-not-installed failures)
- [x] `ruff check` clean
- [ ] Broader eval run across the full Vakra(M3) task set (this PR's numbers are a single-task, 5-run sample)