### PR TITLE
chore(watsonx): default to openai/gpt-oss-120b

### DIFF
--- a/src/cuga/configurations/models/settings.watsonx.toml
+++ b/src/cuga/configurations/models/settings.watsonx.toml
@@ -1,60 +1,60 @@
 [agent.task_decomposition.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.shortlister.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.planner.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.chat.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.plan_controller.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.final_answer.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 api_version ="2024-08-06"
 temperature = 0.1
 max_tokens = 32000
 
 [agent.code.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.code_planner.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.qa.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 16000
 
 [agent.action.model]
 platform = "watsonx"
-model_name = "meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
+model_name = "openai/gpt-oss-120b"
 temperature = 0.1
 max_tokens = 2000


### PR DESCRIPTION
## Chore

Fixes #422

### Summary
Default the Watsonx profile to `openai/gpt-oss-120b`: all `[agent.*.model]` blocks in `src/cuga/configurations/models/settings.watsonx.toml` switch from `meta-llama/llama-4-maverick-17b-128e-instruct-fp8` to `openai/gpt-oss-120b` (`temperature`/`max_tokens` unchanged). With no `MODEL_NAME` override, Watsonx agents now default to gpt-oss-120b; users who want llama-4 can set `MODEL_NAME` or edit the TOML.

⚠️ **Default-behavior change** for all Watsonx users (llama-4 → gpt-oss-120b unless `MODEL_NAME` is set).

### Testing
- [x] Verified locally

With `MODEL_NAME` unset (so the TOML default is exercised):
- `LLMManager.get_model(...)` resolves `model_id=openai/gpt-oss-120b` from the TOML default; a live `invoke` returned `OK` against Watsonx.
- `uv run demo` (CUGA FastAPI server): clean `Application startup complete`, **HTTP 200** on `/` and `/docs`, log line `Using model_name from TOML: openai/gpt-oss-120b`, 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Watsonx-backed AI models used across several agent workflows to a newer model, which may improve response quality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->