### PR TITLE
fix(llm): honor TOML temperature/top_p; add sampling-config INFO log

### DIFF
--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -625,6 +625,11 @@ class LLMManager:
         api_version = self._get_api_version(model_settings, platform)
         base_url = self._get_base_url(model_settings, platform)
         http_timeout = self._get_http_timeout(model_settings)
+        logger.info(
+            f"Sampling config for {platform}/{model_name}: "
+            f"temperature={temperature}, top_p={model_settings.get('top_p', 1.0)}, "
+            f"max_tokens={max_tokens}"
+        )
         if platform == "azure":
             api_version = str(model_settings.get('api_version'))
             is_reasoning = self._is_reasoning_model(model_name)
@@ -644,6 +649,7 @@ class LLMManager:
                     timeout=http_timeout,
                     azure_deployment=model_name + "-" + api_version,
                     temperature=temperature,
+                    top_p=model_settings.get('top_p', 1.0),
                     max_tokens=max_tokens,
                 )
         elif platform == "openai":
@@ -657,6 +663,7 @@ class LLMManager:
 
             if not is_reasoning:
                 openai_params["temperature"] = temperature
+                openai_params["top_p"] = model_settings.get('top_p', 1.0)
             else:
                 logger.debug(f"Skipping temperature for reasoning model: {model_name}")
 
@@ -743,6 +750,7 @@ class LLMManager:
                 max_tokens=max_tokens,
                 model=model_name,
                 temperature=temperature,
+                top_p=model_settings.get('top_p', 1.0),
                 seed=42,
             )
         elif platform == "rits-restricted":
@@ -794,6 +802,7 @@ class LLMManager:
 
             if not is_reasoning:
                 openrouter_params["temperature"] = temperature
+                openrouter_params["top_p"] = model_settings.get('top_p', 1.0)
             else:
                 logger.debug(f"Skipping temperature for reasoning model: {model_name}")
 
@@ -826,6 +835,7 @@ class LLMManager:
             }
             if not is_reasoning:
                 litellm_params["temperature"] = temperature
+                litellm_params["top_p"] = model_settings.get('top_p', 1.0)
             else:
                 logger.debug(f"Skipping temperature for reasoning model (litellm): {model_name}")
             # Tell litellm to use the OpenAI-compatible code path without parsing
@@ -881,7 +891,10 @@ class LLMManager:
         if is_mock_llm_enabled():
             mock = clone_load_test_mock_chat_model()
             return self._update_model_parameters(
-                mock, temperature=0.1, max_tokens=max_tokens, max_completion_tokens=max_tokens
+                mock,
+                temperature=model_settings.get('temperature', 0.1),
+                max_tokens=max_tokens,
+                max_completion_tokens=max_tokens,
             )
 
         # Check if pre-instantiated model is available
@@ -889,7 +902,9 @@ class LLMManager:
             logger.debug(f"Using pre-instantiated model: {type(self._pre_instantiated_model).__name__}")
             # Update parameters for the task
             updated_model = self._update_model_parameters(
-                self._pre_instantiated_model, temperature=0.1, max_tokens=max_tokens
+                self._pre_instantiated_model,
+                temperature=model_settings.get('temperature', 0.1),
+                max_tokens=max_tokens,
             )
             return updated_model
 
@@ -908,7 +923,10 @@ class LLMManager:
             # Update parameters for the task
             cached_model = self._models[cache_key]
             updated_model = self._update_model_parameters(
-                cached_model, temperature=0.1, max_tokens=max_tokens, max_completion_tokens=max_tokens
+                cached_model,
+                temperature=model_settings.get('temperature', 0.1),
+                max_tokens=max_tokens,
+                max_completion_tokens=max_tokens,
             )
             return updated_model
 
@@ -920,7 +938,11 @@ class LLMManager:
         self._models[cache_key] = model
 
         # Update parameters for the task
-        updated_model = self._update_model_parameters(model, temperature=0.1, max_tokens=max_tokens)
+        updated_model = self._update_model_parameters(
+            model,
+            temperature=model_settings.get('temperature', 0.1),
+            max_tokens=max_tokens,
+        )
         return updated_model
 
 

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -625,9 +625,18 @@ class LLMManager:
         api_version = self._get_api_version(model_settings, platform)
         base_url = self._get_base_url(model_settings, platform)
         http_timeout = self._get_http_timeout(model_settings)
