### PR TITLE
fix(watsonx): correct gpt-oss-120b context profile to prevent negative max_tokens

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-06-28T22:09:19Z",
+  "generated_at": "2026-07-05T09:11:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 666,
+        "line_number": 683,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/cuga/backend/cuga_graph/utils/context_management_utils.py
+++ b/src/cuga/backend/cuga_graph/utils/context_management_utils.py
@@ -11,6 +11,7 @@ from langchain_core.messages import BaseMessage
 from loguru import logger
 
 from cuga.backend.cuga_graph.state.agent_state import AgentState
+from cuga.backend.cuga_graph.utils.token_counter import resolve_model_identifier
 from cuga.backend.activity_tracker.tracker import ActivityTracker, Step
 
 
@@ -50,7 +51,7 @@ async def apply_context_summarization(
     if not messages:
         return messages
 
-    model_name = getattr(model, 'model_name', 'gpt-4')
+    model_name = resolve_model_identifier(model, fallback_name="gpt-4")
 
     # Do not use model.with_config(callbacks=...) here: it wraps the model in
     # RunnableBinding and breaks ContextSummarizer._setup_model_profile (profile field).

--- a/src/cuga/backend/cuga_graph/utils/context_summarizer.py
+++ b/src/cuga/backend/cuga_graph/utils/context_summarizer.py
@@ -86,10 +86,7 @@ class ContextSummarizer:
             self.middleware = None
 
     def _setup_model_profile(self):
-        """Setup model profile with context size for fraction-based triggers."""
-        if not (hasattr(self.config, 'trigger_fraction') and self.config.trigger_fraction):
-            return
-
+        """Setup model profile with correct context window for the resolved model."""
         resolved_name = resolve_model_identifier(self.model, fallback_name=self.model_name)
         try:
             context_size = ensure_model_context_profile(self.model, resolved_name)

--- a/src/cuga/backend/cuga_graph/utils/context_summarizer.py
+++ b/src/cuga/backend/cuga_graph/utils/context_summarizer.py
@@ -14,7 +14,11 @@ from langchain.agents.middleware import SummarizationMiddleware
 from loguru import logger
 
 from cuga.config import settings
-from cuga.backend.cuga_graph.utils.token_counter import TokenCounter
+from cuga.backend.cuga_graph.utils.token_counter import (
+    TokenCounter,
+    ensure_model_context_profile,
+    resolve_model_identifier,
+)
 from cuga.backend.cuga_graph.utils.message_utils import convert_to_proper_message_type
 
 # Optional imports for middleware invocation (may not be available in all LangChain versions)
@@ -86,19 +90,10 @@ class ContextSummarizer:
         if not (hasattr(self.config, 'trigger_fraction') and self.config.trigger_fraction):
             return
 
-        # Check if profile already exists
-        if hasattr(self.model, 'profile') and self.model.profile:
-            if isinstance(self.model.profile, dict) and 'max_input_tokens' in self.model.profile:
-                logger.debug(f"Model already has profile: {self.model.profile}")
-                return
-
-        # Set profile with context size
+        resolved_name = resolve_model_identifier(self.model, fallback_name=self.model_name)
         try:
-            context_size = self.token_counter.get_model_context_size(self.model)
-            self.model.profile = {"max_input_tokens": context_size}
-            logger.info(f"Set model profile: max_input_tokens={context_size} for {self.model_name}")
-
-            # Verify profile was set
+            context_size = ensure_model_context_profile(self.model, resolved_name)
+            logger.info(f"Set model profile: max_input_tokens={context_size} for {resolved_name}")
             if not hasattr(self.model, 'profile'):
                 logger.error("Failed to set model.profile - attribute doesn't exist after assignment")
         except Exception as e:

--- a/src/cuga/backend/cuga_graph/utils/token_counter.py
+++ b/src/cuga/backend/cuga_graph/utils/token_counter.py
@@ -289,6 +289,72 @@ if TYPE_CHECKING:
     pass
 
 
+def resolve_model_identifier(model: Optional[Any] = None, fallback_name: str = "") -> str:
+    """Return the best-effort model id/name from a LangChain chat model instance."""
+    if model is None:
+        return fallback_name
+
+    try:
+        from langchain_ibm import ChatWatsonx
+
+        if isinstance(model, ChatWatsonx):
+            model_id = getattr(model, "model_id", None)
+            if model_id:
+                return str(model_id)
+    except ImportError:
+        pass
+
+    for attr in ("model_id", "model_name", "model"):
+        value = getattr(model, attr, None)
+        if value:
+            return str(value)
+
+    return fallback_name
+
+
+def lookup_model_context_size(model_name: Optional[str]) -> Optional[int]:
+    """Look up a known context window size for *model_name*, if available."""
+    if not model_name:
+        return None
+
+    normalized_name = model_name.strip()
+    if "/" in normalized_name:
+        normalized_name = normalized_name.split("/", 1)[1]
+
+    if normalized_name in MODEL_CONTEXT_SIZES:
+        return MODEL_CONTEXT_SIZES[normalized_name]
+
+    sorted_keys = sorted(MODEL_CONTEXT_SIZES.keys(), key=len, reverse=True)
+    for key in sorted_keys:
+        if normalized_name.startswith(key):
+            return MODEL_CONTEXT_SIZES[key]
+
+    return None
+
+
+def ensure_model_context_profile(model: Optional[Any] = None, model_name: Optional[str] = None) -> int:
+    """Ensure *model.profile* reflects the known context window for the resolved model name."""
+    resolved_name = resolve_model_identifier(model, fallback_name=model_name or "")
+    context_size = lookup_model_context_size(resolved_name)
+    if context_size is None:
+        context_size = DEFAULT_CONTEXT_SIZE
+
+    if model is not None:
+        try:
+            existing = getattr(model, "profile", None)
+            if not isinstance(existing, Mapping) or existing.get("max_input_tokens") != context_size:
+                model.profile = {"max_input_tokens": context_size}
+                logger.debug(
+                    "Set model profile: max_input_tokens={} for {}",
+                    context_size,
+                    resolved_name or model_name or "unknown",
+                )
+        except Exception as exc:
+            logger.warning(f"Failed to set model.profile: {exc}")
+
+    return context_size
+
+
 class TokenCounter:
     """
     Utility for counting tokens in messages.
@@ -460,7 +526,9 @@ class TokenCounter:
         """
         Get the context window size for a given model.
 
-        First tries to get from model profile, then falls back to hardcoded values.
+        Prefers known model-name mappings over provider-supplied profiles, because
+        some integrations (e.g. ChatWatsonx) ship with generic 8K profiles that
+        do not match large-context models like gpt-oss-120b.
 
         Args:
             model: Optional BaseChatModel instance (uses instance model if not provided)
@@ -468,42 +536,20 @@ class TokenCounter:
         Returns:
             Context window size in tokens
         """
-        # Try to get from model profile first
         model_to_check = model or self.model
+        model_name = resolve_model_identifier(model_to_check, fallback_name=self.model_name)
+
+        known_size = lookup_model_context_size(model_name)
+        if known_size is not None:
+            return known_size
+
         if model_to_check:
             profile_limit = self._get_profile_limits(model_to_check)
             if profile_limit is not None:
                 return profile_limit
 
-        # Fallback to model context sizes constant
-        model_name = self.model_name
-        if model_to_check and hasattr(model_to_check, 'model_name'):
-            model_name = model_to_check.model_name
-
-        # Normalize model name - strip provider prefixes like "Azure/", "OpenAI/", etc.
-        normalized_name = model_name
-        if '/' in model_name:
-            normalized_name = model_name.split('/', 1)[1]
-            logger.debug(f"Normalized model name from '{model_name}' to '{normalized_name}'")
-
-        # Try exact match first
-        if normalized_name in MODEL_CONTEXT_SIZES:
-            return MODEL_CONTEXT_SIZES[normalized_name]
-
-        # Try partial match (e.g., "gpt-4-0613" matches "gpt-4", "gpt-4.1" matches "gpt-4")
-        # Sort keys by length (descending) to match longer prefixes first
-        # This ensures "gpt-4o" matches before "gpt-4"
-        sorted_keys = sorted(MODEL_CONTEXT_SIZES.keys(), key=len, reverse=True)
-        for key in sorted_keys:
-            if normalized_name.startswith(key):
-                logger.debug(
-                    f"Matched '{normalized_name}' to '{key}' with context size {MODEL_CONTEXT_SIZES[key]}"
-                )
-                return MODEL_CONTEXT_SIZES[key]
-
-        # Default to 32K for unknown models
         logger.warning(
-            f"Unknown model '{model_name}', defaulting to 32K context window. "
+            f"Unknown model '{model_name}', defaulting to {DEFAULT_CONTEXT_SIZE} context window. "
             "Consider adding the model to MODEL_CONTEXT_SIZES constant or setting model.profile "
             "with max_input_tokens for accurate tracking."
         )

--- a/src/cuga/backend/cuga_graph/utils/token_counter.py
+++ b/src/cuga/backend/cuga_graph/utils/token_counter.py
@@ -285,6 +285,8 @@ MODEL_CONTEXT_SIZES = {
     "xai/grok-beta": 128000,
 }
 
+_SORTED_MODEL_CONTEXT_KEYS = sorted(MODEL_CONTEXT_SIZES.keys(), key=len, reverse=True)
+
 if TYPE_CHECKING:
     pass
 
@@ -324,7 +326,7 @@ def lookup_model_context_size(model_name: Optional[str]) -> Optional[int]:
     if normalized_name in MODEL_CONTEXT_SIZES:
         return MODEL_CONTEXT_SIZES[normalized_name]
 
-    sorted_keys = sorted(MODEL_CONTEXT_SIZES.keys(), key=len, reverse=True)
+    sorted_keys = _SORTED_MODEL_CONTEXT_KEYS
     for key in sorted_keys:
         if normalized_name.startswith(key):
             return MODEL_CONTEXT_SIZES[key]
@@ -334,7 +336,7 @@ def lookup_model_context_size(model_name: Optional[str]) -> Optional[int]:
 
 def ensure_model_context_profile(model: Optional[Any] = None, model_name: Optional[str] = None) -> int:
     """Ensure *model.profile* reflects the known context window for the resolved model name."""
-    resolved_name = resolve_model_identifier(model, fallback_name=model_name or "")
+    resolved_name = (model_name or "").strip() or resolve_model_identifier(model, fallback_name="")
     context_size = lookup_model_context_size(resolved_name)
     if context_size is None:
         context_size = DEFAULT_CONTEXT_SIZE
@@ -343,11 +345,13 @@ def ensure_model_context_profile(model: Optional[Any] = None, model_name: Option
         try:
             existing = getattr(model, "profile", None)
             if not isinstance(existing, Mapping) or existing.get("max_input_tokens") != context_size:
-                model.profile = {"max_input_tokens": context_size}
+                merged = dict(existing) if isinstance(existing, Mapping) else {}
+                merged["max_input_tokens"] = context_size
+                model.profile = merged
                 logger.debug(
                     "Set model profile: max_input_tokens={} for {}",
                     context_size,
-                    resolved_name or model_name or "unknown",
+                    resolved_name or "unknown",
                 )
         except Exception as exc:
             logger.warning(f"Failed to set model.profile: {exc}")

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -16,6 +16,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatResult
 from loguru import logger
 
+from cuga.backend.cuga_graph.utils.token_counter import ensure_model_context_profile
 from cuga.backend.llm.load_test_mock import clone_load_test_mock_chat_model, is_mock_llm_enabled
 from cuga.backend.secrets import resolve_secret
 from cuga.config import DEFAULT_LLM_HTTP_TIMEOUT, settings
@@ -748,6 +749,7 @@ class LLMManager:
                 raise ValueError("WatsonX requires WATSONX_SPACE_ID or WATSONX_PROJECT_ID to be set.")
 
             llm = ChatWatsonx(**watsonx_params)
+            ensure_model_context_profile(llm, model_name)
         elif platform == "rits":
             apikey_name = model_settings.get("apikey_name")
             api_key = _normalize_secret(resolve_secret(apikey_name)) if apikey_name else None

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -85,11 +85,11 @@ class TestTokenCounter:
     def test_ensure_model_context_profile_overrides_stale_watsonx_profile(self):
         model = Mock()
         model.model_id = "openai/gpt-oss-120b"
-        model.profile = {"max_input_tokens": 8192}
+        model.profile = {"max_input_tokens": 8192, "tool_calling": True}
 
-        size = ensure_model_context_profile(model)
+        size = ensure_model_context_profile(model, "openai/gpt-oss-120b")
         assert size == 131072
-        assert model.profile == {"max_input_tokens": 131072}
+        assert model.profile == {"max_input_tokens": 131072, "tool_calling": True}
 
     def test_lookup_model_context_size_with_provider_prefix(self):
         assert lookup_model_context_size("openai/gpt-oss-120b") == 131072

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -3,8 +3,14 @@ Unit tests for TokenCounter utility.
 """
 
 import pytest
+from unittest.mock import Mock
 from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
-from cuga.backend.cuga_graph.utils.token_counter import TokenCounter
+from cuga.backend.cuga_graph.utils.token_counter import (
+    TokenCounter,
+    ensure_model_context_profile,
+    lookup_model_context_size,
+    resolve_model_identifier,
+)
 from cuga.backend.cuga_graph.utils.message_utils import convert_to_proper_message_type
 
 
@@ -63,6 +69,37 @@ class TestTokenCounter:
 
         counter_claude_sonnet = TokenCounter(model_name="claude-3-sonnet")
         assert counter_claude_sonnet.get_model_context_size() == 200000
+
+        counter_gpt_oss = TokenCounter(model_name="openai/gpt-oss-120b")
+        assert counter_gpt_oss.get_model_context_size() == 131072
+
+    def test_get_model_context_size_prefers_known_size_over_stale_profile(self):
+        """ChatWatsonx-style stale 8K profiles must not override gpt-oss-120b."""
+        model = Mock()
+        model.model_id = "openai/gpt-oss-120b"
+        model.profile = {"max_input_tokens": 8192}
+
+        counter = TokenCounter(model=model, model_name="gpt-4")
+        assert counter.get_model_context_size(model) == 131072
+
+    def test_ensure_model_context_profile_overrides_stale_watsonx_profile(self):
+        model = Mock()
+        model.model_id = "openai/gpt-oss-120b"
+        model.profile = {"max_input_tokens": 8192}
+
+        size = ensure_model_context_profile(model)
+        assert size == 131072
+        assert model.profile == {"max_input_tokens": 131072}
+
+    def test_lookup_model_context_size_with_provider_prefix(self):
+        assert lookup_model_context_size("openai/gpt-oss-120b") == 131072
+
+    def test_resolve_model_identifier_prefers_model_id(self):
+        model = Mock()
+        model.model_id = "openai/gpt-oss-120b"
+        model.model_name = "gpt-4"
+
+        assert resolve_model_identifier(model, fallback_name="gpt-4") == "openai/gpt-oss-120b"
 
     def test_get_model_context_size_unknown_model(self):
         """Test context size retrieval for unknown model (should default to 131K based on gpt-oss-120b)."""


### PR DESCRIPTION
Fixes #439

## Summary
- Fix watsonx `max_tokens must be at least 1, got -5178` failures when using `openai/gpt-oss-120b` on long CugaLite runs
- `ChatWatsonx` from langchain_ibm ships with a stale 8K `max_input_tokens` profile; langchain_ibm then computes `max_tokens = profile - input_tokens`, which goes negative once prompts exceed 8K
- Prefer known model context sizes (131K for gpt-oss-120b) over provider profiles, set the correct profile at watsonx model creation, and resolve `model_id` for context summarization

## Root cause
On large agent sessions, context summarization triggered against an 8K window (1407% usage) while the actual model supports 131K. Even after summarization, the next watsonx call still used the 8K profile, producing negative `max_tokens`.

## Test plan
- [x] `uv run pytest tests/unit/test_token_counter.py -q` (21 passed)
- [x] `uv run pytest tests/unit/test_context_summarizer.py -q` (46 passed)
- [ ] Restart server with watsonx + `openai/gpt-oss-120b` and rerun a long CugaLite workflow that previously failed with `max_tokens ... got -5178`