### PR TITLE
fix(toolguard): serialize ToolGuard objects before returning generation response

### DIFF
--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -2836,7 +2836,15 @@ async def generate_tool_guard_for_policy(
 
         updated_policy = await policy_system.storage.get_policy(policy_id)
         if updated_policy is not None:
-            result["tool_guards"] = updated_policy.tool_guards or {}
+            # Serialize ToolGuard Pydantic objects to plain dicts for JSON response
+            result["tool_guards"] = (
+                {
+                    k: v.model_dump() if hasattr(v, "model_dump") else v
+                    for k, v in updated_policy.tool_guards.items()
+                }
+                if updated_policy.tool_guards
+                else {}
+            )
 
         agent_id = "cuga-default"  # TODO: get from request if multi-agent support needed
         try:


### PR DESCRIPTION
## Bug fix

Fixes #408

### Summary

The `/api/config/policies/{policy_id}/tool-guards/generate` endpoint was returning `400 Bad Request` after every successful guard generation.

**Root cause:** Commit `eeb1ff3` added `result["tool_guards"] = updated_policy.tool_guards or {}` to include generated guards in the response. However, `updated_policy.tool_guards` is `Dict[str, ToolGuard]` where `ToolGuard` is a Pydantic model instance. `JSONResponse` uses `json.dumps()` internally which cannot serialize Pydantic objects, raising `TypeError: Object of type ToolGuard is not JSON serializable`. The route's `except TypeError` handler caught this and returned a `400`, even though the guard had been fully generated and saved.

**Solution:** Serialize each `ToolGuard` value to a plain dict via `.model_dump()` before adding to the response. A `hasattr` guard handles cases where values are already plain dicts (e.g. test fixtures or certain storage paths):

```python
# Serialize ToolGuard Pydantic objects to plain dicts for JSON response
result["tool_guards"] = {
    k: v.model_dump() if hasattr(v, "model_dump") else v
    for k, v in updated_policy.tool_guards.items()
} if updated_policy.tool_guards else {}
```

### Testing
- [x] Verified fix locally; tests pass
- [x] `tests/unit/test_tool_guard_generation_route.py` — 15/15 passing
- [x] `tests/unit/test_tool_guard_generation_route_sync.py` — all passing
- [x] `tests/unit/test_tool_guard_generation.py` — all passing
- [x] Ruff format and lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the format of tool guard data returned by the API so it is now serialized as plain JSON-friendly objects.
  * This helps prevent issues when consuming policy results in clients or integrations expecting standard dictionary data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->