### PR TITLE
fix: SDK HITL resume and tool-approval denial crash

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
@@ -80,7 +80,6 @@ class CugaLiteHumanInTheLoopHandler:
             # User denied - set final answer and end
             policy_name = state.cuga_lite_metadata.get("policy_name", "Tool Approval Policy")
             state.final_answer = f"❌ **Execution Cancelled**\n\nYou denied the execution of restricted tools required by **{policy_name}**.\n\nThe agent will not proceed with this task."
-            state.execution_complete = True
             state.sender = node_name
             return Command(update=state.model_dump(), goto=NodeNames.FINAL_ANSWER_AGENT)
 

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -1949,7 +1949,6 @@ class CugaAgent:
                     # User denied - set final answer and end
                     policy_name = state.cuga_lite_metadata.get("policy_name", "Tool Approval Policy")
                     state.final_answer = f"❌ **Execution Cancelled**\n\nYou denied the execution of restricted tools required by **{policy_name}**.\n\nThe agent will not proceed with this task."
-                    state.execution_complete = True
                     # Set sender to CugaLite so FinalAnswerAgent handles it properly
                     state.sender = NodeNames.CUGA_LITE
                     return Command(update=state.model_dump(), goto=NodeNames.FINAL_ANSWER_AGENT)
@@ -2261,15 +2260,18 @@ class CugaAgent:
             # Add callbacks (TokenUsageTracker + user callbacks merged with per-call callbacks)
             self._apply_callbacks(run_config)
 
-            # If action_response provided, update state with it
+            from langgraph.types import Command
+
             if action_response:
-                self.graph.update_state(run_config, {"hitl_response": action_response})
                 logger.info(
                     f"Resuming execution after HITL response (action_id: {action_response.action_id})"
                 )
-
-            # Resume by invoking with None (LangGraph pattern for resuming)
-            result = await self.graph.ainvoke(None, config=run_config)
+                result = await self.graph.ainvoke(
+                    Command(resume=action_response.model_dump()),
+                    config=run_config,
+                )
+            else:
+                result = await self.graph.ainvoke(None, config=run_config)
 
             # Extract final answer
             final_answer = result.get("final_answer", "")
@@ -2574,14 +2576,14 @@ class CugaAgent:
             # Add knowledge engine for awareness injection
             self._inject_knowledge_to_config(run_config)
 
-            # If action_response provided, update state with it
+            from langgraph.types import Command
+
+            resume_input = Command(resume=action_response.model_dump()) if action_response else None
             if action_response:
-                self.graph.update_state(run_config, {"hitl_response": action_response})
                 logger.info(f"Streaming resume after HITL response (action_id: {action_response.action_id})")
 
