### PR TITLE
feat(rits): direct RITS connections with .env-driven model swapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,9 @@ CUGA supports LiteLLM through the OpenAI configuration by overriding the base UR
    RITS_API_KEY=your-rits-api-key
    AGENT_SETTING_CONFIG="settings.rits.toml"
 
-   # Optional overrides (swap model/endpoint without editing 14 TOML blocks)
+   # Optional overrides — update MODEL_NAME and RITS_BASE_URL together for
+   # direct RITS setups, since each model has a model-specific URL path.
+   # Setting MODEL_NAME alone will leave you pointed at the previous model's URL.
    MODEL_NAME=google/gemma-4-31B-it
    RITS_BASE_URL="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
    ```

--- a/README.md
+++ b/README.md
@@ -358,6 +358,28 @@ CUGA supports LiteLLM through the OpenAI configuration by overriding the base UR
    MODEL_NAME=openai/gpt-4o                    # Override model name
     ```
 
+### Option 7: RITS Support
+**Setup Instructions:**
+1. Obtain a RITS API key from the RITS platform admin.
+2. Add to your `.env` file:
+   ```env
+   # RITS Configuration — direct RITS endpoint (default preset)
+   RITS_API_KEY=your-rits-api-key
+   AGENT_SETTING_CONFIG="settings.rits.toml"
+
+   # Optional overrides (swap model/endpoint without editing 14 TOML blocks)
+   MODEL_NAME=google/gemma-4-31B-it
+   RITS_BASE_URL="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+   ```
+
+To front RITS with a local LiteLLM proxy instead, use `AGENT_SETTING_CONFIG="settings.rits.proxy.toml"`.
+
+**Default Values:**
+
+- Model: `google/gemma-4-31B-it` (direct preset)
+- Base URL: gemma-4-31B-it `/v1` endpoint on the RITS 3scale apicast host (direct preset)
+- Local proxy URL: `http://localhost:4000` (proxy preset)
+
 
 ## Configuration Files
 
@@ -368,6 +390,8 @@ CUGA uses TOML configuration files located in `src/cuga/configurations/models/`:
 - `settings.azure.toml` - Azure OpenAI configuration
 - `settings.groq.toml` - Groq configuration
 - `settings.openrouter.toml` - OpenRouter configuration
+- `settings.rits.toml` - RITS configuration (direct endpoint)
+- `settings.rits.proxy.toml` - RITS configuration (local LiteLLM proxy fronting RITS)
 
 Each file contains agent-specific model settings that can be overridden by environment variables.
 

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -759,6 +759,7 @@ class LLMManager:
                 "max_tokens": max_tokens,
                 "model": model_name,
                 "seed": 42,
+                "default_headers": {"RITS_API_KEY": api_key} if api_key else None,
             }
             if not is_reasoning:
                 rits_params["temperature"] = temperature

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -375,6 +375,19 @@ class LLMManager:
                 default_model = "gpt-4o"
                 logger.info(f"No model_name specified for LiteLLM, using default: {default_model}")
                 return default_model
+        elif platform == "rits":
+            env_model_name = os.environ.get('MODEL_NAME')
+            if env_model_name:
+                logger.info(f"Using MODEL_NAME from environment for RITS: {env_model_name}")
+                return env_model_name
+            elif toml_model_name:
+                logger.debug(f"Using model_name from TOML for RITS: {toml_model_name}")
+                return toml_model_name
+            else:
+                raise ValueError(
+                    "model_name must be specified for platform rits "
+                    "(set MODEL_NAME env var or model_name in the TOML)"
+                )
         else:
             # For other platforms, use TOML or default
             if toml_model_name:
@@ -476,6 +489,19 @@ class LLMManager:
         """
         # Groq SDK manages its own endpoint; any URL in config is ignored
         if platform == "groq":
+            return None
+
+        # RITS: let RITS_BASE_URL env override the TOML so model/endpoint can be
+        # swapped from .env without editing every per-role TOML block.
+        if platform == "rits":
+            env_base_url = os.environ.get('RITS_BASE_URL')
+            if env_base_url:
+                logger.info(f"Using RITS_BASE_URL from environment: {env_base_url}")
+                return env_base_url
+            toml_url = model_settings.get("base_url") or model_settings.get("url")
+            if toml_url and str(toml_url).strip():
+                logger.debug(f"Using url from TOML for RITS: {toml_url}")
+                return str(toml_url).strip()
             return None
 
         config_url = model_settings.get("base_url") or model_settings.get("url")
@@ -755,7 +781,7 @@ class LLMManager:
                 api_key = os.environ.get(apikey_name)
             rits_params: Dict[str, Any] = {
                 "api_key": api_key,
-                "base_url": model_settings.get('url'),
+                "base_url": base_url,
                 "max_tokens": max_tokens,
                 "model": model_name,
                 "seed": 42,

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -779,8 +779,12 @@ class LLMManager:
             api_key = _normalize_secret(resolve_secret(apikey_name)) if apikey_name else None
             if not api_key and apikey_name:
                 api_key = os.environ.get(apikey_name)
+            # RITS authenticates via the custom RITS_API_KEY header, not
+            # Authorization: Bearer. Pass a dummy api_key so ChatOpenAI does not
+            # also send the real key on the Authorization header — matches the
+            # `openai` branch's pattern when auth_headers are in play.
             rits_params: Dict[str, Any] = {
-                "api_key": api_key,
+                "api_key": "dummy" if api_key else None,
                 "base_url": base_url,
                 "max_tokens": max_tokens,
                 "model": model_name,

--- a/src/cuga/configurations/models/settings.rits.proxy.toml
+++ b/src/cuga/configurations/models/settings.rits.proxy.toml
@@ -1,0 +1,113 @@
+[agent.task_decomposition.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 1000
+
+[agent.planner.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 7000
+
+[agent.shortlister.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 7000
+
+
+[agent.chat.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 5000
+
+[agent.plan_controller.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 5000
+
+
+[agent.final_answer.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 15000
+
+[agent.code.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 3000
+
+[agent.code_planner.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 3000
+
+[agent.qa.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 4000
+
+[agent.action.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 400
+
+[memory.mem0.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 1000
+
+[memory.milvus.step_processing.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 1000
+
+[memory.milvus.fact_extraction.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 1000
+
+[memory.tips_extractor.model]
+platform = "rits"
+model_name = "rits/openai/gpt-oss-120b"
+url="http://localhost:4000"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+max_tokens = 5000

--- a/src/cuga/configurations/models/settings.rits.toml
+++ b/src/cuga/configurations/models/settings.rits.toml
@@ -1,81 +1,127 @@
 [agent.task_decomposition.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 1000
 
 [agent.planner.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 7000
 
 [agent.shortlister.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 7000
 
 
 [agent.chat.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 5000
 
 [agent.plan_controller.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 5000
 
 
 [agent.final_answer.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 15000
 
 [agent.code.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 3000
 
 [agent.code_planner.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 3000
 
 [agent.qa.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 4000
 
 [agent.action.model]
 platform = "rits"
-model_name = "rits/openai/gpt-oss-120b"
-url="http://localhost:4000"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
+top_p = 1.0
 max_tokens = 400
+
+[memory.mem0.model]
+platform = "rits"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+top_p = 1.0
+max_tokens = 1000
+
+[memory.milvus.step_processing.model]
+platform = "rits"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+top_p = 1.0
+max_tokens = 1000
+
+[memory.milvus.fact_extraction.model]
+platform = "rits"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+top_p = 1.0
+max_tokens = 1000
+
+[memory.tips_extractor.model]
+platform = "rits"
+model_name = "google/gemma-4-31B-it"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+apikey_name = "RITS_API_KEY"
+temperature = 0.1
+top_p = 1.0
+max_tokens = 5000


### PR DESCRIPTION
Closes #374.

## Summary

Enables CUGA to talk to the RITS endpoint directly (without a local LiteLLM proxy in front of it) and lets users swap the RITS model or endpoint per run via `.env` without editing every per-role TOML block.

Before this PR, the `platform == "rits"` code path only worked behind a local LiteLLM proxy: a direct RITS call returned HTTP 403 *"Authentication parameters missing"* because RITS requires a custom `RITS_API_KEY` header, and the `ChatOpenAI` client we use sends only `Authorization: Bearer`. This PR:

- **Wires the `RITS_API_KEY` custom header** through langchain-openai's `default_headers`, so direct RITS auth works end-to-end.
- **Adds `platform == "rits"` branches** to `_get_model_name` and `_get_base_url` so `MODEL_NAME` and `RITS_BASE_URL` in `.env` override the TOML. This makes swapping between RITS-hosted models (e.g. gemma → gpt-oss → nemotron) a two-line `.env` change instead of 14 per-role TOML edits.
- **Fixes the rits constructor** to consume the already-resolved `base_url` local variable rather than re-reading `model_settings.get('url')`, so the new env override actually reaches `ChatOpenAI`.

## Presets shipped

- **`settings.rits.toml`** — direct RITS preset. Defaults to `google/gemma-4-31B-it` at the `/v1` endpoint on the RITS 3scale apicast host, cuga-baseline sampling (`temperature=0.1`, `top_p=1.0`).
- **`settings.rits.proxy.toml`** — local LiteLLM proxy preset (`http://localhost:4000`, `rits/openai/gpt-oss-120b`), for teams already running their own proxy in front of RITS.

Note the deliberate deviation from the issue text: the local-proxy preset is named `settings.rits.proxy.toml`, **not** `settings.rits.local.toml`. Dynaconf silently auto-merges any `*.local.*` file on top of its non-local sibling, which would cause the two presets to override each other rather than coexist. The `.proxy.toml` suffix escapes that convention while remaining explicit about the setup.

## Docs

Adds *"Option 7: RITS Support"* to the LLM Configuration section of the README, mirroring the format used for Options 1-6 (OpenAI / WatsonX / Azure / LiteLLM / Groq / OpenRouter). Extends the Configuration Files list to include both new presets.

## Test plan

- [x] `uv run ruff check src/cuga/backend/llm/models.py` — passes
- [x] `uv run ruff format --check src/cuga/backend/llm/models.py` — passes
- [x] Runtime smoke: model factory constructs the direct-RITS `ChatOpenAI` with the correct `base_url`, `temperature=0.1`, `top_p=1.0`, and the sampling-config INFO log line surfaces the effective values.
- [x] End-to-end AppWorld eval runs on the `gemma-4-31B-it` direct preset — many bundles produced during development; consistent behavior across easy / med / hard task splits.
- [x] `.env` override path validated: setting `MODEL_NAME` / `RITS_BASE_URL` in cuga-eval's `.env` reaches the request body (verified via Langfuse `modelParameters`).

## Related follow-ups

Not blocking this PR but worth linking:

- #386 — cuga-lite has no guard against unproductive iteration loops
- #401 — Cuga-lite extractor should dispatch OpenAI-style tool-call JSON as a fallback
- #394 — `top_k` sampling parameter cannot be set on LLM calls
- #405 — TOML-defined sampling params honored (merged; this PR builds on it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RITS-based model configuration presets for both direct endpoint and local proxy routing.
  * Added standardized model settings for agent and memory components (including token limits and temperature).

* **Documentation**
  * Documented **Option 7: RITS Support**, including `RITS_API_KEY` setup and `.env` configuration for direct and proxy modes.
  * Clarified how updating `MODEL_NAME` may require updating `RITS_BASE_URL` to avoid reusing the previous URL path.
  * Updated the “Configuration Files” list to include the new `settings.rits.toml` and `settings.rits.proxy.toml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->