### PR TITLE
fix: deliver HITL response in tool-approval e2e resume helper

### DIFF
--- a/src/cuga/backend/cuga_graph/policy/tests/helpers.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/helpers.py
@@ -3,6 +3,7 @@
 import uuid
 from typing import Dict, List, Any, Optional
 from langchain_core.messages import HumanMessage
+from langgraph.types import Command
 
 from cuga.backend.cuga_graph.policy.storage import PolicyStorage
 from cuga.backend.cuga_graph.policy.configurable import PolicyConfigurable
@@ -461,13 +462,11 @@ async def resume_graph_with_response(
     """
     config = graph.get_config_with_policy({"configurable": {"thread_id": thread_id}})
 
-    # Update the state with the response
-    current_state = graph.graph.get_state(config)
-    updated_state = AgentState(**current_state.values)
-    updated_state.hitl_response = response
-
-    # Stream events until completion or next interrupt
-    async for event in graph.graph.astream(None, config, stream_mode="updates"):
+    async for event in graph.graph.astream(
+        Command(resume=response.model_dump()),
+        config,
+        stream_mode="updates",
+    ):
         if isinstance(event, tuple):
             namespace, state_dict = event
             if "__interrupt__" in state_dict or state_dict.get("__interrupt__"):

--- a/src/cuga/backend/cuga_graph/policy/tests/helpers.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/helpers.py
@@ -452,6 +452,11 @@ async def resume_graph_with_response(
 ) -> Any:
     """Resume the graph with a human response.
 
+    Delivers the response via LangGraph's interrupt/resume protocol
+    (``Command(resume=...)``), matching the SDK path. When the user
+    confirmed approval, may resume more than once: follow-up codegen
+    (e.g. structure probes) can re-trigger tool approval on the same thread.
+
     Args:
         graph: DynamicAgentGraph instance
         thread_id: Thread identifier
@@ -459,11 +464,18 @@ async def resume_graph_with_response(
 
     Returns:
         Final state snapshot after resuming
+
+    Raises:
+        RuntimeError: If the graph keeps interrupting after repeated confirmed resumes.
     """
     config = graph.get_config_with_policy({"configurable": {"thread_id": thread_id}})
     resume_payload: Any = Command(resume=response.model_dump())
+    max_resume_attempts = 5
 
-    while True:
+    for attempt in range(max_resume_attempts):
+        # Drain the stream so LangGraph runs nodes and updates the checkpoint.
+        # We don't inspect individual events; the authoritative state is read
+        # from get_state() after the stream finishes (or hits an interrupt).
         async for _event in graph.graph.astream(
             resume_payload,
             config,
@@ -475,12 +487,21 @@ async def resume_graph_with_response(
         if not state_snapshot.next:
             return state_snapshot
 
-        # After first approval, follow-up codegen (e.g. structure probes) can
-        # re-trigger tool approval; auto-resume with the same confirmation.
+        # Still interrupted. Denials should end the graph above; if not, return
+        # as-is so deny/modification tests can assert on the partial state.
         if not response.confirmed:
             return state_snapshot
 
+        # Confirmed approval but another interrupt (e.g. structure-probe codegen
+        # calling the same tool again). Re-send the same approval to continue.
+        if attempt + 1 >= max_resume_attempts:
+            raise RuntimeError(
+                f"Graph still interrupted after {max_resume_attempts} confirmed "
+                "resume attempts; possible approval loop"
+            )
         resume_payload = Command(resume=response.model_dump())
+
+    raise RuntimeError("unreachable")
 
 
 async def run_full_graph_to_completion(

--- a/src/cuga/backend/cuga_graph/policy/tests/helpers.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/helpers.py
@@ -461,22 +461,26 @@ async def resume_graph_with_response(
         Final state snapshot after resuming
     """
     config = graph.get_config_with_policy({"configurable": {"thread_id": thread_id}})
+    resume_payload: Any = Command(resume=response.model_dump())
 
-    async for event in graph.graph.astream(
-        Command(resume=response.model_dump()),
-        config,
-        stream_mode="updates",
-    ):
-        if isinstance(event, tuple):
-            namespace, state_dict = event
-            if "__interrupt__" in state_dict or state_dict.get("__interrupt__"):
-                break
-        elif "__interrupt__" in event:
-            break
+    while True:
+        async for _event in graph.graph.astream(
+            resume_payload,
+            config,
+            stream_mode="updates",
+        ):
+            pass
 
-    # Get the final state
-    state_snapshot = graph.graph.get_state(config)
-    return state_snapshot
+        state_snapshot = graph.graph.get_state(config)
+        if not state_snapshot.next:
+            return state_snapshot
+
+        # After first approval, follow-up codegen (e.g. structure probes) can
+        # re-trigger tool approval; auto-resume with the same confirmation.
+        if not response.confirmed:
+            return state_snapshot
+
+        resume_payload = Command(resume=response.model_dump())
 
 
 async def run_full_graph_to_completion(

--- a/src/cuga/backend/cuga_graph/policy/tests/test_tool_approval_full_graph.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/test_tool_approval_full_graph.py
@@ -210,18 +210,20 @@ async def test_tool_approval_approve_flow():
             f"  Final answer length: {len(final_state.final_answer) if final_state.final_answer else 0} chars"
         )
 
-        # The agent should have executed the code and provided a final answer
         assert final_state.final_answer, (
             "Agent should complete execution after approval and provide a final answer"
         )
-
-        # Verify the code was actually executed (not regenerated)
-        if final_state.final_answer:
-            assert "cancelled" not in final_state.final_answer.lower(), (
-                "Final answer should not indicate cancellation"
-            )
-            assert "denied" not in final_state.final_answer.lower(), "Final answer should not indicate denial"
-            print("  ✅ Tool execution completed successfully")
+        assert "✋" not in final_state.final_answer, (
+            "Final answer should not be the approval banner after approval"
+        )
+        assert "Acme Corp" in final_state.final_answer, (
+            "Final answer should include tool output after approved execution"
+        )
+        assert "cancelled" not in final_state.final_answer.lower(), (
+            "Final answer should not indicate cancellation"
+        )
+        assert "denied" not in final_state.final_answer.lower(), "Final answer should not indicate denial"
+        print("  ✅ Tool execution completed successfully")
 
         print("\n✅ Tool Approval Approve Flow Test PASSED")
         print("=" * 80)
@@ -327,17 +329,13 @@ async def test_tool_approval_deny_flow():
         final_state = AgentState(**final_snapshot.values)
         print(f"  Final answer: {final_state.final_answer}")
 
-        # The agent should have stopped execution after denial
-        # Either it provides a cancellation message, or it stops without executing
-        if final_state.final_answer:
-            # If there's a final answer, it should indicate the approval was denied
-            print(f"  Final answer indicates: {final_state.final_answer[:100]}...")
-            # The test passes if we got here (denial was processed)
-            print("  ✅ Tool execution cancelled successfully")
-        else:
-            # If no final answer, that's also fine - execution was stopped
-            print("  ✅ Tool execution cancelled (no final answer provided)")
-            print("  ✅ Tool execution cancelled successfully")
+        assert final_state.final_answer, "Denial should produce a cancellation message"
+        assert "Acme Corp" not in final_state.final_answer, "Tool output should not appear after denial"
+        assert (
+            "cancelled" in final_state.final_answer.lower() or "denied" in final_state.final_answer.lower()
+        ), "Final answer should indicate execution was cancelled or denied"
+        print(f"  Final answer indicates: {final_state.final_answer[:100]}...")
+        print("  ✅ Tool execution cancelled successfully")
 
         print("\n✅ Tool Approval Deny Flow Test PASSED")
         print("=" * 80)
@@ -515,12 +513,16 @@ async def test_tool_approval_modification_flow():
         assert final_state_2.final_answer, (
             "Agent should complete execution after approval and provide a final answer"
         )
-
-        if final_state_2.final_answer:
-            assert "cancelled" not in final_state_2.final_answer.lower(), (
-                "Final answer should not indicate cancellation"
-            )
-            print("  ✅ Modified tool execution completed successfully")
+        assert "✋" not in final_state_2.final_answer, (
+            "Final answer should not be the approval banner after approval"
+        )
+        assert "Acme Corp" in final_state_2.final_answer, (
+            "Final answer should include tool output after approved execution"
+        )
+        assert "cancelled" not in final_state_2.final_answer.lower(), (
+            "Final answer should not indicate cancellation"
+        )
+        print("  ✅ Modified tool execution completed successfully")
 
         print("\n✅ Tool Approval Modification Flow Test PASSED")
         print("=" * 80)


### PR DESCRIPTION
## Summary
- Fixes `resume_graph_with_response` so tool-approval e2e tests actually deliver human approvals/denials to the graph via LangGraph's `Command(resume=...)` mechanism (matching the SDK resume path).
- Tightens the three tool-approval full-graph e2e tests to assert post-approval execution (tool output in final answer, no approval banner) and post-denial cancellation.

Fixes #427

## Problem
The helper built a local `AgentState`, set `hitl_response` on it, then called `astream(None, …)` without writing the response back to the checkpoint. On resume the graph re-interrupted without recording approval, so `handle_approval_resumption()` never ran and tests passed on the approval-banner text alone.

## Test plan
- [x] `uv run python -m pytest src/cuga/backend/cuga_graph/policy/tests/test_tool_approval_full_graph.py -s` — all three tests passed in CI (run 28581606688)
- [x] Verify approve flow final answer contains `Acme Corp` and not the approval banner
- [x] Verify deny flow final answer indicates cancellation and does not contain tool output
- [x] Verify modification flow approve step includes tool output after resume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated human-in-the-loop graph resume logic in test helpers to use standard interrupt/resume semantics, with looped resumption and bounded retry behavior.
  * Strengthened end-to-end tool-approval assertions across approve/deny/modify flows to consistently require the expected final answer and tool output content.
  * Added stricter checks ensuring the approval banner and cancellation/denial wording appear only in the correct scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->