### PR TITLE
fix(test): normalize unicode whitespace in tool-approval e2e assertions

### DIFF
--- a/src/cuga/backend/cuga_graph/policy/tests/test_tool_approval_full_graph.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/test_tool_approval_full_graph.py
@@ -1,5 +1,7 @@
 """E2E test: Tool approval policy with full agent graph HITL flow."""
 
+import re
+import unicodedata
 import uuid
 from datetime import datetime
 import pytest
@@ -23,6 +25,14 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.providers.base import (
 )
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel, Field
+
+
+def _normalize_final_answer_text(text: str) -> str:
+    """Normalize LLM final answers for stable substring assertions."""
+    text = unicodedata.normalize("NFKC", text)
+    text = re.sub(r"\*+", "", text)
+    text = re.sub(r"[\s\u00a0\u202f\u2009]+", " ", text)
+    return text.strip()
 
 
 def _pending_tool_approval_code(state: AgentState) -> str:
@@ -216,7 +226,8 @@ async def test_tool_approval_approve_flow():
         assert "✋" not in final_state.final_answer, (
             "Final answer should not be the approval banner after approval"
         )
-        assert "Acme Corp" in final_state.final_answer, (
+        normalized_answer = _normalize_final_answer_text(final_state.final_answer)
+        assert "Acme Corp" in normalized_answer, (
             "Final answer should include tool output after approved execution"
         )
         assert "cancelled" not in final_state.final_answer.lower(), (
@@ -330,7 +341,9 @@ async def test_tool_approval_deny_flow():
         print(f"  Final answer: {final_state.final_answer}")
 
         assert final_state.final_answer, "Denial should produce a cancellation message"
-        assert "Acme Corp" not in final_state.final_answer, "Tool output should not appear after denial"
+        assert "Acme Corp" not in _normalize_final_answer_text(final_state.final_answer), (
+            "Tool output should not appear after denial"
+        )
         assert (
             "cancelled" in final_state.final_answer.lower() or "denied" in final_state.final_answer.lower()
         ), "Final answer should indicate execution was cancelled or denied"
@@ -516,7 +529,7 @@ async def test_tool_approval_modification_flow():
         assert "✋" not in final_state_2.final_answer, (
             "Final answer should not be the approval banner after approval"
         )
-        assert "Acme Corp" in final_state_2.final_answer, (
+        assert "Acme Corp" in _normalize_final_answer_text(final_state_2.final_answer), (
             "Final answer should include tool output after approved execution"
         )
         assert "cancelled" not in final_state_2.final_answer.lower(), (


### PR DESCRIPTION
## Summary
- Fix flaky `test_tool_approval_modification_flow` (and related approve/deny checks) that fail when FinalAnswerAgent uses Unicode spaces or markdown when restating tool output
- Normalize final answers before asserting on `"Acme Corp"` so e2e tests verify execution success without depending on exact LLM formatting

## Context
After tool approval, execution succeeds and prints `Acme Corp`, but FinalAnswerAgent may rephrase the answer as `**Acme\u202fCorp**` (narrow no-break space + markdown). The strict substring check added in #428 then fails even though the flow is correct.

## Test plan
- [ ] `pytest src/cuga/backend/cuga_graph/policy/tests/test_tool_approval_full_graph.py -v`
- [ ] Confirm CI policy test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of approval and denial flows by normalizing response text before checking results, making automated checks more resilient to formatting differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->