### PR TITLE
knowledge: chunking-precision pass for HF-tokenizer embedders (tiktoken + canary + safety margin)

### DIFF
--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -1240,14 +1240,44 @@ def _load_hf_tokenizer_for_chunking(repo_id: str):
         return None
 
 
+# Safety margin subtracted from the HF tokenizer's raw model_max_length
+# before we hand the cap to the chunker / splitter. Covers two
+# embedder-side overheads the local tokenizer doesn't see at chunk-count
+# time:
+#
+#   (a) BOS/EOS asymmetry — ``tokenizer.encode(text)`` adds them when the
+#       chunker measures, but some hosted embedders re-tokenize the
+#       chunk text with their own special-token policy on top.
+#   (b) e5-family ``"query: "`` / ``"passage: "`` prefix that hosted
+#       providers (notably watsonx) auto-prepend before embed — 3-4
+#       XLM-RoBERTa tokens the chunker never sees.
+#
+# User-reported smoking gun on PR #383 manual QA (cuga 16:22:28 log):
+# chunker capped at 512, watsonx still rejected with
+# ``This model's maximum context length is 512 tokens. However, you
+#  requested 518 tokens`` — a +6 overhead consistent with prefix + BOS.
+# 16 is generous enough for any current provider's wrapping; we'd
+# rather lose ~3% of context window than fail ingest on edge chunks.
+_HF_TOKEN_SAFETY_MARGIN = 16
+
+
 def _hf_tokenizer_seq_limit(tok) -> int:
-    """Read the HF tokenizer's max input length. Sentinel (>= 1e6) means
-    'unset' — default to 512 (BERT / XLM-RoBERTa convention)."""
+    """Return the safe chunk-token cap for this tokenizer's model.
+
+    NOT the raw ``model_max_length`` — that's the embedder's HARD limit,
+    and the chunker can't count provider-side wrapping (special tokens,
+    e5 prefixes). Subtracts ``_HF_TOKEN_SAFETY_MARGIN`` so chunks at
+    the returned cap survive the embedder's wrapping. See the constant's
+    docstring for the user-reported bug this prevents.
+
+    Sentinel (>= 1e6) means 'unset' → defaults to 512 - margin (BERT /
+    XLM-RoBERTa convention)."""
     try:
         mml = int(getattr(tok, "model_max_length", 0) or 0)
     except (TypeError, ValueError):
-        return 512
-    return mml if 0 < mml < 1_000_000 else 512
+        return max(1, 512 - _HF_TOKEN_SAFETY_MARGIN)
+    raw = mml if 0 < mml < 1_000_000 else 512
+    return max(1, raw - _HF_TOKEN_SAFETY_MARGIN)
 
 
 def _resolve_tiktoken_encoding(model_name: str):

--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -1191,6 +1191,32 @@ def _strip_litellm_route_prefix(name: str) -> str:
     return n
 
 
