### PR TITLE
fix(policy): json_schema for conflict-resolution structured output (gpt-oss/Watsonx)

### DIFF
--- a/src/cuga/backend/cuga_graph/policy/agent.py
+++ b/src/cuga/backend/cuga_graph/policy/agent.py
@@ -620,8 +620,12 @@ Provide:
             logger.debug(f"    User prompt length: {len(user_prompt)} chars")
             logger.debug(f"    Number of policies in prompt: {len(policies_with_nl_triggers)}")
 
-            # Use structured output for reliable JSON parsing
-            structured_llm = self.llm.with_structured_output(PolicyConflictResolution)
+            # Use structured output for reliable JSON parsing.
+            # method="json_schema" (matching OutputFormatter in enactment.py) is enforced
+            # server-side by IBM Watsonx. The default (function_calling) returns None on
+            # gpt-oss-120b when it emits no tool call, which raised AttributeError below and
+            # silently dropped the policy match.
+            structured_llm = self.llm.with_structured_output(PolicyConflictResolution, method="json_schema")
             result: PolicyConflictResolution = await structured_llm.ainvoke(messages)
 
             logger.debug("  - Received structured LLM response:")


### PR DESCRIPTION
## Bug fix

Fixes #411

### Summary
`PolicyAgent._resolve_nl_trigger_conflicts` called `with_structured_output(PolicyConflictResolution)` without `method=`, defaulting to function/tool-calling. On `openai/gpt-oss-120b` (Watsonx) the model often emits no tool call → returns `None` → `AttributeError` on `.matched_policy_index` → NL-trigger policies silently never match. Fix: pass `method="json_schema"` (enforced server-side by Watsonx; matches the existing OutputFormatter in `enactment.py`). The rest of the graph already uses `response_format=json_schema` via `BaseAgent.get_chain`, so it is unaffected.

### Testing
- [x] Verified fix locally; tests pass

**Checks performed — live on `openai/gpt-oss-120b` (IBM Watsonx):**
- Policy: the 2 failing conflict-resolution tests now pass; all 7 originally-failing policy tests pass in isolation after the fix.
- Full task-decomposition graph: `accurate_test` 3/3, `balanced_test` 3/3.
- AB / stability suite: 10/10 ×3 (100%).
- Mock unit tier (`run_tests.sh unit_tests`): ~535 passed / 0 failed.
- `ruff check` clean on the changed file.

### Related (follow-ups, not fixed here)
- #412 — policy e2e tests flaky with `RuntimeError: Event loop is closed` when run as a suite (test-harness async teardown; each passes in isolation).
- #413 — no live test coverage for the browser sub-graph & feature-flagged paths on gpt-oss/Watsonx.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of conflict resolution for natural-language triggers, reducing cases where responses could be misparsed or fail during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->