### PR TITLE
ci: reduce Windows stability tests to a single smoke case

### DIFF
--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -88,10 +88,10 @@ jobs:
           retention-days: 7
 
   stability-tests-windows:
-    name: Stability Tests Windows (Python 3.12)
+    name: Stability Tests Windows Smoke (Python 3.12)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     strategy:
       fail-fast: false
 
@@ -129,7 +129,7 @@ jobs:
           UV_QUIET: 1
           PYTHONIOENCODING: utf-8
           CUGA_THREAD_WORKSPACE_SEED: crm
-        run: uv run run_stability_tests.py --method local
+        run: uv run run_stability_tests.py --method local --windows-smoke
 
       - name: Check pass rate
         if: always()

--- a/run_stability_tests.py
+++ b/run_stability_tests.py
@@ -532,6 +532,11 @@ def main():
         action="store_true",
         help="E2B mode: use fixed port 8001 for registry, run local without parallel.",
     )
+    parser.add_argument(
+        "--windows-smoke",
+        action="store_true",
+        help="Run only the Windows smoke test subset from stability_test_config.toml.",
+    )
     args = parser.parse_args()
 
     if args.generate_summary:
@@ -570,9 +575,14 @@ def main():
     # Get stability tests
     try:
         stability_config = settings.stability
-        tests = stability_config.tests
+        if args.windows_smoke:
+            tests = stability_config.windows_smoke
+            print("Windows smoke mode: running reduced test subset")
+        else:
+            tests = stability_config.tests
     except AttributeError:
-        print("Error: [stability] section or tests not found in stability_test_config.toml")
+        section = "windows_smoke" if args.windows_smoke else "tests"
+        print(f"Error: [stability].{section} not found in stability_test_config.toml")
         sys.exit(1)
 
     run_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/src/system_tests/e2e/stability_test_config.toml
+++ b/src/system_tests/e2e/stability_test_config.toml
@@ -35,3 +35,11 @@ cases = [
     "TestCRMHF_Examples::test_what_is_cuga",
     "TestCRMHF_Examples::test_playbook_execution"
 ]
+
+# Single smoke test for Windows CI: exercises subprocess servers, port allocation,
+# UTF-8 encoding, and agent streaming without running the full ~30 min suite.
+[[stability.windows_smoke]]
+file = "src/system_tests/e2e/fast_test.py"
+cases = [
+    "TestServerStreamFast::test_list_my_accounts_fast"
+]


### PR DESCRIPTION
## Summary
- Windows stability CI was taking ~30 minutes because it ran all 9 E2E tests sequentially (parallel was removed in ef2662c6 due to Windows subprocess contention).
- Adds a `--windows-smoke` flag and a dedicated `[[stability.windows_smoke]]` config with one fast-mode test (`test_list_my_accounts_fast`) that still exercises subprocess servers, dynamic port allocation, UTF-8 encoding, and agent streaming on Windows.
- Reduces the Windows job timeout from 60 to 15 minutes.

## Why not re-enable parallel?
Parallel on Windows was intentionally removed — subprocess spawning is slower and concurrent execution caused resource contention, often making parallel runs slower than sequential.

## Test plan
- [ ] Windows stability job completes in ~3–5 minutes instead of ~30
- [ ] Smoke test passes on `windows-latest`
- [ ] Ubuntu matrix (3 Python versions) still runs the full suite unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a faster Windows smoke stability check to validate a small, targeted subset of the suite.
  * Reduced the runtime limit for this check so failures surface sooner and CI completes more quickly.
  * Improved test selection and error messaging when the Windows smoke path is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->