### PR TITLE
feat(supervisor): add plan_upfront state models

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/cuga_supervisor_state.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/cuga_supervisor_state.py
@@ -2,7 +2,7 @@
 CugaSupervisor State - State schema for supervisor subgraph
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Literal
 from pydantic import BaseModel, ConfigDict, Field
 from langchain_core.messages import BaseMessage
 
@@ -19,12 +19,31 @@ class AgentInfo(BaseModel):
     status: str = "available"  # available, busy, error
 
 
+class PlanUpfrontDelegation(BaseModel):
+    """A single delegation step in the plan_upfront strategy plan."""
+
+    agent_name: str
+    task: str
+    variables: List[str] = Field(default_factory=list)
+
+
+class PlanUpfrontPlan(BaseModel):
+    """The LLM-generated plan for plan_upfront strategy."""
+
+    strategy: Literal["sequential", "parallel"] = "sequential"
+    delegations: List[PlanUpfrontDelegation] = Field(default_factory=list)
+    reasoning: Optional[str] = None
+
+
 class CugaSupervisorState(AgentState):
     """
     State for CugaSupervisor subgraph.
 
     Extends AgentState to maintain compatibility while adding supervisor-specific fields.
     """
+
+    # Operation mode
+    supervisor_mode: Literal["conversational", "plan_upfront"] = "conversational"
 
     # Supervisor's own conversation history (separate from sub-agents)
     supervisor_chat_messages: Optional[List[BaseMessage]] = Field(default_factory=list)
@@ -40,6 +59,11 @@ class CugaSupervisorState(AgentState):
 
     # Supervisor's aggregated variables collected from sub-agents
     supervisor_variables: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+    # Plan upfront fields
+    plan_upfront_plan: Optional[PlanUpfrontPlan] = None
+    aggregated_results: Optional[str] = None
+    synthesized_response: Optional[str] = None
 
     # Conversational mode fields (similar to CugaLiteState)
     tools_prepared: bool = False

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_cuga_supervisor_state.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_cuga_supervisor_state.py
@@ -106,7 +106,7 @@ class TestCugaSupervisorState:
             plan_upfront_plan=plan.model_dump(),
         )
         assert state.plan_upfront_plan is not None
-        assert state.plan_upfront_plan["strategy"] == "sequential"
+        assert state.plan_upfront_plan.strategy == "sequential"
 
     def test_aggregated_results_default(self):
         state = CugaSupervisorState(input="hello", url="")

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_cuga_supervisor_state.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_cuga_supervisor_state.py
@@ -12,13 +12,17 @@ from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_state import 
 
 
 class TestPlanUpfrontDelegation:
+    """Tests for PlanUpfrontDelegation Pydantic model."""
+
     def test_create_delegation_with_required_fields(self):
+        """Create delegation with only agent_name and task."""
         d = PlanUpfrontDelegation(agent_name="crm_agent", task="Get customers")
         assert d.agent_name == "crm_agent"
         assert d.task == "Get customers"
         assert d.variables == []
 
     def test_create_delegation_with_variables(self):