-            # Stream resume by invoking with None
             async for state in self.graph.astream(
-                None,
+                resume_input,
                 config=run_config,
                 stream_mode="updates",
                 subgraphs=True,

--- a/src/cuga/sdk_core/tests/test_sdk_hitl_resume.py
+++ b/src/cuga/sdk_core/tests/test_sdk_hitl_resume.py
@@ -1,0 +1,81 @@
+"""Tests for SDK HITL resume (Command) and tool-approval denial paths."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langgraph.types import Command
+
+from cuga import CugaAgent
+from cuga.backend.cuga_graph.nodes.human_in_the_loop.followup_model import (
+    ActionResponse,
+    ActionType,
+)
+from cuga.backend.cuga_graph.state.agent_state import AgentState
+
+
+class TestSDKHitlResume:
+    @pytest.mark.asyncio
+    async def test_invoke_resumes_interrupt_with_command(self):
+        agent = CugaAgent(tools=[], auto_load_policies=False, reset_policy_storage=True)
+        mock_graph = MagicMock()
+        mock_graph.ainvoke = AsyncMock(return_value={"final_answer": "done", "tool_calls": []})
+        agent._compiled_graph = mock_graph
+
+        approval = ActionResponse(
+            action_id="tool_approval",
+            response_type=ActionType.CONFIRMATION,
+            confirmed=True,
+            timestamp=datetime.now().isoformat(),
+        )
+
+        with patch("cuga.sdk.init_openlit"), patch("cuga.sdk.set_session_attribute"):
+            result = await agent.invoke(None, thread_id="hitl-resume-test", action_response=approval)
+
+        assert result.answer == "done"
+        mock_graph.ainvoke.assert_awaited_once()
+        resume_arg = mock_graph.ainvoke.await_args.args[0]
+        assert isinstance(resume_arg, Command)
+        assert resume_arg.resume == approval.model_dump()
+        mock_graph.update_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stream_resumes_interrupt_with_command(self):
+        agent = CugaAgent(tools=[], auto_load_policies=False, reset_policy_storage=True)
+        mock_graph = MagicMock()
+
+        async def fake_astream(resume_input, **kwargs):
+            assert isinstance(resume_input, Command)
+            yield ("", {"node": {}})
+
+        mock_graph.astream = fake_astream
+        agent._compiled_graph = mock_graph
+
+        approval = ActionResponse(
+            action_id="tool_approval",
+            response_type=ActionType.CONFIRMATION,
+            confirmed=True,
+            timestamp=datetime.now().isoformat(),
+        )
+
+        with patch("cuga.sdk.init_openlit"), patch("cuga.sdk.set_session_attribute"):
+            chunks = [
+                chunk
+                async for chunk in agent.stream(None, thread_id="hitl-stream-test", action_response=approval)
+            ]
+
+        assert len(chunks) == 1
+
+
+class TestToolApprovalDenial:
+    def test_agent_state_has_no_execution_complete_field(self):
+        state = AgentState(input="test", url="")
+        with pytest.raises(ValueError, match="execution_complete"):
+            state.execution_complete = True
+
+    def test_denial_final_answer_does_not_need_execution_complete(self):
+        state = AgentState(input="test", url="")
+        state.final_answer = "❌ **Execution Cancelled**"
+        dumped = state.model_dump()
+        assert "cancel" in dumped["final_answer"].lower()
+        assert "execution_complete" not in dumped


### PR DESCRIPTION
## Summary
- Validates and fixes #376: `CugaAgent.invoke`/`stream` now resume LangGraph `interrupt()` with `Command(resume=action_response.model_dump())`, matching the existing `CugaSupervisor` pattern instead of `update_state` + `ainvoke(None)`.
- Validates and fixes #377: remove `state.execution_complete = True` on `AgentState` denial paths in `sdk.py` and `cuga_lite_node.py` (field does not exist on `AgentState`; denial already sets `final_answer` and routes to `FinalAnswerAgent`).

## Validation
- Reproduced #377 locally: assigning `execution_complete` on `AgentState` raises `ValueError`.
- Confirmed #376 statically: `CugaAgent.invoke` used broken resume pattern while `CugaSupervisor.invoke` already used `Command(resume=...)`.
- Added `test_sdk_hitl_resume.py` with mocked resume-path tests and denial-state checks (4 tests passing).

Fixes #376
Fixes #377

## Test plan
- [x] `uv run pytest src/cuga/sdk_core/tests/test_sdk_hitl_resume.py -q`
- [x] `uv run ruff check` / `uv run ruff format` on touched files
- [ ] Manual: run issue #376 repro script and confirm gated tool side effect after approval
- [ ] Manual: deny tool approval and confirm clean "Execution Cancelled" answer (no ValueError)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Human-in-the-loop approvals now resume using a structured resume signal, improving continuity for both interactive and streamed runs.
  * When a tool approval is denied, users now receive a clear cancellation message that includes the active policy name.

* **Bug Fixes**
  * Fixed denial handling so the flow routes directly to the final response instead of relying on a completion flag.
  * Improved resume behavior after approval, making confirmed actions continue more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->