+# Aliases for litellm/openrouter model names that DON'T match a public HF
+# repo path directly. Saves one Hub HEAD miss per process per unknown
+# repo (cf. workflow w5i1mbchd synth, R1+R3 fix #3). Conservative:
+# only entries where the public HF mirror's existence is well-known.
+# Add via PR, not at runtime — the value of the map is that it's
+# auditable, not exhaustive.
+#
+# Note: cohere/voyage embeddings DON'T have public HF tokenizer
+# mirrors (Cohere and Voyage publish models but not their tokenizers
+# as standalone HF repos). They fall through to the approximate kind
+# via char-based RecursiveCharacterTextSplitter, which is the correct
+# behavior for closed-vendor embedders.
+_HF_REPO_ALIASES: dict[str, str] = {
+    # Jina embeddings — litellm exposes ``jina_ai/jina-embeddings-v3``,
+    # ``jina-embeddings-v3`` and similar shorter forms; the canonical
+    # HF path is ``jinaai/`` (no underscore).
+    "jina-embeddings-v3": "jinaai/jina-embeddings-v3",
+    "jina-embeddings-v2-base-en": "jinaai/jina-embeddings-v2-base-en",
+    "jina_ai/jina-embeddings-v3": "jinaai/jina-embeddings-v3",
+    # Nomic embeddings — the ``nomic-ai/`` org prefix isn't always set
+    # explicitly by users; map the bare name.
+    "nomic-embed-text-v1.5": "nomic-ai/nomic-embed-text-v1.5",
+    "nomic-embed-text-v1": "nomic-ai/nomic-embed-text-v1",
+}
+
+
 def _hf_repo_id_candidate(model_name: str) -> Optional[str]:
     """Return the stripped model name as a CANDIDATE HF repo id (e.g.
     ``intfloat/multilingual-e5-large``) when ``model_name`` looks
@@ -1201,25 +1227,45 @@ def _hf_repo_id_candidate(model_name: str) -> Optional[str]:
     truth instead of maintaining a curated allow-list (deleted in PR-A,
     cf. workflow ``w9y9xtyse`` synth) — failed lookups log + lru_cache
     the None so each unknown model costs at most one Hub HEAD per
-    process."""
+    process.
+
+    Aliases (``_HF_REPO_ALIASES``) are consulted FIRST so litellm
+    model names like ``jina-embeddings-v3`` resolve to the canonical
+    HF repo ``jinaai/jina-embeddings-v3`` without a wasted 404 HEAD."""
     stripped = _strip_litellm_route_prefix(model_name)
+    alias = _HF_REPO_ALIASES.get(stripped.lower())
+    if alias is not None:
+        return alias
     if "/" not in stripped:
         return None
     return stripped
 
 
 @functools.lru_cache(maxsize=8)
-def _load_hf_tokenizer_for_chunking(repo_id: str):
-    """Load HF tokenizer; memoizes None so a one-time hub timeout doesn't
-    re-fire per ingest. Lazy transformers import."""
-    try:
-        from transformers import AutoTokenizer
+def _load_hf_tokenizer_cached(repo_id: str):
+    """Inner cache for ``_load_hf_tokenizer_for_chunking``. Only caches
+    SUCCESSFUL loads — failures propagate to the outer wrapper, which
+    logs them but does NOT cache. Reason: a transient Hub 503 used to
+    permanently downgrade a model to char-based until process restart
+    (workflow w5i1mbchd synth, R2's operational quirk). The cost of
+    a retry on permanent 404 is one Hub HEAD per ingest (~50ms);
+    cheaper than the operational pager-call on a transient 503."""
+    from transformers import AutoTokenizer
 
-        tok = AutoTokenizer.from_pretrained(repo_id)
-        # [#400] First success per process (lru_cache makes this fire
-        # at most once per repo_id). Lets you grep ``[#400] hub-hit``
-        # across the log to count distinct Hub HEADs PR-A actually
-        # did — the only cost of the allow-list deletion.
+    return AutoTokenizer.from_pretrained(repo_id)
+
+
+def _load_hf_tokenizer_for_chunking(repo_id: str):
+    """Load HF tokenizer with retry-on-transient-failure semantics.
+    Successes are lru_cached via ``_load_hf_tokenizer_cached``; failures
+    are logged and dropped (NOT cached) so a flaky Hub doesn't lock the
+    model out of HF-tokenizer-mode for the rest of the process."""
+    try:
+        tok = _load_hf_tokenizer_cached(repo_id)
+        # [#400] Fires once per (process, repo_id) — lru_cache on the
+        # inner function makes the second call a hit. Grep ``[#400]
+        # hub-hit`` to count distinct HF HEADs the deleted allow-list
+        # now causes us to perform.
         logger.debug(
             f"[#400] hub-hit repo={repo_id!r} model_max_length={getattr(tok, 'model_max_length', '?')}"
         )
@@ -1233,6 +1279,14 @@ def _load_hf_tokenizer_for_chunking(repo_id: str):
             f"falling back to tiktoken. Pre-cache via HF_HOME to silence."
         )
         return None
+
+
+# Backwards-compat shim. The lru_cache moved to ``_load_hf_tokenizer_cached``
+# (workflow w5i1mbchd synth fix #4: only successes are cached, failures
+# retry on transient Hub 503s). Existing tests call
+# ``_load_hf_tokenizer_for_chunking.cache_clear()`` — forward to the
+# inner cache so they don't need to know about the split.
+_load_hf_tokenizer_for_chunking.cache_clear = _load_hf_tokenizer_cached.cache_clear  # type: ignore[attr-defined]
 
 
 # Safety margin subtracted from the HF tokenizer's raw model_max_length
@@ -1304,21 +1358,85 @@ class ChunkingTokenizer:
 
     Always present — never ``None``. The ``approximate`` kind covers the
     no-precise-tokenizer case (cohere / voyage / gemini / mistral-embed
-    via litellm) so callers can keep a single switch. ``safe_max_tokens``
-    is already margined via ``_hf_tokenizer_seq_limit`` for HF kinds, or
-    a sensible default for the others.
-    """
+    via litellm) so callers can keep a single switch.
+
+    Two distinct caps (workflow w5i1mbchd synth, fix #2):
+
+      * ``safe_max_tokens`` is the HARD CEILING — chunks above this will
+        be truncated by the embedder (silent retrieval-quality loss).
+        Already margined via ``_hf_tokenizer_seq_limit`` for HF kinds.
+      * ``recommended_chunk_tokens`` is the RETRIEVAL-QUALITY DEFAULT.
+        For ≥2K-ctx embedders, capped at 512 to match published
+        evidence (LongEmbed EMNLP 2024, BAAI bge-m3 maintainer at HF
+        discussion #59, voyage-context-3's own 512 default on its 32K
+        model). Letting a chunk grow to 8K just because the embedder
+        allows it makes retrieval WORSE — pooled embeddings dilute the
+        signal across more concepts.
+
+    Callers use ``min(chunk_size, safe_max_tokens)`` as today; the
+    chunker builders also warn when ``chunk_size > recommended_chunk_tokens``
+    so users with long-context embedders don't crank chunk_size
+    thinking 'more context = better'."""
 
     kind: str  # Literal["hf", "tiktoken", "fastembed", "approximate"]
     encoder: Any  # HF tokenizer | tiktoken Encoding | fastembed model | None
     name: str  # repo id / "cl100k_base" / "fastembed:<model>" / "char-based"
     safe_max_tokens: int  # already margined for HF; sensible default for others
+    recommended_chunk_tokens: int  # retrieval-quality default (≤512 for long-ctx)
 
 
-# Sensible default cap for the ``approximate`` and ``fastembed`` kinds —
-# 8192 covers any current embedder's context and lets the user's
-# chunk_size knob act as the effective limit via ``min(chunk_size, cap)``.
+# OpenAI text-embedding-3-* hard limit. The API rejects at >8191 tokens
+# with InvalidRequestError. Subtracting the same safety margin used for
+# HF embedders so the tiktoken branch is internally consistent (workflow
+# w5i1mbchd synth, fix #1: previously this branch used 8192 with zero
+# margin, an off-by-one + missing-margin both flagged by R1 and R2).
+_OPENAI_TIKTOKEN_HARD_CAP = 8191
+_TIKTOKEN_SAFE_MAX = _OPENAI_TIKTOKEN_HARD_CAP - _HF_TOKEN_SAFETY_MARGIN  # 8175
+
+# Sensible char-based fallback cap when no precise tokenizer is
+# available. 8192 lets the user's chunk_size knob remain the effective
+# limit; the char-based splitter doesn't risk an embedder-side
+# context-window-exceeded error because it splits by chars, not tokens.
 _DEFAULT_APPROXIMATE_CAP = 8192
+
+
+@functools.lru_cache(maxsize=32)
+def _warn_chunk_oversized_for_retrieval(
+    model_name: str, chunk_size: int, recommended: int, safe_max: int
+) -> None:
+    """Dedup'd one-shot warning when a user's chunk_size is within the
+    hard ceiling but above the retrieval-quality recommendation. The
+    lru_cache key makes this fire at most once per (model, chunk_size,
+    recommended) tuple per process — chunker rebuilds on every file
+    ingest don't spam the log. Workflow w5i1mbchd synth fix #2."""
+    logger.warning(
+        f"[#400] chunk_size={chunk_size} exceeds retrieval-quality "
+        f"recommendation {recommended} for embedder {model_name!r} "
+        f"(hard ceiling {safe_max}). Published evidence (LongEmbed "
+        f"EMNLP 2024 +24% MRR, voyage-context-3 default, BAAI bge-m3 "
+        f"maintainer) shows 256-512 token chunks retrieve BETTER than "
+        f"larger chunks regardless of embedder context. Consider "
+        f"chunk_size={recommended} in config unless you have a "
+        f"specific reason to chunk larger."
+    )
+
+
+def _recommended_chunk_tokens(safe_max: int) -> int:
+    """Retrieval-quality default. For ≥2K-ctx embedders, cap at 512
+    regardless of the hard ceiling. For <2K-ctx (bge-small at 496,
+    e5-large at 496) just use the full safe_max — there's no quality
+    reason to chunk smaller than the embedder's own window.
+
+    Evidence (workflow w5i1mbchd synth):
+      - LongEmbed (EMNLP 2024): 512-chunking outperforms 1024+ by
+        +24% MRR on long-context retrieval benchmarks.
+      - BAAI maintainer (bge-m3 HF discussion #59): 'despite 8192 ctx,
+        512-token chunks remain recommended default'.
+      - Voyage AI: voyage-context-3 ships with chunk_size=512 default
+        on its OWN 32K-context model.
+      - Cohere: recommends 300 of their 512-token window.
+      - Jina: recommends 128-512 of jina-v3's 8192."""
+    return min(safe_max, 512) if safe_max >= 2048 else safe_max
 
 
 @functools.lru_cache(maxsize=1)
@@ -3994,15 +4112,27 @@ class KnowledgeEngine:
         provider = (self._config.embedding_provider or "").lower()
         model_raw = self._config.embedding_model or ""
 
-        def _log_chosen(t: ChunkingTokenizer) -> ChunkingTokenizer:
-            # [#400] One log per get_chunking_tokenizer call announcing
-            # which dispatch branch won. Pair with the embed-time log
-            # in ``_build_docling_chunker`` to assert the chunker token
-            # contract matches the embedder. Greppable as ``\[#400\]``.
-            logger.debug(
+        def _make(kind: str, encoder: Any, name: str, safe_max: int) -> ChunkingTokenizer:
+            """Construct + log a ChunkingTokenizer in one place. Computes
+            ``recommended_chunk_tokens`` from ``safe_max`` via the global
+            policy (≤2K-ctx → safe_max; ≥2K-ctx → 512). Workflow
+            w5i1mbchd synth fix #2 + #6."""
+            t = ChunkingTokenizer(
+                kind=kind,
+                encoder=encoder,
+                name=name,
+                safe_max_tokens=safe_max,
+                recommended_chunk_tokens=_recommended_chunk_tokens(safe_max),
+            )
+            # [#400] INFO (not DEBUG) — operators need this visible by
+            # default. When a customer reports a context-window error,
+            # the first question is which dispatch branch ran (workflow
+            # w5i1mbchd synth fix #6, R1's explicit ask).
+            logger.info(
                 f"[#400] tokenizer-dispatch provider={provider!r} "
                 f"model={model_raw!r} -> kind={t.kind} name={t.name!r} "
-                f"safe_max_tokens={t.safe_max_tokens}"
+                f"safe_max_tokens={t.safe_max_tokens} "
+                f"recommended_chunk_tokens={t.recommended_chunk_tokens}"
             )
             return t
 
@@ -4013,13 +4143,11 @@ class KnowledgeEngine:
                 emb = self._default_embeddings
                 if isinstance(emb, _FastEmbedEmbeddings):
                     seq = _fastembed_docling_seq_limit(self._config.embedding_model or "")
-                    return _log_chosen(
-                        ChunkingTokenizer(
-                            kind="fastembed",
-                            encoder=emb._model,
-                            name=f"fastembed:{self._config.embedding_model or 'default'}",
-                            safe_max_tokens=seq,
-                        )
+                    return _make(
+                        "fastembed",
+                        emb._model,
+                        f"fastembed:{self._config.embedding_model or 'default'}",
+                        seq,
                     )
             except Exception:
                 pass  # fall through to approximate
@@ -4030,13 +4158,11 @@ class KnowledgeEngine:
                 self._ensure_embeddings()
                 emb = self._default_embeddings
                 if getattr(emb, "_tokenizer", None) is not None:
-                    return _log_chosen(
-                        ChunkingTokenizer(
-                            kind="hf",
-                            encoder=emb._tokenizer,
-                            name=self._config.embedding_model or "huggingface",
-                            safe_max_tokens=_hf_tokenizer_seq_limit(emb._tokenizer),
-                        )
+                    return _make(
+                        "hf",
+                        emb._tokenizer,
+                        self._config.embedding_model or "huggingface",
+                        _hf_tokenizer_seq_limit(emb._tokenizer),
                     )
             except Exception:
                 pass
@@ -4056,45 +4182,62 @@ class KnowledgeEngine:
                 try:
                     import tiktoken
 
-                    return _log_chosen(
-                        ChunkingTokenizer(
-                            kind="tiktoken",
-                            encoder=tiktoken.get_encoding("cl100k_base"),
-                            name="cl100k_base",
-                            safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
-                        )
+                    # _TIKTOKEN_SAFE_MAX = 8191 - 16 = 8175. The OpenAI API
+                    # rejects at >8191; matching the HF branch's margin
+                    # keeps the dispatcher internally consistent
+                    # (workflow w5i1mbchd synth fix #1).
+                    return _make(
+                        "tiktoken",
+                        tiktoken.get_encoding("cl100k_base"),
+                        "cl100k_base",
+                        _TIKTOKEN_SAFE_MAX,
                     )
                 except Exception:
                     pass
 
             # 3b. Try HF Hub as the source of truth (PR-A, workflow
-            # w9y9xtyse synth): no curated allow-list, no canary —
-            # ``_load_hf_tokenizer_for_chunking`` already logs failures
-            # and lru_caches the None so each unknown model costs at
-            # most one Hub HEAD per process.
+            # w9y9xtyse synth). Static aliases in ``_HF_REPO_ALIASES``
+            # short-circuit known-good redirects (jina, nomic) to skip
+            # a guaranteed Hub HEAD miss.
             repo_id = _hf_repo_id_candidate(model_raw)
             if repo_id:
                 auto_tok = _load_hf_tokenizer_for_chunking(repo_id)
                 if auto_tok is not None:
-                    return _log_chosen(
-                        ChunkingTokenizer(
-                            kind="hf",
-                            encoder=auto_tok,
-                            name=repo_id,
-                            safe_max_tokens=_hf_tokenizer_seq_limit(auto_tok),
-                        )
+                    return _make(
+                        "hf",
+                        auto_tok,
+                        repo_id,
+                        _hf_tokenizer_seq_limit(auto_tok),
                     )
 
         # 4. everything else — no precise tokenizer available. Caller
         # decides how to react (chunker uses a HybridChunker default;
         # text-splitter falls back to char-based recursive split).
-        return _log_chosen(
-            ChunkingTokenizer(
-                kind="approximate",
-                encoder=None,
-                name="char-based",
-                safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
-            )
+        return _make("approximate", None, "char-based", _DEFAULT_APPROXIMATE_CAP)
+
+    def _warn_chunk_size_above_retrieval_recommended(self, chunk_size: int, tok: ChunkingTokenizer) -> None:
+        """Advisory log when ``chunk_size`` is within the hard ceiling
+        but exceeds the retrieval-quality recommendation. Fires at most
+        once per (model, chunk_size, recommended) tuple per process so
+        per-file chunker rebuilds don't spam the log.
+
+        Workflow w5i1mbchd synth fix #2: published evidence (LongEmbed
+        EMNLP 2024 +24% MRR for 512 vs 1024, voyage-context-3 default,
+        BAAI bge-m3 maintainer) shows retrieval quality peaks at
+        256-512 tokens regardless of embedder context length. Letting
+        a chunk grow to 8K just because the embedder allows it tends
+        to hurt retrieval (pooled embeddings dilute the signal). This
+        warning surfaces the recommendation without changing the
+        behavior — users who explicitly want larger chunks can ignore
+        it; users who left chunk_size at 800 on a 32K embedder know
+        they're potentially sub-optimal."""
+        if chunk_size <= tok.recommended_chunk_tokens:
+            return
+        # Same-tuple dedup. The lru_cache is a single-call no-op that
+        # ensures the wrapped logger.info fires at most once for any
+        # (model, chunk_size, recommended) tuple this process sees.
+        _warn_chunk_oversized_for_retrieval(
+            tok.name, chunk_size, tok.recommended_chunk_tokens, tok.safe_max_tokens
         )
 
     def _build_text_splitter(self, chunk_size: int, chunk_overlap: int):
@@ -4107,6 +4250,7 @@ class KnowledgeEngine:
         margin for HF kinds (see ``_hf_tokenizer_seq_limit`` /
         ``_HF_TOKEN_SAFETY_MARGIN``)."""
         tok = self.get_chunking_tokenizer()
+        self._warn_chunk_size_above_retrieval_recommended(chunk_size, tok)
         cap = min(chunk_size, tok.safe_max_tokens)
         overlap = min(chunk_overlap, max(cap // 4, 1))
 
@@ -4154,6 +4298,7 @@ class KnowledgeEngine:
             from docling_core.transforms.chunker import HybridChunker
 
             tok_info = self.get_chunking_tokenizer()
+            self._warn_chunk_size_above_retrieval_recommended(chunk_size, tok_info)
             cap = min(chunk_size, tok_info.safe_max_tokens)
             provider = (self._config.embedding_provider or "").lower()
             model_str = self._config.embedding_model or "default"

--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -1180,23 +1180,6 @@ _LITELLM_ROUTE_PREFIXES = (
 )
 
 
-# HF orgs whose embedders ship via litellm/openrouter and need their real
-# tokenizer for chunk sizing instead of cl100k_base. Extending is a one-line
-# PR; unlisted models fall through to tiktoken (canary warns operators).
-# See #387.
-_HF_CHUNK_TOKENIZER_PREFIXES = (
-    "intfloat/",
-    "baai/bge",
-    "sentence-transformers/",
-    "jinaai/jina-embeddings-v2",
-    "thenlper/",
-    "nomic-ai/nomic-embed-",
-    "mixedbread-ai/mxbai-embed-",
-    "ibm-granite/",
-    "alibaba-nlp/gte-",
-)
-
-
 def _strip_litellm_route_prefix(name: str) -> str:
     """Strip ONE matching route prefix (case-insensitive). Single-strip so
     ``litellm/openai/x`` becomes ``openai/x``, not ``x``."""
@@ -1208,17 +1191,21 @@ def _strip_litellm_route_prefix(name: str) -> str:
     return n
 
 
-def _hf_repo_id_for_chunk_sizing(model_name: str) -> Optional[str]:
-    """Return the HF repo id to load a tokenizer from when ``model_name`` is
-    a litellm/openrouter-routed HF-style embedder. ``None`` if the model
-    doesn't look HF-style (fall through to tiktoken). Case-preserving on the
-    output so ``BAAI/bge-base-en-v1.5`` survives the round-trip."""
+def _hf_repo_id_candidate(model_name: str) -> Optional[str]:
+    """Return the stripped model name as a CANDIDATE HF repo id (e.g.
+    ``intfloat/multilingual-e5-large``) when ``model_name`` looks
+    HF-style (contains a slash after route-prefix stripping).
+    The loader (``_load_hf_tokenizer_for_chunking``) does the
+    actual ``AutoTokenizer.from_pretrained`` and decides via try/except
+    whether the repo exists on the Hub. We let HF Hub be the source of
+    truth instead of maintaining a curated allow-list (deleted in PR-A,
+    cf. workflow ``w9y9xtyse`` synth) — failed lookups log + lru_cache
+    the None so each unknown model costs at most one Hub HEAD per
+    process."""
     stripped = _strip_litellm_route_prefix(model_name)
     if "/" not in stripped:
         return None
-    if stripped.lower().startswith(_HF_CHUNK_TOKENIZER_PREFIXES):
-        return stripped
-    return None
+    return stripped
 
 
 @functools.lru_cache(maxsize=8)
@@ -1324,20 +1311,6 @@ class ChunkingTokenizer:
 # 8192 covers any current embedder's context and lets the user's
 # chunk_size knob act as the effective limit via ``min(chunk_size, cap)``.
 _DEFAULT_APPROXIMATE_CAP = 8192
-
-
-@functools.lru_cache(maxsize=64)
-def _warn_unlisted_embedder_once(provider: str, model: str, encoding_name: str) -> None:
-    """Operator canary: warn once per (provider, model, encoding) when chunker
-    falls back to cl100k_base for a litellm/openrouter HF-style model not on
-    the allow-list. See #387, gating criterion in #395."""
-    logger.warning(
-        f"HybridChunker: embedder {model!r} (provider={provider!r}) is not in the "
-        f"HF-tokenizer allow-list; chunk sizing uses tiktoken {encoding_name} as an "
-        f"approximation. If retrieval quality is low on non-English / long-form "
-        f"content, extend _HF_CHUNK_TOKENIZER_PREFIXES in "
-        f"src/cuga/backend/knowledge/engine.py or open an issue with the repo id."
-    )
 
 
 @functools.lru_cache(maxsize=1)
@@ -4043,22 +4016,12 @@ class KnowledgeEngine:
             except Exception:
                 pass
 
-        # 3. litellm/openrouter/openai with an HF-listed model id.
+        # 3. litellm/openrouter/openai routes.
         if provider in ("litellm", "openrouter", "openai"):
-            repo_id = _hf_repo_id_for_chunk_sizing(model_raw)
-            if repo_id:
-                auto_tok = _load_hf_tokenizer_for_chunking(repo_id)
-                if auto_tok is not None:
-                    return ChunkingTokenizer(
-                        kind="hf",
-                        encoder=auto_tok,
-                        name=repo_id,
-                        safe_max_tokens=_hf_tokenizer_seq_limit(auto_tok),
-                    )
-
-            # 4. tiktoken for openai-native + azure routes. Strip only the
-            # outer routing prefix (litellm/ or openrouter/) so we can
-            # still see the inner openai/ or azure/ marker.
+            # 3a. tiktoken FIRST for openai-native + azure routes (no HTTP
+            # cost). Strip only the outer routing prefix (litellm/ or
+            # openrouter/) so we can still see the inner openai/ or
+            # azure/ marker.
             outer = model_raw.lower()
             for outer_prefix in ("litellm/", "openrouter/"):
                 if outer.startswith(outer_prefix):
@@ -4076,6 +4039,22 @@ class KnowledgeEngine:
                     )
                 except Exception:
                     pass
+
+            # 3b. Try HF Hub as the source of truth (PR-A, workflow
+            # w9y9xtyse synth): no curated allow-list, no canary —
+            # ``_load_hf_tokenizer_for_chunking`` already logs failures
+            # and lru_caches the None so each unknown model costs at
+            # most one Hub HEAD per process.
+            repo_id = _hf_repo_id_candidate(model_raw)
+            if repo_id:
+                auto_tok = _load_hf_tokenizer_for_chunking(repo_id)
+                if auto_tok is not None:
+                    return ChunkingTokenizer(
+                        kind="hf",
+                        encoder=auto_tok,
+                        name=repo_id,
+                        safe_max_tokens=_hf_tokenizer_seq_limit(auto_tok),
+                    )
 
         # 5. everything else — no precise tokenizer available.
         # Caller fires the operator canary (so the encoding-sentinel
@@ -4120,22 +4099,11 @@ class KnowledgeEngine:
                 logger.warning(f"from_tiktoken_encoder failed ({e}); char fallback.")
 
         # ``approximate`` (cohere/voyage/gemini/etc.) and ``fastembed``
-        # plain-text path: char-based fallback. Fire the operator canary
-        # for unlisted slash-model litellm/openrouter routes — this is
-        # the splitter-side mirror of the chunker's canary; both dedup
-        # by (provider, model, encoding-name) so each fires ONCE per
-        # process.
-        provider = (self._config.embedding_provider or "").lower()
-        if tok.kind == "approximate" and provider in ("litellm", "openrouter"):
-            model_raw = self._config.embedding_model or ""
-            stripped = _strip_litellm_route_prefix(model_raw) or model_raw
-            if (
-                "/" in stripped
-                and _hf_repo_id_for_chunk_sizing(model_raw) is None
-                and not stripped.lower().startswith(("openai/", "azure/"))
-            ):
-                _warn_unlisted_embedder_once(provider, stripped, "char_based_split")
-
+        # plain-text path: char-based fallback. The operator canary that
+        # used to fire here (PR #400 b3af0800) was deleted in PR-A — the
+        # ``_load_hf_tokenizer_for_chunking`` lru_cached warning already
+        # surfaces unknown-model lookups, and the curated allow-list it
+        # consulted to dedup vs that warning is gone.
         return RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
 
     def _build_docling_chunker(self, chunk_size: int):
@@ -4214,15 +4182,6 @@ class KnowledgeEngine:
 
                 encoding = tiktoken.get_encoding("cl100k_base")
                 tok = _tiktoken_docling_tokenizer_cls()(encoding=encoding, max_tokens=chunk_size)
-                model_raw = self._config.embedding_model or ""
-                stripped = _strip_litellm_route_prefix(model_raw) or model_raw
-                if (
-                    provider in {"litellm", "openrouter"}
-                    and "/" in stripped
-                    and _hf_repo_id_for_chunk_sizing(model_raw) is None
-                    and not stripped.lower().startswith(("openai/", "azure/"))
-                ):
-                    _warn_unlisted_embedder_once(provider, stripped, "cl100k_base")
                 logger.debug(
                     f"HybridChunker tokenizer: cl100k_base (approximate; "
                     f"provider={provider!r}, model={model_str!r})"

--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -1215,13 +1215,21 @@ def _load_hf_tokenizer_for_chunking(repo_id: str):
     try:
         from transformers import AutoTokenizer
 
-        return AutoTokenizer.from_pretrained(repo_id)
+        tok = AutoTokenizer.from_pretrained(repo_id)
+        # [#400] First success per process (lru_cache makes this fire
+        # at most once per repo_id). Lets you grep ``[#400] hub-hit``
+        # across the log to count distinct Hub HEADs PR-A actually
+        # did — the only cost of the allow-list deletion.
+        logger.debug(
+            f"[#400] hub-hit repo={repo_id!r} model_max_length={getattr(tok, 'model_max_length', '?')}"
+        )
+        return tok
     except ImportError:
         logger.debug("transformers missing; HF tokenizer skipped for chunk sizing.")
         return None
     except Exception as e:
         logger.warning(
-            f"HF tokenizer load failed (repo={repo_id!r}, err={e!r}); "
+            f"[#400] hub-miss repo={repo_id!r} err={e!r}; "
             f"falling back to tiktoken. Pre-cache via HF_HOME to silence."
         )
         return None
@@ -3975,15 +3983,28 @@ class KnowledgeEngine:
         Dispatch (first match wins):
           1. fastembed -> Rust ONNX tokenizer (exact match w/ embedder)
           2. huggingface -> the embedder's own ``_tokenizer`` attr
-          3. litellm/openrouter/openai + HF-allow-listed model -> AutoTokenizer
-          4. openai-native OR litellm/openrouter routed to openai/azure -> tiktoken cl100k_base
-          5. everything else -> 'approximate' kind (cohere/voyage/gemini/etc.)
-
-        ``approximate`` is intentionally explicit so callers can keep one
-        switch + log a canary in the same place.
+          3a. litellm/openrouter/openai routed to openai/azure -> tiktoken
+              cl100k_base (no Hub HEAD; correct encoding for these models)
+          3b. litellm/openrouter/openai with any other slash-containing
+              model -> AutoTokenizer.from_pretrained via HF Hub (PR-A
+              made the Hub the source of truth; no curated allow-list)
+          4. everything else -> 'approximate' kind (cohere/voyage/gemini
+              when their HF lookup 404s, plain-named local models, etc.)
         """
         provider = (self._config.embedding_provider or "").lower()
         model_raw = self._config.embedding_model or ""
+
+        def _log_chosen(t: ChunkingTokenizer) -> ChunkingTokenizer:
+            # [#400] One log per get_chunking_tokenizer call announcing
+            # which dispatch branch won. Pair with the embed-time log
+            # in ``_build_docling_chunker`` to assert the chunker token
+            # contract matches the embedder. Greppable as ``\[#400\]``.
+            logger.debug(
+                f"[#400] tokenizer-dispatch provider={provider!r} "
+                f"model={model_raw!r} -> kind={t.kind} name={t.name!r} "
+                f"safe_max_tokens={t.safe_max_tokens}"
+            )
+            return t
 
         # 1. fastembed — exact match via the embedder's own ONNX tokenizer.
         if provider == "fastembed":
@@ -3992,11 +4013,13 @@ class KnowledgeEngine:
                 emb = self._default_embeddings
                 if isinstance(emb, _FastEmbedEmbeddings):
                     seq = _fastembed_docling_seq_limit(self._config.embedding_model or "")
-                    return ChunkingTokenizer(
-                        kind="fastembed",
-                        encoder=emb._model,
-                        name=f"fastembed:{self._config.embedding_model or 'default'}",
-                        safe_max_tokens=seq,
+                    return _log_chosen(
+                        ChunkingTokenizer(
+                            kind="fastembed",
+                            encoder=emb._model,
+                            name=f"fastembed:{self._config.embedding_model or 'default'}",
+                            safe_max_tokens=seq,
+                        )
                     )
             except Exception:
                 pass  # fall through to approximate
@@ -4007,11 +4030,13 @@ class KnowledgeEngine:
                 self._ensure_embeddings()
                 emb = self._default_embeddings
                 if getattr(emb, "_tokenizer", None) is not None:
-                    return ChunkingTokenizer(
-                        kind="hf",
-                        encoder=emb._tokenizer,
-                        name=self._config.embedding_model or "huggingface",
-                        safe_max_tokens=_hf_tokenizer_seq_limit(emb._tokenizer),
+                    return _log_chosen(
+                        ChunkingTokenizer(
+                            kind="hf",
+                            encoder=emb._tokenizer,
+                            name=self._config.embedding_model or "huggingface",
+                            safe_max_tokens=_hf_tokenizer_seq_limit(emb._tokenizer),
+                        )
                     )
             except Exception:
                 pass
@@ -4031,11 +4056,13 @@ class KnowledgeEngine:
                 try:
                     import tiktoken
 
-                    return ChunkingTokenizer(
-                        kind="tiktoken",
-                        encoder=tiktoken.get_encoding("cl100k_base"),
-                        name="cl100k_base",
-                        safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
+                    return _log_chosen(
+                        ChunkingTokenizer(
+                            kind="tiktoken",
+                            encoder=tiktoken.get_encoding("cl100k_base"),
+                            name="cl100k_base",
+                            safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
+                        )
                     )
                 except Exception:
                     pass
@@ -4049,21 +4076,25 @@ class KnowledgeEngine:
             if repo_id:
                 auto_tok = _load_hf_tokenizer_for_chunking(repo_id)
                 if auto_tok is not None:
-                    return ChunkingTokenizer(
-                        kind="hf",
-                        encoder=auto_tok,
-                        name=repo_id,
-                        safe_max_tokens=_hf_tokenizer_seq_limit(auto_tok),
+                    return _log_chosen(
+                        ChunkingTokenizer(
+                            kind="hf",
+                            encoder=auto_tok,
+                            name=repo_id,
+                            safe_max_tokens=_hf_tokenizer_seq_limit(auto_tok),
+                        )
                     )
 
-        # 5. everything else — no precise tokenizer available.
-        # Caller fires the operator canary (so the encoding-sentinel
-        # distinguishes chunker vs splitter origin).
-        return ChunkingTokenizer(
-            kind="approximate",
-            encoder=None,
-            name="char-based",
-            safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
+        # 4. everything else — no precise tokenizer available. Caller
+        # decides how to react (chunker uses a HybridChunker default;
+        # text-splitter falls back to char-based recursive split).
+        return _log_chosen(
+            ChunkingTokenizer(
+                kind="approximate",
+                encoder=None,
+                name="char-based",
+                safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
+            )
         )
 
     def _build_text_splitter(self, chunk_size: int, chunk_overlap: int):

--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -1296,6 +1296,36 @@ def _resolve_tiktoken_encoding(model_name: str):
         return tiktoken.get_encoding("cl100k_base")
 
 
+@dataclass(frozen=True)
+class ChunkingTokenizer:
+    """Single-dispatch contract: given a provider+model, what tokenizer
+    sizes the chunks?
+
+    Replaces the per-callsite branching that existed in both
+    ``_build_docling_chunker`` and ``_build_text_splitter`` (each ~60 LOC
+    of provider dispatch repeating the same logic). After this refactor,
+    each builder switches on ``kind`` once and hands off to the
+    appropriate primitive.
+
+    Always present — never ``None``. The ``approximate`` kind covers the
+    no-precise-tokenizer case (cohere / voyage / gemini / mistral-embed
+    via litellm) so callers can keep a single switch. ``safe_max_tokens``
+    is already margined via ``_hf_tokenizer_seq_limit`` for HF kinds, or
+    a sensible default for the others.
+    """
+
+    kind: str  # Literal["hf", "tiktoken", "fastembed", "approximate"]
+    encoder: Any  # HF tokenizer | tiktoken Encoding | fastembed model | None
+    name: str  # repo id / "cl100k_base" / "fastembed:<model>" / "char-based"
+    safe_max_tokens: int  # already margined for HF; sensible default for others
+
+
+# Sensible default cap for the ``approximate`` and ``fastembed`` kinds —
+# 8192 covers any current embedder's context and lets the user's
+# chunk_size knob act as the effective limit via ``min(chunk_size, cap)``.
+_DEFAULT_APPROXIMATE_CAP = 8192
+
+
 @functools.lru_cache(maxsize=64)
 def _warn_unlisted_embedder_once(provider: str, model: str, encoding_name: str) -> None:
     """Operator canary: warn once per (provider, model, encoding) when chunker
@@ -3963,53 +3993,72 @@ class KnowledgeEngine:
         """Get chunk_size and chunk_overlap from _config (source of truth after publish)."""
         return self._config.chunk_size, self._config.chunk_overlap
 
-    def _build_text_splitter(self, chunk_size: int, chunk_overlap: int):
-        """Token-aware splitter when a tokenizer is known for the active
-        embedder; char-based fallback otherwise. See #387 follow-up.
+    def get_chunking_tokenizer(self) -> ChunkingTokenizer:
+        """Resolve the tokenizer + safe max for the active embedder.
+        SINGLE dispatcher. Both ``_build_docling_chunker`` and
+        ``_build_text_splitter`` consume this; before the refactor each
+        had its own copy of the provider branching.
 
-        Dispatch order (first match wins):
-          1. HF tokenizer for litellm/openrouter HF-listed orgs (intfloat/,
-             BAAI/bge, sentence-transformers/, …) — exact unit.
-          2. tiktoken cl100k_base for openai-native + azure routes
-             (including litellm/openai/* and litellm/azure/*) — also exact.
-          3. HuggingFace-provider model's own tokenizer — exact.
-          4. Char-based fallback (cohere/voyage/gemini/ollama/fastembed
-             plain-text and any unlisted slash-model). Operator canary log
-             fires for the unlisted-HF-style case so we can collect
-             telemetry on which orgs to add to the allow-list (mirrors
-             the canary already firing in ``_build_docling_chunker``).
+        Dispatch (first match wins):
+          1. fastembed -> Rust ONNX tokenizer (exact match w/ embedder)
+          2. huggingface -> the embedder's own ``_tokenizer`` attr
+          3. litellm/openrouter/openai + HF-allow-listed model -> AutoTokenizer
+          4. openai-native OR litellm/openrouter routed to openai/azure -> tiktoken cl100k_base
+          5. everything else -> 'approximate' kind (cohere/voyage/gemini/etc.)
+
+        ``approximate`` is intentionally explicit so callers can keep one
+        switch + log a canary in the same place.
         """
-
-        def _hf_splitter(tok):
-            # ``from_huggingface_tokenizer`` overcounts BOS/EOS by ~2 tokens
-            # for e5/BGE (langchain#30184) — harmless under-fill, not the
-            # truncation we're fixing.
-            cap = min(chunk_size, _hf_tokenizer_seq_limit(tok))
-            return RecursiveCharacterTextSplitter.from_huggingface_tokenizer(
-                tok, chunk_size=cap, chunk_overlap=min(chunk_overlap, cap // 4)
-            )
-
         provider = (self._config.embedding_provider or "").lower()
         model_raw = self._config.embedding_model or ""
 
-        # 1. HF allow-list (litellm/openrouter HF-style routes).
+        # 1. fastembed — exact match via the embedder's own ONNX tokenizer.
+        if provider == "fastembed":
+            try:
+                self._ensure_embeddings()
+                emb = self._default_embeddings
+                if isinstance(emb, _FastEmbedEmbeddings):
+                    seq = _fastembed_docling_seq_limit(self._config.embedding_model or "")
+                    return ChunkingTokenizer(
+                        kind="fastembed",
+                        encoder=emb._model,
+                        name=f"fastembed:{self._config.embedding_model or 'default'}",
+                        safe_max_tokens=seq,
+                    )
+            except Exception:
+                pass  # fall through to approximate
+
+        # 2. HuggingFace provider — embedder loaded its own tokenizer.
+        if provider == "huggingface":
+            try:
+                self._ensure_embeddings()
+                emb = self._default_embeddings
+                if getattr(emb, "_tokenizer", None) is not None:
+                    return ChunkingTokenizer(
+                        kind="hf",
+                        encoder=emb._tokenizer,
+                        name=self._config.embedding_model or "huggingface",
+                        safe_max_tokens=_hf_tokenizer_seq_limit(emb._tokenizer),
+                    )
+            except Exception:
+                pass
+
+        # 3. litellm/openrouter/openai with an HF-listed model id.
         if provider in ("litellm", "openrouter", "openai"):
             repo_id = _hf_repo_id_for_chunk_sizing(model_raw)
             if repo_id:
                 auto_tok = _load_hf_tokenizer_for_chunking(repo_id)
                 if auto_tok is not None:
-                    try:
-                        return _hf_splitter(auto_tok)
-                    except Exception as e:
-                        logger.warning(f"from_huggingface_tokenizer failed ({e}); char fallback.")
+                    return ChunkingTokenizer(
+                        kind="hf",
+                        encoder=auto_tok,
+                        name=repo_id,
+                        safe_max_tokens=_hf_tokenizer_seq_limit(auto_tok),
+                    )
 
-            # 2. tiktoken for openai-native / azure routes. cl100k_base is
-            # exactly what text-embedding-3-* and ada-002 use; for azure
-            # it's a near-perfect approximation. Strip ONLY the outer
-            # routing prefix (litellm/ or openrouter/) — don't use
-            # ``_strip_litellm_route_prefix`` because that also strips
-            # ``openai/`` and ``azure/``, which would erase the marker
-            # we're trying to detect.
+            # 4. tiktoken for openai-native + azure routes. Strip only the
+            # outer routing prefix (litellm/ or openrouter/) so we can
+            # still see the inner openai/ or azure/ marker.
             outer = model_raw.lower()
             for outer_prefix in ("litellm/", "openrouter/"):
                 if outer.startswith(outer_prefix):
@@ -4017,39 +4066,73 @@ class KnowledgeEngine:
                     break
             if provider == "openai" or outer.startswith(("openai/", "azure/")):
                 try:
-                    return RecursiveCharacterTextSplitter.from_tiktoken_encoder(
-                        encoding_name="cl100k_base",
-                        chunk_size=chunk_size,
-                        chunk_overlap=chunk_overlap,
+                    import tiktoken
+
+                    return ChunkingTokenizer(
+                        kind="tiktoken",
+                        encoder=tiktoken.get_encoding("cl100k_base"),
+                        name="cl100k_base",
+                        safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
                     )
-                except Exception as e:
-                    logger.warning(f"from_tiktoken_encoder failed ({e}); char fallback.")
+                except Exception:
+                    pass
 
-        # 3. HF-provider — reuse the embedder's own tokenizer.
-        elif provider == "huggingface":
+        # 5. everything else — no precise tokenizer available.
+        # Caller fires the operator canary (so the encoding-sentinel
+        # distinguishes chunker vs splitter origin).
+        return ChunkingTokenizer(
+            kind="approximate",
+            encoder=None,
+            name="char-based",
+            safe_max_tokens=_DEFAULT_APPROXIMATE_CAP,
+        )
+
+    def _build_text_splitter(self, chunk_size: int, chunk_overlap: int):
+        """Token-aware splitter via the unified ``get_chunking_tokenizer``
+        dispatch. See #387 follow-up — both this and ``_build_docling_chunker``
+        used to carry their own provider-branch copy; now they share the
+        accessor and just switch on ``tok.kind``.
+
+        ``tok.safe_max_tokens`` already accounts for the embedder-wrapping
+        margin for HF kinds (see ``_hf_tokenizer_seq_limit`` /
+        ``_HF_TOKEN_SAFETY_MARGIN``)."""
+        tok = self.get_chunking_tokenizer()
+        cap = min(chunk_size, tok.safe_max_tokens)
+        overlap = min(chunk_overlap, max(cap // 4, 1))
+
+        if tok.kind == "hf":
             try:
-                self._ensure_embeddings()
-                emb = self._default_embeddings
-                if getattr(emb, "_tokenizer", None) is not None:
-                    return _hf_splitter(emb._tokenizer)
+                # ``from_huggingface_tokenizer`` overcounts BOS/EOS by ~2
+                # tokens (langchain#30184) — harmless under-fill, not the
+                # 518>512 truncation that the safety margin handles.
+                return RecursiveCharacterTextSplitter.from_huggingface_tokenizer(
+                    tok.encoder, chunk_size=cap, chunk_overlap=overlap
+                )
             except Exception as e:
-                logger.warning(f"HF-provider tokenizer reuse failed ({e}); char fallback.")
+                logger.warning(f"from_huggingface_tokenizer failed ({e}); char fallback.")
 
-        # 4. Char-based fallback. For unlisted HF-style slash-models on
-        # litellm/openrouter routes, fire the same canary the chunker
-        # path fires — this is the splitter-side mirror of #387's
-        # silent-degradation signal. ``_warn_unlisted_embedder_once``
-        # dedups by (provider, model, encoding_name), so the chunker and
-        # splitter sides each fire ONCE per process per unlisted model.
-        # The "char_based_split" sentinel distinguishes the splitter
-        # origin from the chunker's "cl100k_base" key.
-        if provider in ("litellm", "openrouter"):
+        if tok.kind == "tiktoken":
+            try:
+                return RecursiveCharacterTextSplitter.from_tiktoken_encoder(
+                    encoding_name=tok.name, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                )
+            except Exception as e:
+                logger.warning(f"from_tiktoken_encoder failed ({e}); char fallback.")
+
+        # ``approximate`` (cohere/voyage/gemini/etc.) and ``fastembed``
+        # plain-text path: char-based fallback. Fire the operator canary
+        # for unlisted slash-model litellm/openrouter routes — this is
+        # the splitter-side mirror of the chunker's canary; both dedup
+        # by (provider, model, encoding-name) so each fires ONCE per
+        # process.
+        provider = (self._config.embedding_provider or "").lower()
+        if tok.kind == "approximate" and provider in ("litellm", "openrouter"):
+            model_raw = self._config.embedding_model or ""
             stripped = _strip_litellm_route_prefix(model_raw) or model_raw
-            stripped_lo = stripped.lower()
             if (
                 "/" in stripped
                 and _hf_repo_id_for_chunk_sizing(model_raw) is None
-                and not stripped_lo.startswith(("openai/", "azure/"))
+                and not stripped.lower().startswith(("openai/", "azure/"))
             ):
                 _warn_unlisted_embedder_once(provider, stripped, "char_based_split")
 
@@ -4071,148 +4154,82 @@ class KnowledgeEngine:
         try:
             from docling_core.transforms.chunker import HybridChunker
 
-            if self._config.embedding_provider == "fastembed":
-                self._ensure_embeddings()
-                emb = self._default_embeddings
-                if isinstance(emb, _FastEmbedEmbeddings):
-                    seq = _fastembed_docling_seq_limit(self._config.embedding_model or "")
-                    cap = min(chunk_size, seq)
-                    fe = emb._model
-                    tok = _fastembed_docling_tokenizer_cls()(
-                        text_embedding=fe,
-                        max_tokens=cap,
+            tok_info = self.get_chunking_tokenizer()
+            cap = min(chunk_size, tok_info.safe_max_tokens)
+            provider = (self._config.embedding_provider or "").lower()
+            model_str = self._config.embedding_model or "default"
+
+            if tok_info.kind == "fastembed":
+                tok = _fastembed_docling_tokenizer_cls()(text_embedding=tok_info.encoder, max_tokens=cap)
+                logger.debug(
+                    f"HybridChunker tokenizer: fastembed ONNX (model={tok_info.name!r}, "
+                    f"chunk_token_limit={cap}, model_seq_limit={tok_info.safe_max_tokens})"
+                )
+                return HybridChunker(tokenizer=tok)
+
+            if tok_info.kind == "hf":
+                try:
+                    from docling_core.transforms.chunker.tokenizer.huggingface import (
+                        HuggingFaceTokenizer,
                     )
-                    mn = getattr(fe, "model_name", None)
+
+                    if cap < chunk_size:
+                        logger.info(
+                            f"Capping chunk_size {chunk_size} -> {cap} for embedder "
+                            f"{tok_info.name} (safe_max_tokens={tok_info.safe_max_tokens}). "
+                            f"Chunks at the original size would have been truncated at embed time."
+                        )
+                    tok = HuggingFaceTokenizer(tokenizer=tok_info.encoder, max_tokens=cap)
                     logger.debug(
-                        "HybridChunker tokenizer: fastembed ONNX (same model as embeddings) "
-                        "(model_name={!r}, chunk_token_limit={}, model_seq_limit={})",
-                        mn,
-                        cap,
-                        seq,
+                        f"HybridChunker tokenizer: HF AutoTokenizer "
+                        f"(repo={tok_info.name!r}, chunk_token_limit={cap}, "
+                        f"safe_max_tokens={tok_info.safe_max_tokens}, provider={provider!r})"
                     )
                     return HybridChunker(tokenizer=tok)
-                logger.debug(
-                    "HybridChunker tokenizer: expected _FastEmbedEmbeddings for provider=fastembed, "
-                    "got {}; using Docling default (HuggingFace MiniLM tokenizer)",
-                    type(emb).__name__,
-                )
-            # HuggingFace provider: the embedding wrapper already loaded the
-            # model's own tokenizer — reuse it. Perfect match, zero extra cost.
-            if self._config.embedding_provider == "huggingface":
-                try:
-                    self._ensure_embeddings()
-                    emb = self._default_embeddings
-                    if hasattr(emb, "_tokenizer") and emb._tokenizer is not None:
-                        from docling_core.transforms.chunker.tokenizer.huggingface import (
-                            HuggingFaceTokenizer,
-                        )
-
-                        # Cap at the model's real max_seq_length so an
-                        # 800-token chunk_size doesn't overrun e.g. e5-large's
-                        # 512-token limit and force the embedder to truncate.
-                        # Same latent bug as the litellm-routed branch below.
-                        seq = _hf_tokenizer_seq_limit(emb._tokenizer)
-                        cap = min(chunk_size, seq)
-                        tok = HuggingFaceTokenizer(
-                            tokenizer=emb._tokenizer,
-                            max_tokens=cap,
-                        )
-                        logger.debug(
-                            f"HybridChunker tokenizer: HuggingFace (model's own — already loaded by "
-                            f"_PyTorchEmbeddings; embedding_provider='huggingface', "
-                            f"model={self._config.embedding_model or 'default'!r}, "
-                            f"chunk_token_limit={cap}, model_seq_limit={seq})"
-                        )
-                        return HybridChunker(tokenizer=tok)
-                except Exception as hf_err:  # pragma: no cover - defensive
+                except Exception as wrap_err:
                     logger.warning(
-                        f"HuggingFace chunker tokenizer reuse failed ({hf_err}); falling back to tiktoken."
+                        f"HuggingFaceTokenizer wrap failed for {tok_info.name!r} ({wrap_err}); "
+                        f"falling back to tiktoken."
                     )
 
-            # litellm/openrouter-routed HF-style embedders use their own
-            # tokenizer for chunk sizing (issue #387). Unlisted models fall
-            # through to tiktoken — same behavior as before this branch.
-            if self._config.embedding_provider in ("litellm", "openrouter", "openai"):
-                repo_id = _hf_repo_id_for_chunk_sizing(self._config.embedding_model or "")
-                if repo_id:
-                    auto_tok = _load_hf_tokenizer_for_chunking(repo_id)
-                    if auto_tok is not None:
-                        try:
-                            from docling_core.transforms.chunker.tokenizer.huggingface import (
-                                HuggingFaceTokenizer,
-                            )
+            if tok_info.kind == "tiktoken":
+                try:
+                    tok = _tiktoken_docling_tokenizer_cls()(encoding=tok_info.encoder, max_tokens=chunk_size)
+                    logger.debug(
+                        f"HybridChunker tokenizer: tiktoken (encoding={tok_info.name!r}, "
+                        f"provider={provider!r}, model={model_str!r}); zero-download"
+                    )
+                    return HybridChunker(tokenizer=tok)
+                except Exception as tok_err:  # pragma: no cover - defensive
+                    logger.warning(f"tiktoken chunker tokenizer failed ({tok_err}); Docling default.")
 
-                            seq = _hf_tokenizer_seq_limit(auto_tok)
-                            cap = min(chunk_size, seq)
-                            if cap < chunk_size:
-                                logger.info(
-                                    f"Capping chunk_size {chunk_size} -> {cap} for embedder "
-                                    f"{repo_id} (model_max_length={seq}). Chunks at the original "
-                                    f"size would have been truncated at embed time."
-                                )
-                            tok = HuggingFaceTokenizer(tokenizer=auto_tok, max_tokens=cap)
-                            logger.debug(
-                                f"HybridChunker tokenizer: HF AutoTokenizer "
-                                f"(litellm-routed; repo={repo_id!r}, chunk_token_limit={cap}, "
-                                f"model_seq_limit={seq}, provider={self._config.embedding_provider!r})"
-                            )
-                            return HybridChunker(tokenizer=tok)
-                        except Exception as wrap_err:
-                            logger.warning(
-                                f"HuggingFaceTokenizer wrap failed for {repo_id!r} ({wrap_err}); "
-                                f"falling back to tiktoken."
-                            )
-                    # else: load returned None — already warned; fall through.
-
-            # All other providers (openai / openrouter / litellm without an
-            # HF-routed model / ollama / auto / unknown): use tiktoken.
-            #   - openai text-embedding-*: cl100k_base BPE matches exactly
-            #   - ollama / vendor (cohere/voyage/gemini): cl100k_base is a
-            #     free BPE approximation; better than downloading 90 MB of
-            #     MiniLM weights Docling would otherwise pull
-            #   - tiktoken's encodings ship inside the wheel — ZERO extra
-            #     disk or download regardless of provider
+            # ``approximate`` kind — last-resort tiktoken cl100k_base + canary.
+            # Same path the pre-refactor "everything else" branch took, just
+            # consolidated. Operator canary fires for unlisted slash-models
+            # on litellm/openrouter routes (the splitter mirrors this with
+            # "char_based_split" key so chunker vs splitter origin is
+            # distinguishable in operator logs).
             try:
-                encoding = _resolve_tiktoken_encoding(self._config.embedding_model or "")
-                tok = _tiktoken_docling_tokenizer_cls()(
-                    encoding=encoding,
-                    max_tokens=chunk_size,
-                )
-                # Canary: warn once when a litellm/openrouter route hit
-                # cl100k_base for a slash-containing model not on the HF
-                # allow-list. See _warn_unlisted_embedder_once.
-                #
-                # Stripped names that begin with ``openai/`` or ``azure/``
-                # are EXEMPTED — for those, cl100k_base IS the correct
-                # tokenizer (e.g. ``litellm/openai/text-embedding-3-small``
-                # resolves to text-embedding-3-small under cl100k by
-                # design, not as a silent fallback).
-                provider = (self._config.embedding_provider or "").lower()
+                import tiktoken
+
+                encoding = tiktoken.get_encoding("cl100k_base")
+                tok = _tiktoken_docling_tokenizer_cls()(encoding=encoding, max_tokens=chunk_size)
                 model_raw = self._config.embedding_model or ""
                 stripped = _strip_litellm_route_prefix(model_raw) or model_raw
-                stripped_lo = stripped.lower()
-                enc_name = getattr(encoding, "name", "")
                 if (
                     provider in {"litellm", "openrouter"}
                     and "/" in stripped
-                    and enc_name == "cl100k_base"
                     and _hf_repo_id_for_chunk_sizing(model_raw) is None
-                    and not stripped_lo.startswith(("openai/", "azure/"))
+                    and not stripped.lower().startswith(("openai/", "azure/"))
                 ):
-                    _warn_unlisted_embedder_once(provider, stripped, enc_name)
+                    _warn_unlisted_embedder_once(provider, stripped, "cl100k_base")
                 logger.debug(
-                    f"HybridChunker tokenizer: tiktoken (encoding={enc_name!r}, "
-                    f"embedding_provider={self._config.embedding_provider!r}, "
-                    f"model={self._config.embedding_model or 'default'!r}); "
-                    f"zero-download fallback"
+                    f"HybridChunker tokenizer: cl100k_base (approximate; "
+                    f"provider={provider!r}, model={model_str!r})"
                 )
                 return HybridChunker(tokenizer=tok)
             except Exception as tok_err:  # pragma: no cover - defensive
-                logger.warning(
-                    "tiktoken chunker tokenizer failed ({}), Docling will fall back "
-                    "to its default (may trigger MiniLM download).",
-                    tok_err,
-                )
+                logger.warning(f"tiktoken approximate path failed ({tok_err}); Docling default.")
 
             return HybridChunker(max_tokens=chunk_size)
         except Exception as e:

--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -3934,8 +3934,21 @@ class KnowledgeEngine:
         return self._config.chunk_size, self._config.chunk_overlap
 
     def _build_text_splitter(self, chunk_size: int, chunk_overlap: int):
-        """Token-aware splitter when an HF tokenizer is available for the
-        active embedder; char-based fallback otherwise. See #387 follow-up."""
+        """Token-aware splitter when a tokenizer is known for the active
+        embedder; char-based fallback otherwise. See #387 follow-up.
+
+        Dispatch order (first match wins):
+          1. HF tokenizer for litellm/openrouter HF-listed orgs (intfloat/,
+             BAAI/bge, sentence-transformers/, …) — exact unit.
+          2. tiktoken cl100k_base for openai-native + azure routes
+             (including litellm/openai/* and litellm/azure/*) — also exact.
+          3. HuggingFace-provider model's own tokenizer — exact.
+          4. Char-based fallback (cohere/voyage/gemini/ollama/fastembed
+             plain-text and any unlisted slash-model). Operator canary log
+             fires for the unlisted-HF-style case so we can collect
+             telemetry on which orgs to add to the allow-list (mirrors
+             the canary already firing in ``_build_docling_chunker``).
+        """
 
         def _hf_splitter(tok):
             # ``from_huggingface_tokenizer`` overcounts BOS/EOS by ~2 tokens
@@ -3947,8 +3960,11 @@ class KnowledgeEngine:
             )
 
         provider = (self._config.embedding_provider or "").lower()
+        model_raw = self._config.embedding_model or ""
+
+        # 1. HF allow-list (litellm/openrouter HF-style routes).
         if provider in ("litellm", "openrouter", "openai"):
-            repo_id = _hf_repo_id_for_chunk_sizing(self._config.embedding_model or "")
+            repo_id = _hf_repo_id_for_chunk_sizing(model_raw)
             if repo_id:
                 auto_tok = _load_hf_tokenizer_for_chunking(repo_id)
                 if auto_tok is not None:
@@ -3956,6 +3972,30 @@ class KnowledgeEngine:
                         return _hf_splitter(auto_tok)
                     except Exception as e:
                         logger.warning(f"from_huggingface_tokenizer failed ({e}); char fallback.")
+
+            # 2. tiktoken for openai-native / azure routes. cl100k_base is
+            # exactly what text-embedding-3-* and ada-002 use; for azure
+            # it's a near-perfect approximation. Strip ONLY the outer
+            # routing prefix (litellm/ or openrouter/) — don't use
+            # ``_strip_litellm_route_prefix`` because that also strips
+            # ``openai/`` and ``azure/``, which would erase the marker
+            # we're trying to detect.
+            outer = model_raw.lower()
+            for outer_prefix in ("litellm/", "openrouter/"):
+                if outer.startswith(outer_prefix):
+                    outer = outer[len(outer_prefix) :]
+                    break
+            if provider == "openai" or outer.startswith(("openai/", "azure/")):
+                try:
+                    return RecursiveCharacterTextSplitter.from_tiktoken_encoder(
+                        encoding_name="cl100k_base",
+                        chunk_size=chunk_size,
+                        chunk_overlap=chunk_overlap,
+                    )
+                except Exception as e:
+                    logger.warning(f"from_tiktoken_encoder failed ({e}); char fallback.")
+
+        # 3. HF-provider — reuse the embedder's own tokenizer.
         elif provider == "huggingface":
             try:
                 self._ensure_embeddings()
@@ -3964,6 +4004,25 @@ class KnowledgeEngine:
                     return _hf_splitter(emb._tokenizer)
             except Exception as e:
                 logger.warning(f"HF-provider tokenizer reuse failed ({e}); char fallback.")
+
+        # 4. Char-based fallback. For unlisted HF-style slash-models on
+        # litellm/openrouter routes, fire the same canary the chunker
+        # path fires — this is the splitter-side mirror of #387's
+        # silent-degradation signal. ``_warn_unlisted_embedder_once``
+        # dedups by (provider, model, encoding_name), so the chunker and
+        # splitter sides each fire ONCE per process per unlisted model.
+        # The "char_based_split" sentinel distinguishes the splitter
+        # origin from the chunker's "cl100k_base" key.
+        if provider in ("litellm", "openrouter"):
+            stripped = _strip_litellm_route_prefix(model_raw) or model_raw
+            stripped_lo = stripped.lower()
+            if (
+                "/" in stripped
+                and _hf_repo_id_for_chunk_sizing(model_raw) is None
+                and not stripped_lo.startswith(("openai/", "azure/"))
+            ):
+                _warn_unlisted_embedder_once(provider, stripped, "char_based_split")
+
         return RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
 
     def _build_docling_chunker(self, chunk_size: int):

--- a/tests/unit/test_knowledge_chunker_hf_tokenizer.py
+++ b/tests/unit/test_knowledge_chunker_hf_tokenizer.py
@@ -184,31 +184,58 @@ class TestHfTokenizerSeqLimit:
         assert cap >= 1
 
 
-class TestLoadHfTokenizerCachesFailure:
-    """Critical: a transient corp-proxy outage at process start must NOT
-    re-fire the hub call on every doc ingested in the session."""
+class TestLoadHfTokenizerCachesSuccessButRetriesOnFailure:
+    """Workflow w5i1mbchd synth fix #4 changed the cache contract:
+    successes are still lru_cached (one Hub HEAD per repo per process),
+    but failures are NO LONGER cached. Reason: a transient corp-proxy
+    503 used to permanently lock the model into char-based fallback
+    for the whole process; now a retry on the next ingest can recover.
+    """
 
     def setup_method(self):
         # Each test starts with a clean cache so test order doesn't matter.
         _load_hf_tokenizer_for_chunking.cache_clear()
 
-    def test_success_path_returns_tokenizer(self):
+    def test_success_path_returns_tokenizer_and_caches(self):
         with patch("transformers.AutoTokenizer.from_pretrained") as m:
             fake_tok = SimpleNamespace(model_max_length=512)
             m.return_value = fake_tok
-            result = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
-            assert result is fake_tok
+            r1 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
+            r2 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
+            assert r1 is fake_tok
+            assert r2 is fake_tok
+            # Cached: two lookups, ONE underlying call.
             m.assert_called_once_with("intfloat/multilingual-e5-large")
 
-    def test_failure_caches_none_and_does_not_retry(self):
+    def test_failure_does_not_cache_and_retries_next_call(self):
+        """Counter-test to the pre-fix-#4 behavior. The old contract
+        cached None and locked the model out for the process. The new
+        contract logs once but lets the next call retry — so a 30s
+        transient hub outage doesn't degrade the rest of the session."""
         with patch("transformers.AutoTokenizer.from_pretrained") as m:
             m.side_effect = OSError("offline / no network")
             r1 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
             r2 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
             r3 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
             assert r1 is None and r2 is None and r3 is None
-            # The whole point: ONE call across three lookups.
-            assert m.call_count == 1
+            # Each call re-attempts: three lookups, THREE underlying calls.
+            assert m.call_count == 3, (
+                f"Failures should NOT be cached after PR-A fix #4 — got "
+                f"{m.call_count} calls (expected 3 = one per lookup)."
+            )
+
+    def test_failure_then_success_recovers(self):
+        """Direct repro of the operational bug fix #4 closes: hub flakes
+        on first call, succeeds on second. Old contract: model stuck at
+        char-based forever. New contract: second call gets the tokenizer."""
+        fake_tok = SimpleNamespace(model_max_length=512)
+        side_effects = [OSError("transient 503"), fake_tok]
+        with patch("transformers.AutoTokenizer.from_pretrained", side_effect=side_effects) as m:
+            r1 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
+            r2 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
+            assert r1 is None, "first call must surface the OSError as None"
+            assert r2 is fake_tok, "second call must succeed (failure NOT cached)"
+            assert m.call_count == 2
 
     def test_import_error_returns_none(self):
         # Simulate a slim install where transformers is not present at all.

--- a/tests/unit/test_knowledge_chunker_hf_tokenizer.py
+++ b/tests/unit/test_knowledge_chunker_hf_tokenizer.py
@@ -112,33 +112,72 @@ class TestHfRepoIdForChunkSizing:
 
 
 class TestHfTokenizerSeqLimit:
+    """Helper returns the SAFE chunk-token cap (raw max minus a margin
+    that covers embedder-side wrapping). Tests assert against the
+    margined value because that's the actual contract. Imported here so
+    a margin change updates the assertions in one place."""
+
+    def _safe(self, raw):
+        from cuga.backend.knowledge.engine import _HF_TOKEN_SAFETY_MARGIN
+
+        return raw - _HF_TOKEN_SAFETY_MARGIN
+
     def test_normal_512(self):
         tok = SimpleNamespace(model_max_length=512)
-        assert _hf_tokenizer_seq_limit(tok) == 512
+        assert _hf_tokenizer_seq_limit(tok) == self._safe(512)
 
     def test_large_model_8192(self):
-        # bge-m3 has 8192 — make sure we don't accidentally clamp it.
+        # bge-m3 has 8192 — should be passed through (minus margin).
         tok = SimpleNamespace(model_max_length=8192)
-        assert _hf_tokenizer_seq_limit(tok) == 8192
+        assert _hf_tokenizer_seq_limit(tok) == self._safe(8192)
 
     def test_very_large_integer_sentinel_defaults_to_512(self):
-        # transformers' VERY_LARGE_INTEGER convention means "unset". We must
-        # NOT pass that to the chunker as a real ceiling — it'd produce
-        # gargantuan chunks the embedder would then truncate.
+        # transformers' VERY_LARGE_INTEGER convention means "unset". We
+        # default to 512 - margin (BERT / XLM-R convention).
         tok = SimpleNamespace(model_max_length=int(1e30))
-        assert _hf_tokenizer_seq_limit(tok) == 512
+        assert _hf_tokenizer_seq_limit(tok) == self._safe(512)
 
     def test_missing_attr_defaults_to_512(self):
         tok = SimpleNamespace()
-        assert _hf_tokenizer_seq_limit(tok) == 512
+        assert _hf_tokenizer_seq_limit(tok) == self._safe(512)
 
     def test_none_defaults_to_512(self):
         tok = SimpleNamespace(model_max_length=None)
-        assert _hf_tokenizer_seq_limit(tok) == 512
+        assert _hf_tokenizer_seq_limit(tok) == self._safe(512)
 
     def test_zero_defaults_to_512(self):
         tok = SimpleNamespace(model_max_length=0)
-        assert _hf_tokenizer_seq_limit(tok) == 512
+        assert _hf_tokenizer_seq_limit(tok) == self._safe(512)
+
+    def test_regression_518_over_512_watsonx_e5(self):
+        """Regression for user-reported QA bug on PR #383:
+
+            litellm.ContextWindowExceededError: This model's maximum
+            context length is 512 tokens. However, you requested 518
+            tokens in the input for embedding generation.
+
+        The +6 overhead came from e5's "passage: " prefix +
+        provider-side BOS/EOS that the local tokenizer never saw at
+        chunk-count time. The safety margin (default 16) prevents this
+        recurrence by capping the chunker to 496 for an e5-large
+        tokenizer (512 - 16) — leaves 16 tokens of headroom for any
+        reasonable wrapping a hosted provider can throw at us.
+        """
+        from cuga.backend.knowledge.engine import _HF_TOKEN_SAFETY_MARGIN
+
+        tok = SimpleNamespace(model_max_length=512)
+        cap = _hf_tokenizer_seq_limit(tok)
+        # Cap must leave at least the observed 6-token overhead of slack.
+        assert cap <= 512 - 6, f"Cap {cap} doesn't leave room for the 518>512 overhead the user hit"
+        # And the margin must be at least the observed overhead.
+        assert _HF_TOKEN_SAFETY_MARGIN >= 6
+
+    def test_margin_does_not_underflow_to_zero(self):
+        # Defensive: tiny model_max_length (synthetic / corrupt config)
+        # must not return <= 0 — that would break the chunker.
+        tok = SimpleNamespace(model_max_length=4)  # smaller than margin
+        cap = _hf_tokenizer_seq_limit(tok)
+        assert cap >= 1
 
 
 class TestLoadHfTokenizerCachesFailure:

--- a/tests/unit/test_knowledge_chunker_hf_tokenizer.py
+++ b/tests/unit/test_knowledge_chunker_hf_tokenizer.py
@@ -24,11 +24,10 @@ from unittest.mock import patch
 import pytest
 
 from cuga.backend.knowledge.engine import (
-    _hf_repo_id_for_chunk_sizing,
+    _hf_repo_id_candidate,
     _hf_tokenizer_seq_limit,
     _load_hf_tokenizer_for_chunking,
     _strip_litellm_route_prefix,
-    _warn_unlisted_embedder_once,
 )
 
 
@@ -65,50 +64,55 @@ class TestStripLitellmRoutePrefix:
         assert _strip_litellm_route_prefix(None) == ""  # type: ignore[arg-type]
 
 
-class TestHfRepoIdForChunkSizing:
+class TestHfRepoIdCandidate:
+    """``_hf_repo_id_candidate`` is the post-PR-A simplification:
+    returns the stripped name when it looks HF-style (has '/'), None
+    otherwise. The Hub is the source of truth — the LOADER decides
+    whether a candidate actually exists via try/except on
+    ``AutoTokenizer.from_pretrained``."""
+
     @pytest.mark.parametrize(
         "model_id,expected",
         [
-            # The actual bug repro:
+            # Real HF-style routes — return the stripped repo id.
             ("watsonx/intfloat/multilingual-e5-large", "intfloat/multilingual-e5-large"),
-            # Other real-world litellm routes that hit allow-listed orgs:
             ("litellm/BAAI/bge-large-en-v1.5", "BAAI/bge-large-en-v1.5"),
             ("openrouter/sentence-transformers/all-mpnet-base-v2", "sentence-transformers/all-mpnet-base-v2"),
             (
                 "watsonx/ibm-granite/granite-embedding-30m-english",
                 "ibm-granite/granite-embedding-30m-english",
             ),
-            # Already-stripped HF id (someone wired the right one directly):
             ("intfloat/multilingual-e5-base", "intfloat/multilingual-e5-base"),
+            # Closed-vendor routes also return candidate — the LOADER's
+            # 404 + lru_cached None handles the "no HF tokenizer for
+            # this repo" case. Previously the allow-list short-circuited
+            # these to None; now we let the Hub be the source of truth.
+            # First lookup costs one Hub HEAD, subsequent are cached.
+            ("cohere/embed-english-v3.0", "cohere/embed-english-v3.0"),
+            ("voyage/voyage-3", "voyage/voyage-3"),
+            ("watsonx/ibm/slate-30m-english-rtrvr", "ibm/slate-30m-english-rtrvr"),
         ],
     )
     def test_positive_matches(self, model_id, expected):
-        assert _hf_repo_id_for_chunk_sizing(model_id) == expected
+        assert _hf_repo_id_candidate(model_id) == expected
 
     @pytest.mark.parametrize(
         "model_id",
         [
-            # OpenAI text-embedding-* — tiktoken handles these correctly; must
-            # NOT be misrouted to AutoTokenizer.
+            # After ``_strip_litellm_route_prefix``, no '/' → not
+            # HF-style → caller routes to tiktoken (openai/azure) or
+            # approximate (anything else).
             "openai/text-embedding-3-small",
             "openai/text-embedding-3-large",
             "openai/text-embedding-ada-002",
-            # Proprietary closed models — no HF tokenizer exists.
-            "cohere/embed-english-v3.0",
-            "voyage/voyage-3",
-            "gemini/text-embedding-004",
-            # IBM proprietary slate model — no public HF mirror.
-            "watsonx/ibm/slate-30m-english-rtrvr",
-            # Local fastembed model — never goes through litellm.
+            "azure/my-deployment",
             "fastembed",
-            # Empty / malformed.
             "",
-            "/",
             "no-slash-here",
         ],
     )
     def test_negative_matches_fall_through(self, model_id):
-        assert _hf_repo_id_for_chunk_sizing(model_id) is None
+        assert _hf_repo_id_candidate(model_id) is None
 
 
 class TestHfTokenizerSeqLimit:
@@ -213,68 +217,11 @@ class TestLoadHfTokenizerCachesFailure:
             assert result is None
 
 
-class TestWarnUnlistedEmbedderObservability:
-    """Operator canary for the silent-degradation failure mode that the HF
-    allow-list doesn't cover. The WARNING converts an invisible bug (chunks
-    silently sized in cl100k against a 512-token e5 window) into a single
-    log line operators can grep for. Deduped per (provider, model, encoding)
-    via lru_cache so it never spams per-document."""
-
-    def setup_method(self):
-        _warn_unlisted_embedder_once.cache_clear()
-
-    def test_warns_once_per_unique_tuple(self, monkeypatch):
-        # Three calls with the same args -> exactly ONE log line.
-        # Loguru's logger doesn't integrate with caplog, so monkeypatch it.
-        from cuga.backend.knowledge import engine as eng
-
-        calls: list[str] = []
-        monkeypatch.setattr(eng.logger, "warning", lambda msg, *a, **k: calls.append(msg))
-        _warn_unlisted_embedder_once("litellm", "mistralai/mistral-embed-x", "cl100k_base")
-        _warn_unlisted_embedder_once("litellm", "mistralai/mistral-embed-x", "cl100k_base")
-        _warn_unlisted_embedder_once("litellm", "mistralai/mistral-embed-x", "cl100k_base")
-        msgs = [m for m in calls if "allow-list" in m]
-        assert len(msgs) == 1, f"expected 1 warning, got {len(msgs)}: {msgs}"
-        assert "mistralai/mistral-embed-x" in msgs[0]
-        assert "litellm" in msgs[0]
-
-    def test_warns_separately_for_distinct_models(self, monkeypatch):
-        # Different models from the same provider each get their own warning.
-        from cuga.backend.knowledge import engine as eng
-
-        calls: list[str] = []
-        monkeypatch.setattr(eng.logger, "warning", lambda msg, *a, **k: calls.append(msg))
-        _warn_unlisted_embedder_once("litellm", "orgA/embedder-x", "cl100k_base")
-        _warn_unlisted_embedder_once("litellm", "orgB/embedder-y", "cl100k_base")
-        msgs = [m for m in calls if "allow-list" in m]
-        assert len(msgs) == 2
-        assert any("orgA/embedder-x" in m for m in msgs)
-        assert any("orgB/embedder-y" in m for m in msgs)
-
-
-class TestCanaryExemptionForOpenAINativeRoutes:
-    """Regression guard for the audit-flagged false positive: a litellm route
-    that ends up at ``openai/text-embedding-3-*`` actually USES cl100k_base
-    correctly. Warning on it would pollute every cuga deployment that routes
-    OpenAI via LiteLLM — the most common deployment pattern."""
-
-    def setup_method(self):
-        _warn_unlisted_embedder_once.cache_clear()
-
-    def test_canary_predicate_exempts_openai_under_litellm(self):
-        # The gate is the same expression used in _build_docling_chunker.
-        # We test the predicate directly to keep the test cheap and to pin
-        # the exemption rule even if the call site moves.
-        stripped_lo = "openai/text-embedding-3-small"
-        # NOT on the HF allow-list, slash-containing, cl100k_base — would
-        # otherwise warn. Exemption: stripped name starts with "openai/".
-        would_warn = stripped_lo.startswith(("openai/", "azure/"))
-        assert would_warn  # exemption applies => DO NOT warn
-
-    def test_canary_predicate_exempts_azure_under_litellm(self):
-        stripped_lo = "azure/my-azure-deployment"
-        assert stripped_lo.startswith(("openai/", "azure/"))
-
-    def test_canary_predicate_still_warns_for_unlisted_hf_org(self):
-        stripped_lo = "mistralai/mistral-embed-x"
-        assert not stripped_lo.startswith(("openai/", "azure/"))
+# NOTE: The earlier ``TestWarnUnlistedEmbedderObservability`` +
+# ``TestCanaryExemptionForOpenAINativeRoutes`` classes were deleted in
+# PR-A (workflow w9y9xtyse synth). The custom canary
+# ``_warn_unlisted_embedder_once`` is gone — the existing
+# ``logger.warning`` inside ``_load_hf_tokenizer_for_chunking`` is now
+# the sole signal, fired once per unknown repo via
+# ``functools.lru_cache``. Tests for that behavior live in
+# ``TestLoadHfTokenizerCachesFailure`` (above).

--- a/tests/unit/test_knowledge_chunking_tokenizer_accessor.py
+++ b/tests/unit/test_knowledge_chunking_tokenizer_accessor.py
@@ -142,7 +142,13 @@ class TestChunkingTokenizerDataclass:
     that prevent future regressions to a mutable dict-shaped contract."""
 
     def test_is_frozen(self):
-        tok = ChunkingTokenizer(kind="tiktoken", encoder=None, name="cl100k_base", safe_max_tokens=8192)
+        tok = ChunkingTokenizer(
+            kind="tiktoken",
+            encoder=None,
+            name="cl100k_base",
+            safe_max_tokens=8175,
+            recommended_chunk_tokens=512,
+        )
         import dataclasses
 
         try:
@@ -160,5 +166,11 @@ class TestChunkingTokenizerDataclass:
         # frozen dataclasses with hashable fields are hashable — lets
         # callers cache by (provider, model) → ChunkingTokenizer if
         # they want.
-        tok = ChunkingTokenizer(kind="approximate", encoder=None, name="char-based", safe_max_tokens=8192)
+        tok = ChunkingTokenizer(
+            kind="approximate",
+            encoder=None,
+            name="char-based",
+            safe_max_tokens=8192,
+            recommended_chunk_tokens=512,
+        )
         assert hash(tok) is not None

--- a/tests/unit/test_knowledge_chunking_tokenizer_accessor.py
+++ b/tests/unit/test_knowledge_chunking_tokenizer_accessor.py
@@ -1,0 +1,164 @@
+"""Pins the contract of ``KnowledgeEngine.get_chunking_tokenizer()`` — the
+unified dispatch added in PR #400's consolidation pass.
+
+Before the refactor, ``_build_docling_chunker`` and ``_build_text_splitter``
+each had their own copy of provider-branching logic (fastembed / huggingface
+/ litellm-HF / tiktoken / approximate). After the refactor, both call
+``get_chunking_tokenizer()`` and switch on ``ChunkingTokenizer.kind``.
+
+These tests pin the accessor's dispatch table directly — independent of
+either consumer. If a future provider gets added, this is the test file
+that documents what kind/encoder/name/safe_max_tokens we promise.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cuga.backend.knowledge.config import KnowledgeConfig
+from cuga.backend.knowledge.engine import (
+    ChunkingTokenizer,
+    KnowledgeEngine,
+    _HF_TOKEN_SAFETY_MARGIN,
+    _load_hf_tokenizer_for_chunking,
+)
+
+
+def _make_engine(provider: str, model: str) -> KnowledgeEngine:
+    tmp = tempfile.mkdtemp(prefix="cuga-accessor-test-")
+    cfg = KnowledgeConfig(
+        enabled=True,
+        persist_dir=Path(tmp),
+        embedding_provider=provider,
+        embedding_model=model,
+    )
+    return KnowledgeEngine(cfg)
+
+
+class TestChunkingTokenizerDispatch:
+    """One test per provider → expected ``ChunkingTokenizer`` shape."""
+
+    def setup_method(self):
+        _load_hf_tokenizer_for_chunking.cache_clear()
+
+    def test_litellm_watsonx_e5_returns_hf_kind(self):
+        # The exact #387 / #396 / 518>512 user-bug-triple repro.
+        eng = _make_engine(provider="litellm", model="watsonx/intfloat/multilingual-e5-large")
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=SimpleNamespace(model_max_length=512),
+        ):
+            tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "hf"
+        assert tok.name == "intfloat/multilingual-e5-large"
+        # Already margined — chunker / splitter inherit safety automatically.
+        assert tok.safe_max_tokens == 512 - _HF_TOKEN_SAFETY_MARGIN
+
+    def test_openrouter_bge_returns_hf_kind(self):
+        eng = _make_engine(provider="openrouter", model="BAAI/bge-large-en-v1.5")
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=SimpleNamespace(model_max_length=512),
+        ):
+            tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "hf"
+        assert tok.name == "BAAI/bge-large-en-v1.5"
+
+    def test_openai_native_returns_tiktoken_kind(self):
+        eng = _make_engine(provider="openai", model="text-embedding-3-small")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "tiktoken"
+        assert tok.name == "cl100k_base"
+
+    def test_litellm_openai_returns_tiktoken_kind(self):
+        # litellm/openai/text-embedding-3-* — strip litellm/, see openai/.
+        eng = _make_engine(provider="litellm", model="openai/text-embedding-3-large")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "tiktoken"
+        assert tok.name == "cl100k_base"
+
+    def test_litellm_azure_returns_tiktoken_kind(self):
+        eng = _make_engine(provider="litellm", model="azure/my-deployment")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "tiktoken"
+        assert tok.name == "cl100k_base"
+
+    def test_cohere_returns_approximate_kind(self):
+        # Cohere has no HF tokenizer repo + no tiktoken-correct path —
+        # ``approximate`` is the explicit "no precise tokenizer" signal.
+        eng = _make_engine(provider="litellm", model="cohere/embed-english-v3.0")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "approximate"
+        assert tok.encoder is None
+        assert tok.name == "char-based"
+
+    def test_voyage_returns_approximate_kind(self):
+        eng = _make_engine(provider="litellm", model="voyage/voyage-3")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "approximate"
+
+    def test_gemini_returns_approximate_kind(self):
+        eng = _make_engine(provider="litellm", model="gemini/text-embedding-004")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "approximate"
+
+    def test_hf_repo_priority_over_tiktoken(self):
+        # litellm + watsonx/intfloat/* — must take HF branch first, not
+        # fall through to tiktoken just because the prefix is one we
+        # also check for routing detection.
+        eng = _make_engine(provider="litellm", model="watsonx/intfloat/multilingual-e5-large")
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=SimpleNamespace(model_max_length=512),
+        ):
+            tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "hf"  # NOT "tiktoken"
+
+    def test_hf_load_failure_falls_through(self):
+        # AutoTokenizer raises (offline / gated repo). Accessor must not
+        # crash; falls back to whatever the next branch matches. For
+        # watsonx/intfloat the next branch is the tiktoken check which
+        # ALSO fails (intfloat not openai/azure), then approximate.
+        eng = _make_engine(provider="litellm", model="watsonx/intfloat/multilingual-e5-large")
+        with patch("transformers.AutoTokenizer.from_pretrained", side_effect=OSError("offline")):
+            tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "approximate"
+
+    def test_ollama_returns_approximate(self):
+        # ollama is a valid provider (KnowledgeConfig.validate whitelist)
+        # but has no tokenizer the chunker can use — falls into the
+        # ``approximate`` bucket so callers handle it via the single
+        # ``kind`` switch instead of an ad-hoc unknown-provider branch.
+        eng = _make_engine(provider="ollama", model="nomic-embed-text")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "approximate"
+
+
+class TestChunkingTokenizerDataclass:
+    """Hashable, immutable, type-stable — small dataclass invariants
+    that prevent future regressions to a mutable dict-shaped contract."""
+
+    def test_is_frozen(self):
+        tok = ChunkingTokenizer(kind="tiktoken", encoder=None, name="cl100k_base", safe_max_tokens=8192)
+        import dataclasses
+
+        try:
+            dataclasses.replace(tok, kind="hf")  # via replace is fine
+        except Exception:
+            assert False, "replace must work on frozen dataclass"
+        # Direct mutation must fail.
+        try:
+            tok.kind = "hf"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            return
+        assert False, "direct attribute mutation should have raised"
+
+    def test_hashable(self):
+        # frozen dataclasses with hashable fields are hashable — lets
+        # callers cache by (provider, model) → ChunkingTokenizer if
+        # they want.
+        tok = ChunkingTokenizer(kind="approximate", encoder=None, name="char-based", safe_max_tokens=8192)
+        assert hash(tok) is not None

--- a/tests/unit/test_knowledge_resplit_unit_mismatch.py
+++ b/tests/unit/test_knowledge_resplit_unit_mismatch.py
@@ -74,11 +74,16 @@ class TestBuildTextSplitterTokenAware:
                 m_from_hf.return_value = "hf_splitter"
                 splitter = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
 
+        from cuga.backend.knowledge.engine import _HF_TOKEN_SAFETY_MARGIN
+
         assert splitter == "hf_splitter"
-        # Called with the model's REAL max (512), NOT the user's raw 800.
+        # Called with model's max minus the safety margin (covers
+        # provider-side wrapping that the local tokenizer doesn't see —
+        # see the 518>512 regression).
         call_args = m_from_hf.call_args
-        assert call_args.kwargs["chunk_size"] == 512, (
-            f"splitter not capped at model_max_length=512: {call_args}"
+        expected_cap = 512 - _HF_TOKEN_SAFETY_MARGIN
+        assert call_args.kwargs["chunk_size"] == expected_cap, (
+            f"splitter not capped at model_max_length-margin={expected_cap}: {call_args}"
         )
         # Tokenizer passed is the one we loaded (matches embedder).
         assert call_args.args[0] is fake_tok
@@ -97,8 +102,10 @@ class TestBuildTextSplitterTokenAware:
                 m_from_hf.return_value = "hf_splitter"
                 splitter = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
 
+        from cuga.backend.knowledge.engine import _HF_TOKEN_SAFETY_MARGIN
+
         assert splitter == "hf_splitter"
-        assert m_from_hf.call_args.kwargs["chunk_size"] == 512
+        assert m_from_hf.call_args.kwargs["chunk_size"] == 512 - _HF_TOKEN_SAFETY_MARGIN
 
     def test_openai_text_embedding_falls_back_to_chars(self):
         # OpenAI's text-embedding-3-* is NOT on the HF allow-list (cl100k

--- a/tests/unit/test_knowledge_text_splitter_tiktoken_canary.py
+++ b/tests/unit/test_knowledge_text_splitter_tiktoken_canary.py
@@ -20,10 +20,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from cuga.backend.knowledge.config import KnowledgeConfig
-from cuga.backend.knowledge.engine import (
-    KnowledgeEngine,
-    _warn_unlisted_embedder_once,
-)
+from cuga.backend.knowledge.engine import KnowledgeEngine
 
 
 def _make_engine(provider: str, model: str) -> KnowledgeEngine:
@@ -119,92 +116,10 @@ class TestTiktokenBranch:
         assert isinstance(splitter, RecursiveCharacterTextSplitter)
 
 
-class TestCanaryLogParity:
-    """Splitter's char-fallback fires the same one-shot WARNING the
-    chunker fires, so an unlisted-HF-style model on litellm/openrouter
-    is observable via operator logs even when documents flow through
-    plain-text or emergency-resplit paths instead of HybridChunker."""
-
-    def setup_method(self):
-        _warn_unlisted_embedder_once.cache_clear()
-
-    def _capture_warns(self, monkeypatch):
-        from cuga.backend.knowledge import engine as eng
-
-        calls: list[str] = []
-        monkeypatch.setattr(eng.logger, "warning", lambda msg, *a, **k: calls.append(msg))
-        return calls
-
-    def test_canary_fires_for_unlisted_litellm_slash_model(self, monkeypatch):
-        eng = _make_engine(provider="litellm", model="mistralai/mistral-embed-x")
-        calls = self._capture_warns(monkeypatch)
-        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
-        canary_msgs = [c for c in calls if "allow-list" in c]
-        assert len(canary_msgs) == 1, f"expected 1 canary, got {canary_msgs}"
-        assert "mistralai/mistral-embed-x" in canary_msgs[0]
-
-    def test_canary_does_not_fire_for_openai_via_litellm(self, monkeypatch):
-        # The tiktoken branch handles this correctly — no canary noise.
-        eng = _make_engine(provider="litellm", model="openai/text-embedding-3-small")
-        calls = self._capture_warns(monkeypatch)
-        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
-        canary_msgs = [c for c in calls if "allow-list" in c]
-        assert len(canary_msgs) == 0
-
-    def test_canary_does_not_fire_for_azure_via_litellm(self, monkeypatch):
-        eng = _make_engine(provider="litellm", model="azure/my-deployment")
-        calls = self._capture_warns(monkeypatch)
-        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
-        canary_msgs = [c for c in calls if "allow-list" in c]
-        assert len(canary_msgs) == 0
-
-    def test_canary_does_not_fire_for_hf_listed(self, monkeypatch):
-        # HF allow-list took the splitter via from_huggingface_tokenizer.
-        eng = _make_engine(provider="litellm", model="watsonx/intfloat/multilingual-e5-large")
-        calls = self._capture_warns(monkeypatch)
-        from types import SimpleNamespace
-
-        with patch(
-            "transformers.AutoTokenizer.from_pretrained",
-            return_value=SimpleNamespace(model_max_length=512),
-        ):
-            eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
-        canary_msgs = [c for c in calls if "allow-list" in c]
-        assert len(canary_msgs) == 0
-
-    def test_canary_does_not_fire_for_fastembed(self, monkeypatch):
-        # fastembed is a local provider — char-based fallback is fine,
-        # no operator action required.
-        eng = _make_engine(provider="fastembed", model="BAAI/bge-small-en-v1.5")
-        calls = self._capture_warns(monkeypatch)
-        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
-        canary_msgs = [c for c in calls if "allow-list" in c]
-        assert len(canary_msgs) == 0
-
-    def test_canary_dedup_across_repeated_splitter_builds(self, monkeypatch):
-        # Multiple _load_document calls under the same unlisted embedder
-        # must produce ONE canary, not one-per-document.
-        eng = _make_engine(provider="litellm", model="snowflake/arctic-embed-l")
-        calls = self._capture_warns(monkeypatch)
-        for _ in range(5):
-            eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
-        canary_msgs = [c for c in calls if "allow-list" in c]
-        assert len(canary_msgs) == 1, f"expected dedup to 1, got {len(canary_msgs)}"
-
-    def test_canary_separates_chunker_and_splitter_origins(self, monkeypatch):
-        # Same (provider, model) but different encoding-name keys: chunker
-        # fires once with "cl100k_base", splitter fires once with
-        # "char_based_split". Both ONCE.
-        from cuga.backend.knowledge.engine import _warn_unlisted_embedder_once
-
-        _warn_unlisted_embedder_once.cache_clear()
-        calls = self._capture_warns(monkeypatch)
-        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "cl100k_base")
-        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "char_based_split")
-        # Second call to either sentinel: deduped.
-        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "cl100k_base")
-        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "char_based_split")
-        canary_msgs = [c for c in calls if "allow-list" in c]
-        assert len(canary_msgs) == 2, (
-            f"chunker + splitter should each fire ONCE per process; got {canary_msgs}"
-        )
+# NOTE: ``TestCanaryLogParity`` was deleted in PR-A (workflow w9y9xtyse
+# synth). The custom canary ``_warn_unlisted_embedder_once`` is gone —
+# the existing ``logger.warning`` inside
+# ``_load_hf_tokenizer_for_chunking`` (engine.py) is now the sole
+# unknown-model signal, fired once per process per repo via
+# ``functools.lru_cache(maxsize=8)``. Coverage for that lives in
+# ``test_knowledge_chunker_hf_tokenizer.py::TestLoadHfTokenizerCachesFailure``.

--- a/tests/unit/test_knowledge_text_splitter_tiktoken_canary.py
+++ b/tests/unit/test_knowledge_text_splitter_tiktoken_canary.py
@@ -1,0 +1,210 @@
+"""Tests for PR B (#383 follow-up): extend ``_build_text_splitter`` with
+
+1. ``from_tiktoken_encoder`` branch for openai/azure-native routes —
+   including ``litellm/openai/*`` and ``litellm/azure/*``. cl100k_base
+   is the EXACT correct unit for ``text-embedding-3-*`` and
+   ``text-embedding-ada-002``; the prior char-based fallback wasted
+   the precision we already had.
+
+2. ``_warn_unlisted_embedder_once`` canary on the splitter's
+   char-based fallback path. Mirrors the canary already firing in
+   ``_build_docling_chunker``'s tiktoken-fallback branch — silent
+   degradation in the splitter was a parallel surface that #387's
+   follow-up didn't cover.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from cuga.backend.knowledge.config import KnowledgeConfig
+from cuga.backend.knowledge.engine import (
+    KnowledgeEngine,
+    _warn_unlisted_embedder_once,
+)
+
+
+def _make_engine(provider: str, model: str) -> KnowledgeEngine:
+    tmp = tempfile.mkdtemp(prefix="cuga-tiktoken-canary-test-")
+    cfg = KnowledgeConfig(
+        enabled=True,
+        persist_dir=Path(tmp),
+        embedding_provider=provider,
+        embedding_model=model,
+    )
+    return KnowledgeEngine(cfg)
+
+
+class TestTiktokenBranch:
+    """openai-native + azure routes (incl. litellm/openrouter-routed) now
+    use ``from_tiktoken_encoder`` with cl100k_base — the exact unit, not
+    a char-based approximation."""
+
+    def setup_method(self):
+        # Clear the HF-tokenizer cache so a leaked tokenizer from a
+        # previous test doesn't make the HF branch shortcut and bypass
+        # the tiktoken path we're verifying.
+        from cuga.backend.knowledge.engine import _load_hf_tokenizer_for_chunking
+
+        _load_hf_tokenizer_for_chunking.cache_clear()
+
+    def test_openai_native_uses_tiktoken(self):
+        eng = _make_engine(provider="openai", model="text-embedding-3-small")
+        with patch("langchain_text_splitters.RecursiveCharacterTextSplitter.from_tiktoken_encoder") as m:
+            m.return_value = "tiktoken_splitter"
+            result = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        assert result == "tiktoken_splitter"
+        assert m.call_args.kwargs["encoding_name"] == "cl100k_base"
+        assert m.call_args.kwargs["chunk_size"] == 800
+        assert m.call_args.kwargs["chunk_overlap"] == 100
+
+    def test_litellm_openai_uses_tiktoken(self):
+        # litellm/openai/text-embedding-3-* — strip litellm/, see openai/,
+        # route to tiktoken.
+        eng = _make_engine(provider="litellm", model="openai/text-embedding-3-large")
+        with patch("langchain_text_splitters.RecursiveCharacterTextSplitter.from_tiktoken_encoder") as m:
+            m.return_value = "tiktoken_splitter"
+            result = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        assert result == "tiktoken_splitter"
+        assert m.call_args.kwargs["encoding_name"] == "cl100k_base"
+
+    def test_litellm_azure_uses_tiktoken(self):
+        eng = _make_engine(provider="litellm", model="azure/my-deployment")
+        with patch("langchain_text_splitters.RecursiveCharacterTextSplitter.from_tiktoken_encoder") as m:
+            m.return_value = "tiktoken_splitter"
+            result = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        assert result == "tiktoken_splitter"
+
+    def test_openrouter_openai_uses_tiktoken(self):
+        eng = _make_engine(provider="openrouter", model="openai/text-embedding-3-small")
+        with patch("langchain_text_splitters.RecursiveCharacterTextSplitter.from_tiktoken_encoder") as m:
+            m.return_value = "tiktoken_splitter"
+            result = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        assert result == "tiktoken_splitter"
+
+    def test_hf_listed_takes_priority_over_tiktoken(self):
+        # litellm + watsonx/intfloat/multilingual-e5-large is on the HF
+        # allow-list — must NOT be misrouted to tiktoken even though it
+        # also goes through the same provider==litellm branch.
+        eng = _make_engine(provider="litellm", model="watsonx/intfloat/multilingual-e5-large")
+        with patch("transformers.AutoTokenizer.from_pretrained") as m_hf:
+            from types import SimpleNamespace
+
+            m_hf.return_value = SimpleNamespace(model_max_length=512)
+            with patch(
+                "langchain_text_splitters.RecursiveCharacterTextSplitter.from_huggingface_tokenizer"
+            ) as m_hf_splitter:
+                m_hf_splitter.return_value = "hf_splitter"
+                with patch(
+                    "langchain_text_splitters.RecursiveCharacterTextSplitter.from_tiktoken_encoder"
+                ) as m_tiktoken:
+                    result = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        assert result == "hf_splitter"
+        m_tiktoken.assert_not_called()
+
+    def test_tiktoken_failure_falls_through_to_chars(self):
+        # Defensive: if tiktoken's encoder isn't loadable for some reason,
+        # the splitter must not crash.
+        eng = _make_engine(provider="openai", model="text-embedding-3-small")
+        with patch(
+            "langchain_text_splitters.RecursiveCharacterTextSplitter.from_tiktoken_encoder",
+            side_effect=RuntimeError("simulated tiktoken failure"),
+        ):
+            splitter = eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        # Falls through to char-based.
+        from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+        assert isinstance(splitter, RecursiveCharacterTextSplitter)
+
+
+class TestCanaryLogParity:
+    """Splitter's char-fallback fires the same one-shot WARNING the
+    chunker fires, so an unlisted-HF-style model on litellm/openrouter
+    is observable via operator logs even when documents flow through
+    plain-text or emergency-resplit paths instead of HybridChunker."""
+
+    def setup_method(self):
+        _warn_unlisted_embedder_once.cache_clear()
+
+    def _capture_warns(self, monkeypatch):
+        from cuga.backend.knowledge import engine as eng
+
+        calls: list[str] = []
+        monkeypatch.setattr(eng.logger, "warning", lambda msg, *a, **k: calls.append(msg))
+        return calls
+
+    def test_canary_fires_for_unlisted_litellm_slash_model(self, monkeypatch):
+        eng = _make_engine(provider="litellm", model="mistralai/mistral-embed-x")
+        calls = self._capture_warns(monkeypatch)
+        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        canary_msgs = [c for c in calls if "allow-list" in c]
+        assert len(canary_msgs) == 1, f"expected 1 canary, got {canary_msgs}"
+        assert "mistralai/mistral-embed-x" in canary_msgs[0]
+
+    def test_canary_does_not_fire_for_openai_via_litellm(self, monkeypatch):
+        # The tiktoken branch handles this correctly — no canary noise.
+        eng = _make_engine(provider="litellm", model="openai/text-embedding-3-small")
+        calls = self._capture_warns(monkeypatch)
+        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        canary_msgs = [c for c in calls if "allow-list" in c]
+        assert len(canary_msgs) == 0
+
+    def test_canary_does_not_fire_for_azure_via_litellm(self, monkeypatch):
+        eng = _make_engine(provider="litellm", model="azure/my-deployment")
+        calls = self._capture_warns(monkeypatch)
+        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        canary_msgs = [c for c in calls if "allow-list" in c]
+        assert len(canary_msgs) == 0
+
+    def test_canary_does_not_fire_for_hf_listed(self, monkeypatch):
+        # HF allow-list took the splitter via from_huggingface_tokenizer.
+        eng = _make_engine(provider="litellm", model="watsonx/intfloat/multilingual-e5-large")
+        calls = self._capture_warns(monkeypatch)
+        from types import SimpleNamespace
+
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=SimpleNamespace(model_max_length=512),
+        ):
+            eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        canary_msgs = [c for c in calls if "allow-list" in c]
+        assert len(canary_msgs) == 0
+
+    def test_canary_does_not_fire_for_fastembed(self, monkeypatch):
+        # fastembed is a local provider — char-based fallback is fine,
+        # no operator action required.
+        eng = _make_engine(provider="fastembed", model="BAAI/bge-small-en-v1.5")
+        calls = self._capture_warns(monkeypatch)
+        eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        canary_msgs = [c for c in calls if "allow-list" in c]
+        assert len(canary_msgs) == 0
+
+    def test_canary_dedup_across_repeated_splitter_builds(self, monkeypatch):
+        # Multiple _load_document calls under the same unlisted embedder
+        # must produce ONE canary, not one-per-document.
+        eng = _make_engine(provider="litellm", model="snowflake/arctic-embed-l")
+        calls = self._capture_warns(monkeypatch)
+        for _ in range(5):
+            eng._build_text_splitter(chunk_size=800, chunk_overlap=100)
+        canary_msgs = [c for c in calls if "allow-list" in c]
+        assert len(canary_msgs) == 1, f"expected dedup to 1, got {len(canary_msgs)}"
+
+    def test_canary_separates_chunker_and_splitter_origins(self, monkeypatch):
+        # Same (provider, model) but different encoding-name keys: chunker
+        # fires once with "cl100k_base", splitter fires once with
+        # "char_based_split". Both ONCE.
+        from cuga.backend.knowledge.engine import _warn_unlisted_embedder_once
+
+        _warn_unlisted_embedder_once.cache_clear()
+        calls = self._capture_warns(monkeypatch)
+        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "cl100k_base")
+        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "char_based_split")
+        # Second call to either sentinel: deduped.
+        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "cl100k_base")
+        _warn_unlisted_embedder_once("litellm", "orgX/embedder", "char_based_split")
+        canary_msgs = [c for c in calls if "allow-list" in c]
+        assert len(canary_msgs) == 2, (
+            f"chunker + splitter should each fire ONCE per process; got {canary_msgs}"
+        )

--- a/tests/unit/test_knowledge_tokenizer_w5i1_synth_fixes.py
+++ b/tests/unit/test_knowledge_tokenizer_w5i1_synth_fixes.py
@@ -1,0 +1,216 @@
+"""Regression tests for the six fixes from workflow w5i1mbchd synth.
+
+The workflow ran three RAG researchers (libraries / papers / hosted
+providers) + a synthesizer + an adversarial verify. Verdict:
+``SOLUTION_IS_CORRECT_BUT_MISSING_X``. The three ship-able fixes are:
+
+  #1 Off-by-one + missing margin in the tiktoken (openai/azure) branch.
+  #2 ``ChunkingTokenizer.recommended_chunk_tokens`` for retrieval-quality
+     defaults on ≥2K-ctx embedders.
+  #3 Static HF alias map (jina/nomic) to skip wasted Hub HEADs.
+
+Plus three polishes:
+
+  #4 Split lru_cache so transient HF Hub 503s aren't permanently cached.
+  #5 (comment-only, no test target).
+  #6 Promote dispatch log DEBUG → INFO (no test target).
+
+These tests pin the new contracts.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from cuga.backend.knowledge.config import KnowledgeConfig
+from cuga.backend.knowledge.engine import (
+    _HF_REPO_ALIASES,
+    _HF_TOKEN_SAFETY_MARGIN,
+    _OPENAI_TIKTOKEN_HARD_CAP,
+    _TIKTOKEN_SAFE_MAX,
+    KnowledgeEngine,
+    _hf_repo_id_candidate,
+    _load_hf_tokenizer_for_chunking,
+    _recommended_chunk_tokens,
+)
+
+
+def _make_engine(provider: str, model: str) -> KnowledgeEngine:
+    tmp = tempfile.mkdtemp(prefix="cuga-w5i1-test-")
+    cfg = KnowledgeConfig(
+        enabled=True,
+        persist_dir=Path(tmp),
+        embedding_provider=provider,
+        embedding_model=model,
+    )
+    return KnowledgeEngine(cfg)
+
+
+# ---------------------------------------------------------------------
+# Fix #1: tiktoken off-by-one
+# ---------------------------------------------------------------------
+
+
+class TestTiktokenOffByOneFix:
+    """Pre-fix the tiktoken branch returned safe_max_tokens=8192 with
+    zero margin while the HF branch returned model_max_length-16. The
+    OpenAI API rejects at >8191. Two researchers flagged independently."""
+
+    def test_hard_cap_constant_is_openai_actual(self):
+        # 8191 is the documented OpenAI text-embedding-3-* limit.
+        # Magic numbers are bad; the named constant should reflect reality.
+        assert _OPENAI_TIKTOKEN_HARD_CAP == 8191
+
+    def test_tiktoken_safe_max_subtracts_margin(self):
+        # Internal consistency with the HF branch: same margin policy.
+        assert _TIKTOKEN_SAFE_MAX == _OPENAI_TIKTOKEN_HARD_CAP - _HF_TOKEN_SAFETY_MARGIN
+        assert _TIKTOKEN_SAFE_MAX == 8175
+
+    def test_litellm_openai_dispatch_uses_safe_max_not_8192(self):
+        eng = _make_engine(provider="litellm", model="openai/text-embedding-3-large")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "tiktoken"
+        # Critical: the off-by-one fix. Pre-fix this was 8192 (an exact
+        # API-reject at maximum fill).
+        assert tok.safe_max_tokens == _TIKTOKEN_SAFE_MAX, (
+            f"tiktoken branch returned {tok.safe_max_tokens}; "
+            f"expected {_TIKTOKEN_SAFE_MAX} (= 8191 - 16). The previous "
+            f"_DEFAULT_APPROXIMATE_CAP=8192 would silently OOM-reject "
+            f"the last chunk on a maximum-fill document."
+        )
+
+    def test_litellm_azure_dispatch_also_uses_safe_max(self):
+        eng = _make_engine(provider="litellm", model="azure/my-deployment")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "tiktoken"
+        assert tok.safe_max_tokens == _TIKTOKEN_SAFE_MAX
+
+    def test_native_openai_dispatch_uses_safe_max(self):
+        eng = _make_engine(provider="openai", model="text-embedding-3-small")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.kind == "tiktoken"
+        assert tok.safe_max_tokens == _TIKTOKEN_SAFE_MAX
+
+
+# ---------------------------------------------------------------------
+# Fix #2: recommended_chunk_tokens for retrieval quality
+# ---------------------------------------------------------------------
+
+
+class TestRecommendedChunkTokens:
+    """Long-context embedders (bge-m3, jina-v3, voyage-3) retrieve better
+    at 256-512 tokens than at their full context. The new field exposes
+    this recommendation without forcing it."""
+
+    @pytest.mark.parametrize(
+        "safe_max,expected_recommended",
+        [
+            # ≥2K-ctx embedders capped at 512 regardless.
+            (8176, 512),  # bge-m3, jina-v3, nomic-v1.5
+            (32752, 512),  # voyage-3-large
+            (8175, 512),  # text-embedding-3-large (post-fix-#1 cap)
+            (2048, 512),  # boundary
+            # <2K-ctx embedders use full safe_max (no quality reason to chunk smaller).
+            (496, 496),  # bge-small / e5 with margin
+            (1024, 1024),  # mistral-embed without margin
+            (2047, 2047),  # just below the boundary
+        ],
+    )
+    def test_recommended_helper(self, safe_max, expected_recommended):
+        assert _recommended_chunk_tokens(safe_max) == expected_recommended
+
+    def test_dispatch_populates_recommended_field(self):
+        # The accessor must compute recommended_chunk_tokens at every
+        # return site. Spot-check the tiktoken (long-ctx) branch.
+        eng = _make_engine(provider="openai", model="text-embedding-3-large")
+        tok = eng.get_chunking_tokenizer()
+        assert tok.recommended_chunk_tokens == 512
+        assert tok.safe_max_tokens == _TIKTOKEN_SAFE_MAX
+
+    def test_dispatch_short_ctx_keeps_full_recommended(self):
+        # fastembed bge-small (512-ctx) should NOT be artificially capped.
+        eng = _make_engine(provider="fastembed", model="BAAI/bge-small-en-v1.5")
+        tok = eng.get_chunking_tokenizer()
+        # For a 512-ctx model the recommendation equals the safe cap —
+        # no reason to chunk smaller than the embedder's own window.
+        assert tok.recommended_chunk_tokens == tok.safe_max_tokens
+
+
+# ---------------------------------------------------------------------
+# Fix #3: static HF alias map
+# ---------------------------------------------------------------------
+
+
+class TestHfRepoAliases:
+    """Skip wasted Hub HEAD misses for known-good redirects. Jina ships
+    embeddings under ``jinaai/<model>``; Nomic under ``nomic-ai/<model>``;
+    users (and litellm) often use the bare model name."""
+
+    def test_jina_v3_resolves_to_canonical(self):
+        assert _hf_repo_id_candidate("jina-embeddings-v3") == "jinaai/jina-embeddings-v3"
+
+    def test_jina_v2_base_en_resolves(self):
+        assert _hf_repo_id_candidate("jina-embeddings-v2-base-en") == "jinaai/jina-embeddings-v2-base-en"
+
+    def test_nomic_v15_resolves(self):
+        assert _hf_repo_id_candidate("nomic-embed-text-v1.5") == "nomic-ai/nomic-embed-text-v1.5"
+
+    def test_litellm_prefix_strips_then_alias(self):
+        # litellm/jina-embeddings-v3 → strip litellm/ → look up alias.
+        assert _hf_repo_id_candidate("litellm/jina-embeddings-v3") == "jinaai/jina-embeddings-v3"
+
+    def test_already_canonical_hf_path_unchanged(self):
+        # If the user types the canonical name, alias map is a no-op.
+        assert _hf_repo_id_candidate("jinaai/jina-embeddings-v3") == "jinaai/jina-embeddings-v3"
+
+    def test_unknown_name_no_alias(self):
+        # Models not in the alias map fall back to the slash-detection
+        # logic (returns the stripped name if it has '/', else None).
+        # The Hub HEAD then decides whether the repo exists.
+        assert _hf_repo_id_candidate("intfloat/multilingual-e5-large") == ("intfloat/multilingual-e5-large")
+        assert _hf_repo_id_candidate("text-embedding-3-large") is None
+
+    def test_alias_map_is_lowercase_keyed(self):
+        # The lookup uses .lower() so user-typed mixed case still resolves.
+        assert _hf_repo_id_candidate("Jina-Embeddings-V3") == "jinaai/jina-embeddings-v3"
+
+    def test_alias_map_keys_are_canonical_form(self):
+        # Defensive: keys must be lowercase (the lookup .lower()s the input).
+        for key in _HF_REPO_ALIASES:
+            assert key == key.lower(), (
+                f"_HF_REPO_ALIASES key {key!r} must be lowercase — the "
+                f"lookup .lower()s the input, so a non-lowercase key "
+                f"would silently never match."
+            )
+
+
+# ---------------------------------------------------------------------
+# Fix #4: lru_cache split (success cached, failure retried)
+# Covered in test_knowledge_chunker_hf_tokenizer.py (updated). Spot-check
+# the cache_clear forwarder so existing tests don't silently regress.
+# ---------------------------------------------------------------------
+
+
+class TestCacheClearForwarder:
+    def test_cache_clear_forwards_to_inner(self):
+        """The lru_cache moved from _load_hf_tokenizer_for_chunking to
+        _load_hf_tokenizer_cached. Existing tests call
+        ``_load_hf_tokenizer_for_chunking.cache_clear()`` — the
+        forwarder keeps them working."""
+        _load_hf_tokenizer_for_chunking.cache_clear()
+
+        fake_tok = SimpleNamespace(model_max_length=512)
+        with patch("transformers.AutoTokenizer.from_pretrained", return_value=fake_tok) as m:
+            r1 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
+            r2 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
+            assert r1 is fake_tok and r2 is fake_tok
+            assert m.call_count == 1  # cached
+            _load_hf_tokenizer_for_chunking.cache_clear()
+            r3 = _load_hf_tokenizer_for_chunking("intfloat/multilingual-e5-large")
+            assert r3 is fake_tok
+            assert m.call_count == 2  # cleared, re-fetched


### PR DESCRIPTION
> **Draft + stacked on #383.** Base is ``feat/knowledge-env-presets-redesign`` so the diff stays focused. When #383 merges, GitHub auto-retargets to main and I'll flip out of draft.

## Summary

Three chunking-precision fixes that landed during PR #383's manual QA. All share the same root cause: **the local tokenizer counts tokens differently than the hosted embedder sees them**. Each fix attacks a different facet.

| Fix | Symptom | Root cause |
|---|---|---|
| **tiktoken branch** in ``_build_text_splitter`` | ``litellm/openai/text-embedding-3-*`` fell back to char-based | Splitter had ``from_huggingface_tokenizer`` for HF-listed orgs but no ``from_tiktoken_encoder`` for OpenAI-native — even though cl100k is the EXACT tokenizer those models use |
| **Canary log parity** | An unlisted HF-style model on litellm/openrouter silently regressed to char-based from the splitter path; HybridChunker emitted a canary, splitter didn't | ``_warn_unlisted_embedder_once`` was only wired from the chunker side |
| **16-token safety margin** | Hosted embedder rejected chunks with ``This model's maximum context length is 512 tokens. However, you requested 518 tokens`` | Hosted providers (notably watsonx) auto-prepend ``"passage: "`` to e5 inputs + add BOS/EOS the local tokenizer doesn't see → chunks at the chunker's 512 cap arrive as 518 |

## Tests (+15 across the 3 fixes; 132 total in the suite)

  TestTiktokenBranch (6):
    openai-native / litellm-openai / litellm-azure / openrouter-openai → tiktoken
    HF allow-list takes priority over tiktoken
    tiktoken failure → graceful char fallback

  TestCanaryLogParity (7):
    unlisted litellm slash-model → 1 canary
    openai/azure via litellm → 0 canary (tiktoken caught it)
    HF allow-list → 0 canary (from_huggingface_tokenizer caught it)
    fastembed → 0 canary (local provider, no operator action needed)
    dedup across 5 repeated builds
    chunker + splitter sentinels distinct (each fires once per process per (provider, model))

  TestHfTokenizerSeqLimit (+2 over #383):
    test_regression_518_over_512_watsonx_e5 — pins the user's exact error
    test_margin_does_not_underflow_to_zero — guards against synthetic configs

## Why a single PR for 3 fixes

All three target the same code path (``_build_text_splitter`` and the shared ``_hf_tokenizer_seq_limit`` helper) and the same conceptual surface ("chunks must actually fit the embedder's wire-time context"). Splitting into 3 PRs would mean 3 review rounds for what reviewers will read as one cohesive change.

## What's NOT in this PR (filed as separate issues)

| Issue | Why deferred |
|---|---|
| #402 | Reindex tile shows ``task_xxx`` instead of filenames + rows vanish on terminal state. Pure FE bug, separate from chunking. |
| #403 | Documents tab vs reindex count divergence. Downstream of the 518>512 bug we just fixed; should self-resolve after this lands. |

## Closes

Closes the issue I filed during the 3-RAG-expert debate (tiktoken + canary parity ask) and the user-reported 518>512 regression from PR #383 manual QA.