### PR TITLE
test(policy): process-isolate policy e2e tests to fix 'Event loop is closed' flakiness

### DIFF
--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -75,8 +75,24 @@ run_pytest_with_e2b() {
 # transient live-LLM nondeterminism. See issue #412.
 run_pytest_isolated() {
     echo "Running $* with process-per-test isolation + retry (issue #412)..."
-    local nodes
-    nodes=$(uv run pytest "$@" --collect-only -q -p no:cacheprovider 2>/dev/null | grep '::')
+    local nodes collect_output collect_ec
+    if collect_output=$(uv run pytest "$@" --collect-only -q -p no:cacheprovider 2>&1); then
+        collect_ec=0
+    else
+        collect_ec=$?
+    fi
+    # pytest exit code 5 = no tests collected (not a failure); any other non-zero is a
+    # collection/import error and must NOT be silently treated as "no tests".
+    if [ "$collect_ec" -eq 5 ]; then
+        echo "No tests collected for $* (treating as success)"
+        return 0
+    fi
+    if [ "$collect_ec" -ne 0 ]; then
+        echo "$collect_output"
+        echo "❌ Test collection failed for $* (exit $collect_ec)! Exiting..."
+        exit 1
+    fi
+    nodes=$(printf '%s\n' "$collect_output" | grep '::' || true)
     if [ -z "$nodes" ]; then
         echo "No tests collected for $* (treating as success)"
         return 0

--- a/src/scripts/run_tests.sh
+++ b/src/scripts/run_tests.sh
@@ -67,6 +67,39 @@ run_pytest_with_e2b() {
     fi
 }
 
+# Helper: run each collected test in its OWN pytest subprocess (process-per-test isolation),
+# retrying a failure once. Live async e2e tests (e.g. policy/tests) cache LLM/HTTP clients bound
+# to the event loop active at creation; pytest's function-scoped loops mean a cached client gets
+# reused on a later test's loop -> "RuntimeError: Event loop is closed" (nondeterministic, passes
+# in isolation). A fresh interpreter per test avoids the cross-loop reuse; the single retry absorbs
+# transient live-LLM nondeterminism. See issue #412.
+run_pytest_isolated() {
+    echo "Running $* with process-per-test isolation + retry (issue #412)..."
+    local nodes
+    nodes=$(uv run pytest "$@" --collect-only -q -p no:cacheprovider 2>/dev/null | grep '::')
+    if [ -z "$nodes" ]; then
+        echo "No tests collected for $* (treating as success)"
+        return 0
+    fi
+    local fails=0 total=0
+    while IFS= read -r t; do
+        [ -z "$t" ] && continue
+        total=$((total + 1))
+        if ! uv run pytest "$t" -p no:cacheprovider -q; then
+            echo "⚠️  isolated test failed once, retrying: $t"
+            if ! uv run pytest "$t" -p no:cacheprovider -q; then
+                echo "❌ isolated test failed twice: $t"
+                fails=$((fails + 1))
+            fi
+        fi
+    done <<< "$nodes"
+    echo "Isolated run of $*: $((total - fails))/$total passed"
+    if [ $fails -ne 0 ]; then
+        echo "❌ $fails isolated test(s) failed after retry! Exiting..."
+        exit 1
+    fi
+}
+
 echo "Running unit tests (registry + variables manager + local sandbox + E2B lite)..."
 run_pytest ./src/cuga/backend/tools_env/registry/tests/
 run_pytest ./src/cuga/backend/tools_env/registry/mcp_manager/tests/
@@ -106,7 +139,7 @@ if [ "$1" = "unit_tests" ]; then
     exit 0
 else
     echo "Running policy integration tests..."
-    run_pytest ./src/cuga/backend/cuga_graph/policy/tests
+    run_pytest_isolated ./src/cuga/backend/cuga_graph/policy/tests
     echo "Running SDK integration tests..."
     run_pytest ./src/cuga/sdk_core/tests/
     echo "Running manager API integration tests..."


### PR DESCRIPTION
## Bug fix

Fixes #412

### Summary
Policy e2e tests flaked with `RuntimeError: Event loop is closed` when run as one pytest session: `LLMManager` caches async clients (e.g. `ChatWatsonx`'s httpx client) bound to the event loop active at creation, and pytest's function-scoped loops reuse a cached client on a later test's loop. Each test passes in isolation; the failing set varied run-to-run.

Fix: run the policy tests **process-per-test** in `src/scripts/run_tests.sh` via a new `run_pytest_isolated` helper — one `pytest` subprocess per test (fresh interpreter / loop / singletons), with a single retry to absorb transient live-LLM nondeterminism.

### Testing
- [x] Verified fix locally; tests pass

- **Before** (one session): 6 failed (all `Event loop is closed`) / 51 passed; failing set varied run-to-run.
- **After** (process-isolated): full policy dir 56/57 passed; the 1 was a transient accuracy flake (`healthcare_family_claims`) that passes on re-run — now absorbed by the retry. The 6 event-loop offenders (`output_formatter`×3, `playbook_guidance`, `tool_enrichment`, `nl_trigger_conflict`) all pass.

Note: a fully-green policy run also requires the #411 fix (PR #414).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the test runner by discovering test nodes first and then executing each test in an isolated pytest subprocess.
  * Added an automatic single retry for any individual test that fails; the overall run fails only if a test fails twice.
  * Treats “no tests collected” during discovery as a successful run.
  * Updated policy-related test execution to use the isolated per-test-node flow for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->