+        """Create delegation with optional variables list."""
         d = PlanUpfrontDelegation(
             agent_name="email_agent",
             task="Send email",
@@ -27,22 +31,28 @@ class TestPlanUpfrontDelegation:
         assert d.variables == ["customer_data"]
 
     def test_delegation_requires_agent_name(self):
+        """Delegation without agent_name raises ValidationError."""
         with pytest.raises(ValidationError):
             PlanUpfrontDelegation(task="task")
 
     def test_delegation_requires_task(self):
+        """Delegation without task raises ValidationError."""
         with pytest.raises(ValidationError):
             PlanUpfrontDelegation(agent_name="agent")
 
 
 class TestPlanUpfrontPlan:
+    """Tests for PlanUpfrontPlan Pydantic model."""
+
     def test_create_plan_defaults(self):
+        """Plan uses default strategy 'sequential' and empty delegations."""
         p = PlanUpfrontPlan()
         assert p.strategy == "sequential"
         assert p.delegations == []
         assert p.reasoning is None
 
     def test_create_plan_with_delegations(self):
+        """Plan accepts delegations list and explicit strategy."""
         d = PlanUpfrontDelegation(agent_name="crm_agent", task="Get data")
         p = PlanUpfrontPlan(
             strategy="parallel",
@@ -55,10 +65,12 @@ class TestPlanUpfrontPlan:
         assert p.reasoning == "Run in parallel"
 
     def test_plan_rejects_invalid_strategy(self):
+        """Plan rejects strategy not in sequential or parallel."""
         with pytest.raises(ValidationError):
             PlanUpfrontPlan(strategy="invalid")
 
     def test_plan_serialize_roundtrip(self):
+        """Plan model_dump and reconstruction preserves all fields."""
         d = PlanUpfrontDelegation(agent_name="a", task="t")
         p = PlanUpfrontPlan(strategy="sequential", delegations=[d])
         data = p.model_dump()
@@ -68,11 +80,15 @@ class TestPlanUpfrontPlan:
 
 
 class TestCugaSupervisorState:
+    """Tests for CugaSupervisorState with new plan_upfront fields."""
+
     def test_default_supervisor_mode(self):
+        """Default supervisor_mode is conversational."""
         state = CugaSupervisorState(input="hello", url="")
         assert state.supervisor_mode == "conversational"
 
     def test_explicit_conversational_mode(self):
+        """Setting supervisor_mode explicitly to conversational."""
         state = CugaSupervisorState(
             input="hello",
             url="",
@@ -81,6 +97,7 @@ class TestCugaSupervisorState:
         assert state.supervisor_mode == "conversational"
 
     def test_explicit_plan_upfront_mode(self):
+        """Setting supervisor_mode to plan_upfront is accepted."""
         state = CugaSupervisorState(
             input="hello",
             url="",
@@ -89,14 +106,17 @@ class TestCugaSupervisorState:
         assert state.supervisor_mode == "plan_upfront"
 
     def test_invalid_mode_rejected(self):
+        """Legacy delegation value raises ValidationError."""
         with pytest.raises(ValidationError):
             CugaSupervisorState(input="hello", url="", supervisor_mode="delegation")
 
     def test_plan_upfront_plan_field_default(self):
+        """plan_upfront_plan defaults to None."""
         state = CugaSupervisorState(input="hello", url="")
         assert state.plan_upfront_plan is None
 
     def test_plan_upfront_plan_field_set(self):
+        """plan_upfront_plan can be set via dict or PlanUpfrontPlan."""
         d = PlanUpfrontDelegation(agent_name="a", task="t")
         plan = PlanUpfrontPlan(strategy="sequential", delegations=[d])
         state = CugaSupervisorState(
@@ -109,10 +129,12 @@ class TestCugaSupervisorState:
         assert state.plan_upfront_plan.strategy == "sequential"
 
     def test_aggregated_results_default(self):
+        """aggregated_results defaults to None."""
         state = CugaSupervisorState(input="hello", url="")
         assert state.aggregated_results is None
 
     def test_aggregated_results_set(self):
+        """aggregated_results can be set with a string value."""
         state = CugaSupervisorState(
             input="hello",
             url="",
@@ -121,10 +143,12 @@ class TestCugaSupervisorState:
         assert state.aggregated_results == "Agent results here"
 
     def test_synthesized_response_default(self):
+        """synthesized_response defaults to None."""
         state = CugaSupervisorState(input="hello", url="")
         assert state.synthesized_response is None
 
     def test_synthesized_response_set(self):
+        """synthesized_response can be set with a string value."""
         state = CugaSupervisorState(
             input="hello",
             url="",
@@ -133,6 +157,7 @@ class TestCugaSupervisorState:
         assert state.synthesized_response == "Final answer"
 
     def test_all_new_fields_in_model_dump(self):
+        """All plan_upfront fields appear in model_dump output."""
         state = CugaSupervisorState(
             input="test",
             url="",

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_cuga_supervisor_state.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_cuga_supervisor_state.py
@@ -1,0 +1,145 @@
+"""Tests for CugaSupervisorState, PlanUpfrontPlan, and PlanUpfrontDelegation models."""
+
+from langchain_core.messages import HumanMessage
+from pydantic import ValidationError
+import pytest
+
+from cuga.backend.cuga_graph.nodes.cuga_supervisor.cuga_supervisor_state import (
+    CugaSupervisorState,
+    PlanUpfrontPlan,
+    PlanUpfrontDelegation,
+)
+
+
+class TestPlanUpfrontDelegation:
+    def test_create_delegation_with_required_fields(self):
+        d = PlanUpfrontDelegation(agent_name="crm_agent", task="Get customers")
+        assert d.agent_name == "crm_agent"
+        assert d.task == "Get customers"
+        assert d.variables == []
+
+    def test_create_delegation_with_variables(self):
+        d = PlanUpfrontDelegation(
+            agent_name="email_agent",
+            task="Send email",
+            variables=["customer_data"],
+        )
+        assert d.variables == ["customer_data"]
+
+    def test_delegation_requires_agent_name(self):
+        with pytest.raises(ValidationError):
+            PlanUpfrontDelegation(task="task")
+
+    def test_delegation_requires_task(self):
+        with pytest.raises(ValidationError):
+            PlanUpfrontDelegation(agent_name="agent")
+
+
+class TestPlanUpfrontPlan:
+    def test_create_plan_defaults(self):
+        p = PlanUpfrontPlan()
+        assert p.strategy == "sequential"
+        assert p.delegations == []
+        assert p.reasoning is None
+
+    def test_create_plan_with_delegations(self):
+        d = PlanUpfrontDelegation(agent_name="crm_agent", task="Get data")
+        p = PlanUpfrontPlan(
+            strategy="parallel",
+            delegations=[d],
+            reasoning="Run in parallel",
+        )
+        assert p.strategy == "parallel"
+        assert len(p.delegations) == 1
+        assert p.delegations[0].agent_name == "crm_agent"
+        assert p.reasoning == "Run in parallel"
+
+    def test_plan_rejects_invalid_strategy(self):
+        with pytest.raises(ValidationError):
+            PlanUpfrontPlan(strategy="invalid")
+
+    def test_plan_serialize_roundtrip(self):
+        d = PlanUpfrontDelegation(agent_name="a", task="t")
+        p = PlanUpfrontPlan(strategy="sequential", delegations=[d])
+        data = p.model_dump()
+        restored = PlanUpfrontPlan(**data)
+        assert restored.strategy == "sequential"
+        assert restored.delegations[0].agent_name == "a"
+
+
+class TestCugaSupervisorState:
+    def test_default_supervisor_mode(self):
+        state = CugaSupervisorState(input="hello", url="")
+        assert state.supervisor_mode == "conversational"
+
+    def test_explicit_conversational_mode(self):
+        state = CugaSupervisorState(
+            input="hello",
+            url="",
+            supervisor_mode="conversational",
+        )
+        assert state.supervisor_mode == "conversational"
+
+    def test_explicit_plan_upfront_mode(self):
+        state = CugaSupervisorState(
+            input="hello",
+            url="",
+            supervisor_mode="plan_upfront",
+        )
+        assert state.supervisor_mode == "plan_upfront"
+
+    def test_invalid_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            CugaSupervisorState(input="hello", url="", supervisor_mode="delegation")
+
+    def test_plan_upfront_plan_field_default(self):
+        state = CugaSupervisorState(input="hello", url="")
+        assert state.plan_upfront_plan is None
+
+    def test_plan_upfront_plan_field_set(self):
+        d = PlanUpfrontDelegation(agent_name="a", task="t")
+        plan = PlanUpfrontPlan(strategy="sequential", delegations=[d])
+        state = CugaSupervisorState(
+            input="hello",
+            url="",
+            supervisor_mode="plan_upfront",
+            plan_upfront_plan=plan.model_dump(),
+        )
+        assert state.plan_upfront_plan is not None
+        assert state.plan_upfront_plan["strategy"] == "sequential"
+
+    def test_aggregated_results_default(self):
+        state = CugaSupervisorState(input="hello", url="")
+        assert state.aggregated_results is None
+
+    def test_aggregated_results_set(self):
+        state = CugaSupervisorState(
+            input="hello",
+            url="",
+            aggregated_results="Agent results here",
+        )
+        assert state.aggregated_results == "Agent results here"
+
+    def test_synthesized_response_default(self):
+        state = CugaSupervisorState(input="hello", url="")
+        assert state.synthesized_response is None
+
+    def test_synthesized_response_set(self):
+        state = CugaSupervisorState(
+            input="hello",
+            url="",
+            synthesized_response="Final answer",
+        )
+        assert state.synthesized_response == "Final answer"
+
+    def test_all_new_fields_in_model_dump(self):
+        state = CugaSupervisorState(
+            input="test",
+            url="",
+            supervisor_chat_messages=[HumanMessage(content="hi")],
+        )
+        data = state.model_dump()
+        assert "supervisor_mode" in data
+        assert "plan_upfront_plan" in data
+        assert "aggregated_results" in data
+        assert "synthesized_response" in data

--- a/src/cuga/supervisor_utils/supervisor_config.py
+++ b/src/cuga/supervisor_utils/supervisor_config.py
@@ -36,6 +36,11 @@ async def load_supervisor_config(yaml_path: str) -> SupervisorConfig:
     with open(yaml_path, "r") as f:
         config = yaml.safe_load(f)
 
+    # Normalize legacy mode value
+    supervisor_cfg = config.get("supervisor", {})
+    if supervisor_cfg.get("mode") == "delegation":
+        supervisor_cfg["mode"] = "plan_upfront"
+
     agents = {}
 
     for agent_config in config.get("agents", []):


### PR DESCRIPTION
Adds supervisor_mode field, PlanUpfrontPlan and PlanUpfrontDelegation pydantic models, and new state fields for the upcoming plan_upfront strategy. Normalizes legacy `delegation` mode in the config loader for backward compatibility.

No behavioral changes — purely additive type definitions.

Refs: design.md (CugaSupervisor plan_upfront strategy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “plan_upfront” supervisor operating mode for plan-ahead workflows.
  * Enables defining plan strategies with optional delegations, plus storing plan results, aggregated outputs, and a synthesized response.
* **Bug Fixes**
  * Improved compatibility with legacy supervisor configuration by mapping an older mode value to “plan_upfront”.
* **Tests**
  * Added coverage for the new supervisor mode, plan models, validation rules, defaults, and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->