+        # Compute effective sampling values *after* reasoning-model suppression and
+        # platform-specific overrides, so the INFO log reflects what is actually sent.
+        is_reasoning = self._is_reasoning_model(model_name)
+        effective_temperature = None if is_reasoning else temperature
+        effective_top_p = (
+            None
+            if is_reasoning
+            else (0.95 if platform == "rits-restricted" else model_settings.get('top_p', 1.0))
+        )
         logger.info(
             f"Sampling config for {platform}/{model_name}: "
-            f"temperature={temperature}, top_p={model_settings.get('top_p', 1.0)}, "
+            f"temperature={effective_temperature}, top_p={effective_top_p}, "
             f"max_tokens={max_tokens}"
         )
         if platform == "azure":
@@ -744,15 +753,17 @@ class LLMManager:
             api_key = _normalize_secret(resolve_secret(apikey_name)) if apikey_name else None
             if not api_key and apikey_name:
                 api_key = os.environ.get(apikey_name)
-            llm = ChatOpenAI(
-                api_key=api_key,
-                base_url=model_settings.get('url'),
-                max_tokens=max_tokens,
-                model=model_name,
-                temperature=temperature,
-                top_p=model_settings.get('top_p', 1.0),
-                seed=42,
-            )
+            rits_params: Dict[str, Any] = {
+                "api_key": api_key,
+                "base_url": model_settings.get('url'),
+                "max_tokens": max_tokens,
+                "model": model_name,
+                "seed": 42,
+            }
+            if not is_reasoning:
+                rits_params["temperature"] = temperature
+                rits_params["top_p"] = model_settings.get('top_p', 1.0)
+            llm = ChatOpenAI(**rits_params)
         elif platform == "rits-restricted":
             api_key = _normalize_secret(resolve_secret("RITS_API_KEY_RESTRICT")) or os.environ.get(
                 "RITS_API_KEY_RESTRICT"


### PR DESCRIPTION
## Summary

Closes #404.

- Read `temperature` from `model_settings` at the four `_update_model_parameters` callsites in `LLMManager.get_model` (was hardcoded `0.1`, which silently clobbered every `temperature = X` in every `settings.<provider>.toml`).
- Read `top_p` from `model_settings` in five platform constructors (azure, openai, rits, openrouter, litellm), default 1.0. Gated by `is_reasoning` where the existing code already gates `temperature`, since OpenAI's o1/o3/gpt-5 reasoning models reject `top_p`.
- Add a startup INFO log in `_create_llm_instance` showing the effective sampling configuration. The previous invisibility of these parameters is exactly why the temperature bug went unnoticed — a TOML edit appeared to take effect (visible to Dynaconf) but never reached the actual request.

Platforms intentionally left for a follow-up: `rits-restricted` (top_p remains hardcoded at 0.95 per the discussion in #404), `groq`, `watsonx`, `google-genai` (not in the active-use set, untested for top_p).

## Test plan

- [x] `uv run ruff check src/cuga/backend/llm/models.py` — passes
- [x] `uv run ruff format --check src/cuga/backend/llm/models.py` — passes
- [x] Manual e2e on AppWorld via cuga-eval with both gemma and nemotron RITS endpoints; the new INFO log line surfaces the effective `temperature`/`top_p`/`max_tokens` at construction time, and runtime `Updated model parameters` log shows the TOML value (was `0.1` before this PR regardless of TOML).
- [ ] Add a small unit test that mocks `model_settings` with `temperature = 0.7, top_p = 0.9` and asserts both reach the constructed `ChatOpenAI` instance — recommend adding before merge.

## Out of scope

- Adding `top_p` to `groq`/`watsonx`/`google-genai` constructors (those use non-OpenAI SDKs and need separate verification — happy to follow up in a separate PR).
- Making `rits-restricted`'s hardcoded `top_p=0.95` configurable (intentional preservation per #404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced request tuning across multiple AI model providers, with improved support for `top_p` in non-reasoning configurations.

* **Bug Fixes**
  * Applied `temperature` from model settings more consistently when loading or reusing models.
  * Ensured `max_completion_tokens` aligns with `max_tokens` for mock and cached model flows.

* **Style**
  * Added clearer logging of the final, effective sampling and token limits before creating a model instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->