### PR TITLE
fix: harden watsonx context budget and skills syntax validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-07-05T09:11:38Z",
+  "generated_at": "2026-07-06T20:41:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 683,
+        "line_number": 829,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -37,7 +37,10 @@ from cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.graph_nodes import (
     enforce_step_limit,
 )
 from cuga.backend.cuga_graph.nodes.cuga_agent_core.policy.tool_approval_handler import ToolApprovalHandler
-from cuga.backend.cuga_graph.utils.context_management_utils import apply_context_summarization
+from cuga.backend.cuga_graph.utils.context_management_utils import (
+    apply_context_summarization,
+    truncate_text_for_context,
+)
 
 
 def create_call_model_node(
@@ -80,6 +83,11 @@ def create_call_model_node(
             existing_var_names = var_manager.get_variable_names()
             if existing_var_names:
                 variables_summary_text = var_manager.get_variables_summary(variable_names=existing_var_names)
+                variables_summary_text = truncate_text_for_context(
+                    variables_summary_text,
+                    settings.advanced_features.variables_summary_max_length,
+                    label="Variables summary",
+                )
                 variables_addendum = (
                     f"\n\n## Available Variables\n\n{variables_summary_text}"
                     f"\n\nYou can use these variables directly by their names."

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -72,30 +72,7 @@ def create_call_model_node(
         base_prompt: str = getattr(state, "prepared_prompt", "") or ""
         system_content: str = adapter.prepare_system_content(state, configurable, base_prompt)
 
-        # ── Context summarisation ──────────────────────────────────────────
-        effective_messages = await apply_context_summarization(
-            adapter.get_messages(state) or [],
-            active_model,
-            system_prompt=base_prompt,
-            tools=None,
-            tracker=adapter.get_tracker(),
-            variables_storage=adapter.get_variables_storage(state),
-            variable_counter_state=getattr(state, "variable_counter_state", None),
-            variable_creation_order=getattr(state, "variable_creation_order", None),
-            message_list_name=adapter.messages_key,
-        )
-
-        # ── Build messages_for_model: [system] + few-shot + conversation ───
-        messages_for_model: list = [{"role": "system", "content": system_content}]
-
-        for example in adapter.get_few_shot_messages(state):
-            if isinstance(example, dict):
-                role = (example.get("role") or "").strip().lower()
-                ex_content = example.get("content") or ""
-                if role in {"user", "assistant"} and ex_content:
-                    messages_for_model.append({"role": role, "content": ex_content})
-
-        # ── Variables summary ──────────────────────────────────────────────
+        # ── Variables summary (count toward context before summarization) ──
         var_manager = adapter.get_variable_manager(state)
         variables_summary_text: Optional[str] = None
         variables_addendum = ""
@@ -120,6 +97,33 @@ def create_call_model_node(
             playbook_guidance = metadata.get("playbook_guidance")
             if playbook_guidance:
                 logger.info("Will inject playbook guidance into last user message (first time only)")
+
+        summarization_system_prompt = system_content + variables_addendum
+        if playbook_guidance:
+            summarization_system_prompt += f"\n\n## Task Guidance\n{playbook_guidance}"
+
+        # ── Context summarisation ──────────────────────────────────────────
+        effective_messages = await apply_context_summarization(
+            adapter.get_messages(state) or [],
+            active_model,
+            system_prompt=summarization_system_prompt,
+            tools=None,
+            tracker=adapter.get_tracker(),
+            variables_storage=adapter.get_variables_storage(state),
+            variable_counter_state=getattr(state, "variable_counter_state", None),
+            variable_creation_order=getattr(state, "variable_creation_order", None),
+            message_list_name=adapter.messages_key,
+        )
+
+        # ── Build messages_for_model: [system] + few-shot + conversation ───
+        messages_for_model: list = [{"role": "system", "content": system_content}]
+
+        for example in adapter.get_few_shot_messages(state):
+            if isinstance(example, dict):
+                role = (example.get("role") or "").strip().lower()
+                ex_content = example.get("content") or ""
+                if role in {"user", "assistant"} and ex_content:
+                    messages_for_model.append({"role": role, "content": ex_content})
 
         # ── Process messages: inject PI / playbook / variables ─────────────
         pi = adapter.get_pi(state)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -29,6 +29,7 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.nl_auto_continue_classifier import 
     classify_nl_auto_continue,
     normalize_assistant_text,
 )
+from cuga.backend.cuga_graph.utils.token_counter import clamp_watsonx_completion_for_messages
 from cuga.backend.llm.errors import extract_code_from_tool_use_failed
 from cuga.config import settings
 
@@ -105,6 +106,7 @@ class AgentGraphAdapter(CoreGraphAdapter):
 
     async def ainvoke_model(self, bound: Any, messages: list, invoke_config: dict) -> Any:
         try:
+            clamp_watsonx_completion_for_messages(bound, messages)
             return await bound.ainvoke(messages, config=invoke_config)
         except Exception as exc:
             code = extract_code_from_tool_use_failed(exc)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/sandbox_node.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any, Callable, Optional
 
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import HumanMessage
 from langchain_core.runnables import RunnableConfig
 from loguru import logger
 
@@ -24,6 +24,11 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.executors.code_executor import (
     is_find_tools_listing_markdown,
 )
 from cuga.backend.cuga_graph.nodes.cuga_lite.reflection.reflection import reflection_task
+from cuga.backend.cuga_graph.utils.context_management_utils import (
+    prepare_reflection_context,
+    truncate_text_for_context,
+)
+from cuga.backend.cuga_graph.utils.token_counter import clamp_watsonx_completion_for_messages
 from cuga.backend.llm.models import LLMManager
 from cuga.config import settings
 
@@ -122,32 +127,45 @@ def create_sandbox_node(adapter: Any, base_thread_id: Any, base_apps_list: Any) 
                         settings.agent.planner.model
                     )
                     reflection_agent = reflection_task(llm=active_model)
-                    # Format chat messages as history string
-                    agent_history_parts = []
-                    for msg in state.chat_messages:
-                        if isinstance(msg, HumanMessage):
-                            agent_history_parts.append(f"User: {msg.content}")
-                        elif isinstance(msg, AIMessage):
-                            agent_history_parts.append(f"Assistant: {msg.content}")
-                        else:
-                            agent_history_parts.append(
-                                f"{type(msg).__name__}: {getattr(msg, 'content', str(msg))}"
-                            )
-                    agent_history = (
-                        "\n".join(agent_history_parts)
-                        if agent_history_parts
-                        else "No previous conversation history"
+                    reflection_text_limit = min(
+                        30_000,
+                        settings.advanced_features.execution_output_max_length // 2,
+                    )
+                    agent_history, coder_output = await prepare_reflection_context(
+                        list(state.chat_messages),
+                        output,
+                        active_model,
+                        max_output_chars=reflection_text_limit,
+                        max_history_chars=reflection_text_limit,
+                        tracker=adapter._tracker,
+                    )
+                    skills_prompt_section = truncate_text_for_context(
+                        state.reflection_skills_prompt_section or "",
+                        reflection_text_limit,
+                        label="Skills prompt section",
+                    )
+                    current_task = reflection_current_task(state) or "(no task text)"
+                    clamp_watsonx_completion_for_messages(
+                        active_model,
+                        [
+                            {
+                                "role": "user",
+                                "content": "\n".join(
+                                    [current_task, agent_history, coder_output, skills_prompt_section]
+                                ),
+                            }
+                        ],
                     )
                     reflection_result = await reflection_agent.ainvoke(
                         {
                             "instructions": "",
-                            "current_task": reflection_current_task(state) or "(no task text)",
+                            "current_task": current_task,
                             "agent_history": agent_history,
-                            "coder_agent_output": output,
+                            "coder_agent_output": coder_output,
                             "apps": state.reflection_apps or [],
                             "enable_find_tools": state.reflection_enable_find_tools,
                             "skills_enabled": state.reflection_skills_enabled,
-                            "skills_prompt_section": state.reflection_skills_prompt_section,
+                            "skills_prompt_section": skills_prompt_section,
                             "force_autonomous_mode": settings.advanced_features.force_autonomous_mode,
                         },
                         config=config or {},

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/code_executor.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/code_executor.py
@@ -281,6 +281,7 @@ class CodeExecutor:
     @classmethod
     def _wrap_code_for_code_agent(cls, code: str, fake_datetime: Optional[str] = None) -> str:
         """Wrap code for CodeAgent execution."""
+        SecurityValidator.validate_syntax(code)
         indented_code = '\n'.join('    ' + line for line in code.split('\n'))
 
         datetime_mock = CodeWrapper.create_datetime_mock(fake_datetime)
@@ -397,7 +398,11 @@ async def _async_main():
 
             tracker = ActivityTracker()
             fake_datetime = tracker.current_date if tracker.current_date and is_benchmark_mode() else None
-            wrapped_code = cls._wrap_code_for_code_agent(code, fake_datetime=fake_datetime)
+            try:
+                wrapped_code = cls._wrap_code_for_code_agent(code, fake_datetime=fake_datetime)
+            except CodeSyntaxError as e:
+                executor = cls._get_local_executor()
+                return executor.format_error(e), {}
 
             if skills_on:
                 if mode in ('e2b', 'docker'):

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/security.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/security.py
@@ -122,9 +122,11 @@ class SecurityValidator:
 
     @staticmethod
     def validate_syntax(code: str, *, filename: str = "<code>") -> None:
-        """Reject invalid Python before sandbox exec so the model can retry cleanly."""
-        if is_relaxed_execution():
-            return
+        """Reject invalid Python before sandbox exec so the model can retry cleanly.
+
+        Runs unconditionally, including under relaxed/skills/benchmark execution:
+        this checks whether `exec()` will even parse the code, not a security policy.
+        """
         try:
             compile(code, filename, "exec", flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT)
         except SyntaxError as exc:
@@ -141,10 +143,11 @@ class SecurityValidator:
             ImportError: If dangerous or disallowed imports are found
             CodeSyntaxError: If code is not valid Python (via validate_syntax)
         """
+        SecurityValidator.validate_syntax(code)
+
         if is_relaxed_execution():
             return
 
-        SecurityValidator.validate_syntax(code)
         tree = ast.parse(code)
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_code_executor.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_code_executor.py
@@ -94,6 +94,26 @@ async def test_syntax_error_blocked_before_exec(mock_state, monkeypatch):
     assert "Traceback" not in result
 
 
+@pytest.mark.asyncio
+async def test_syntax_error_blocked_before_exec_in_skills_relaxed_mode(mock_state):
+    """Skills/relaxed execution loosens import checks but must still reject unparseable code
+    before exec() — regression test for the syntax guard being skipped alongside the
+    security checks it was bundled with."""
+    mock_state.reflection_skills_enabled = True
+    code = 'phase2_md = f"""\n# report\n'
+
+    result, new_vars = await CodeExecutor.eval_with_tools_async(
+        code=code,
+        _locals={},
+        state=mock_state,
+        mode='local',
+    )
+
+    assert "Python syntax error" in result
+    assert new_vars == {}
+    assert "Traceback" not in result
+
+
 def test_format_syntax_error_hints_for_unterminated_fstring():
     code = 'x = f"""\nhello\n'
     try:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/supervisor_graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/supervisor_graph_adapter.py
@@ -22,6 +22,7 @@ from cuga.backend.cuga_graph.nodes.cuga_supervisor.nodes.execute_agent_tool impo
 from cuga.backend.cuga_graph.nodes.cuga_supervisor.nodes.prepare_agents_and_prompt import (
     create_prepare_agents_and_prompt_node,
 )
+from cuga.backend.cuga_graph.utils.token_counter import clamp_watsonx_completion_for_messages
 from cuga.config import settings
 
 # Backward-compatible alias for tests and callers that imported the private helper.
@@ -81,6 +82,10 @@ class SupervisorGraphAdapter(CoreGraphAdapter):
     def get_invoke_config(self, configurable: dict) -> dict:
         callbacks = configurable.get("callbacks", self._base_callbacks)
         return {"callbacks": callbacks}
+
+    async def ainvoke_model(self, bound: Any, messages: list, invoke_config: dict) -> Any:
+        clamp_watsonx_completion_for_messages(bound, messages)
+        return await bound.ainvoke(messages, config=invoke_config)
 
     def build_metadata_update(self, state: Any, *, playbook_fired: bool) -> dict:
         meta = dict(self.get_metadata(state))

--- a/src/cuga/backend/cuga_graph/utils/context_management_utils.py
+++ b/src/cuga/backend/cuga_graph/utils/context_management_utils.py
@@ -7,12 +7,62 @@ Helper functions for managing message context and summarization across different
 import json
 from typing import Any, List, Optional
 
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from loguru import logger
 
 from cuga.backend.cuga_graph.state.agent_state import AgentState
 from cuga.backend.cuga_graph.utils.token_counter import resolve_model_identifier
 from cuga.backend.activity_tracker.tracker import ActivityTracker, Step
+
+
+def truncate_text_for_context(text: str, max_chars: int, *, label: str = "content") -> str:
+    """Trim long prompt sections so downstream LLM calls stay within context."""
+    trimmed = (text or "").strip()
+    if max_chars <= 0 or len(trimmed) <= max_chars:
+        return trimmed
+    return f"{trimmed[:max_chars]}...\n\n[{label} trimmed to {max_chars} chars]"
+
+
+def messages_to_history_text(messages: List[BaseMessage]) -> str:
+    """Format chat messages as a plain-text history block."""
+    parts: list[str] = []
+    for msg in messages:
+        if isinstance(msg, HumanMessage):
+            parts.append(f"User: {msg.content}")
+        elif isinstance(msg, AIMessage):
+            parts.append(f"Assistant: {msg.content}")
+        else:
+            parts.append(f"{type(msg).__name__}: {getattr(msg, 'content', str(msg))}")
+    return "\n".join(parts) if parts else "No previous conversation history"
+
+
+async def prepare_reflection_context(
+    chat_messages: List[BaseMessage],
+    coder_agent_output: str,
+    model: Any,
+    *,
+    max_output_chars: int,
+    max_history_chars: int,
+    tracker: Optional[ActivityTracker] = None,
+) -> tuple[str, str]:
+    """Summarize chat history and trim execution output for reflection prompts."""
+    summarized = await apply_context_summarization(
+        list(chat_messages),
+        model,
+        tracker=tracker,
+        message_list_name="chat_messages",
+    )
+    history = truncate_text_for_context(
+        messages_to_history_text(summarized),
+        max_history_chars,
+        label="Agent history",
+    )
+    output = truncate_text_for_context(
+        coder_agent_output,
+        max_output_chars,
+        label="Execution output",
+    )
+    return history, output
 
 
 async def apply_context_summarization(

--- a/src/cuga/backend/cuga_graph/utils/token_counter.py
+++ b/src/cuga/backend/cuga_graph/utils/token_counter.py
@@ -18,6 +18,14 @@ from cuga.backend.cuga_graph.utils.message_utils import convert_to_proper_messag
 CHARS_PER_TOKEN_FALLBACK = 4  # Rough estimate: 1 token ≈ 4 characters
 DEFAULT_CONTEXT_SIZE = 131072  # Default context size for unknown models (based on gpt-oss-120b)
 
+# Our approximate counter (count_tokens_approximately + 15% overhead) has been observed to
+# undercount IBM's real tokenizer by ~20% on JSON/dict-heavy prompts (e.g. skill/report
+# generation). Inflate the estimate and reserve a larger buffer before trusting it to size
+# max_completion_tokens for a WatsonX call, so we clamp to a small budget instead of sending
+# a request that watsonx.ai rejects with "max_tokens must be at least 1".
+WATSONX_PROMPT_SAFETY_MARGIN = 0.20
+WATSONX_COMPLETION_BUFFER = 1024
+
 # Model context size constants (in tokens)
 MODEL_CONTEXT_SIZES = {
     # ============================================================================
@@ -376,7 +384,9 @@ def clamp_watsonx_completion_for_messages(model: Any, messages: list) -> None:
                 lc_messages.append(HumanMessage(content=content))
         else:
             lc_messages.append(message)
-    prompt_tokens = counter.count_total_context_tokens(lc_messages)
+    raw_prompt_tokens = counter.count_total_context_tokens(lc_messages)
+    # Inflate: our estimator undercounts vs IBM's real tokenizer on dense/JSON-heavy prompts.
+    prompt_tokens = int(raw_prompt_tokens * (1 + WATSONX_PROMPT_SAFETY_MARGIN))
 
     params = dict(llm.params or {})
     requested = (
@@ -387,12 +397,16 @@ def clamp_watsonx_completion_for_messages(model: Any, messages: list) -> None:
     )
     requested = int(requested)
 
-    clamped = clamp_completion_tokens(context_size, prompt_tokens, requested)
+    clamped = clamp_completion_tokens(
+        context_size, prompt_tokens, requested, buffer=WATSONX_COMPLETION_BUFFER
+    )
     if clamped != requested:
         logger.warning(
-            "Clamped WatsonX max_completion_tokens {} -> {} (~{} prompt tokens, {} context)",
+            "Clamped WatsonX max_completion_tokens {} -> {} "
+            "(~{} raw / ~{} safety-inflated prompt tokens, {} context)",
             requested,
             clamped,
+            raw_prompt_tokens,
             prompt_tokens,
             context_size,
         )

--- a/src/cuga/backend/cuga_graph/utils/token_counter.py
+++ b/src/cuga/backend/cuga_graph/utils/token_counter.py
@@ -9,7 +9,7 @@ for reactive usage tracking.
 from typing import TYPE_CHECKING, List, Optional, Mapping, Any
 from functools import partial
 from loguru import logger
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.messages.utils import count_tokens_approximately
 
 from cuga.backend.cuga_graph.utils.message_utils import convert_to_proper_message_type
@@ -332,6 +332,72 @@ def lookup_model_context_size(model_name: Optional[str]) -> Optional[int]:
             return MODEL_CONTEXT_SIZES[key]
 
     return None
+
+
+def clamp_completion_tokens(
+    context_size: int,
+    prompt_tokens: int,
+    requested: int,
+    *,
+    buffer: int = 256,
+) -> int:
+    """Keep completion budget positive when prompt size is near the context window."""
+    remaining = context_size - prompt_tokens - buffer
+    if remaining >= requested:
+        return requested
+    return max(1, remaining)
+
+
+def clamp_watsonx_completion_for_messages(model: Any, messages: list) -> None:
+    """Prevent negative max_completion_tokens when prompt size nears the context window."""
+    try:
+        from langchain_ibm import ChatWatsonx
+    except ImportError:
+        return
+
+    llm = model
+    while hasattr(llm, "bound"):
+        llm = llm.bound
+    if not isinstance(llm, ChatWatsonx):
+        return
+
+    context_size = ensure_model_context_profile(llm)
+    counter = TokenCounter(model=llm)
+    lc_messages = []
+    for message in messages:
+        if isinstance(message, dict):
+            role = (message.get("role") or "user").lower()
+            content = str(message.get("content", ""))
+            if role == "system":
+                lc_messages.append(SystemMessage(content=content))
+            elif role == "assistant":
+                lc_messages.append(AIMessage(content=content))
+            else:
+                lc_messages.append(HumanMessage(content=content))
+        else:
+            lc_messages.append(message)
+    prompt_tokens = counter.count_total_context_tokens(lc_messages)
+
+    params = dict(llm.params or {})
+    requested = (
+        getattr(llm, "max_completion_tokens", None)
+        or getattr(llm, "max_tokens", None)
+        or params.get("max_completion_tokens")
+        or 16000
+    )
+    requested = int(requested)
+
+    clamped = clamp_completion_tokens(context_size, prompt_tokens, requested)
+    if clamped != requested:
+        logger.warning(
+            "Clamped WatsonX max_completion_tokens {} -> {} (~{} prompt tokens, {} context)",
+            requested,
+            clamped,
+            prompt_tokens,
+            context_size,
+        )
+    params["max_completion_tokens"] = clamped
+    llm.params = params
 
 
 def ensure_model_context_profile(model: Optional[Any] = None, model_name: Optional[str] = None) -> int:

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -244,6 +244,19 @@ class LLMManager:
         if hasattr(model, 'model_kwargs') and model.model_kwargs is not None:
             model.model_kwargs = model_kwargs
 
+        # ChatWatsonx sends nested params to the API, not the top-level pydantic fields.
+        try:
+            from langchain_ibm import ChatWatsonx
+
+            if isinstance(model, ChatWatsonx):
+                params = dict(model.params or {})
+                if not is_reasoning:
+                    params["temperature"] = temperature
+                params["max_completion_tokens"] = completion_tokens
+                model.params = params
+        except ImportError:
+            pass
+
         logger.debug(
             f"Updated model parameters: temperature={temperature}, max_tokens={max_tokens}, max_completion_tokens={completion_tokens}"
         )

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -65,6 +65,7 @@ path_segment_index = 1  # Which path segment to use for operation naming (1 = fi
 force_autonomous_mode = false
 tool_call_timeout = 30  # Timeout in seconds for tool/API calls (sandbox operations). If exceeded, raises TimeoutError
 execution_output_max_length = 70000  # Maximum characters to show in execution output (prevents token overflow)
+variables_summary_max_length = 12000  # Maximum characters for the "Available Variables" prompt addendum (prevents unbounded growth as sandbox variables accumulate)
 # OpenSandbox shell tools (run_command, write_file, …) and matching prompt guidance. Opt-in: set true when using OpenSandbox shell tools.
 enable_shell_tool = false
 # Sandbox backend for shell tool execution. Options:
@@ -205,7 +206,7 @@ trim_tokens_to_summarize = 500  # Target token count for generated summaries
 summarization_model = "gpt-4o-mini"  # Model to use for generating summaries (fast and cost-effective)
 
 # Trigger conditions (at least one should be set, multiple can be active):
-trigger_fraction = 0.75  # Trigger at 75% of context window (recommended for production)
+trigger_fraction = 0.70  # Trigger at 70% of context window (lowered from 0.75: our token estimator undercounts vs some providers' real tokenizers, e.g. WatsonX, by ~20% on JSON/dict-heavy prompts)
 # trigger_tokens = 2000  # Alternative: trigger when total tokens exceed this count
 # trigger_messages = 20  # Alternative: trigger after N messages since last summary
 

--- a/tests/unit/test_context_management_utils.py
+++ b/tests/unit/test_context_management_utils.py
@@ -1,0 +1,28 @@
+from langchain_core.messages import AIMessage, HumanMessage
+
+from cuga.backend.cuga_graph.utils.context_management_utils import (
+    messages_to_history_text,
+    truncate_text_for_context,
+)
+
+
+def test_truncate_text_for_context_noop_when_short():
+    text = "hello"
+    assert truncate_text_for_context(text, 100) == "hello"
+
+
+def test_truncate_text_for_context_adds_marker():
+    text = "x" * 100
+    result = truncate_text_for_context(text, 20, label="Execution output")
+    assert result.startswith("x" * 20)
+    assert "[Execution output trimmed to 20 chars]" in result
+
+
+def test_messages_to_history_text_formats_roles():
+    messages = [
+        HumanMessage(content="hi"),
+        AIMessage(content="hello"),
+    ]
+    text = messages_to_history_text(messages)
+    assert "User: hi" in text
+    assert "Assistant: hello" in text

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -278,6 +278,37 @@ def test_clamp_watsonx_completion_for_messages_updates_params():
     assert model.params["max_completion_tokens"] == 16000
 
 
+def test_clamp_watsonx_completion_applies_safety_margin_for_undercounted_prompts():
+    """Our approximate counter undercounts real WatsonX tokenization on dense prompts.
+
+    A prompt whose *raw* estimate leaves just enough room for the requested completion
+    must still be clamped once the safety margin/buffer is applied, so we never send a
+    request that watsonx.ai would reject with a negative max_tokens.
+    """
+    pytest.importorskip("langchain_ibm")
+    from unittest.mock import patch
+    from langchain_ibm import ChatWatsonx
+
+    model = ChatWatsonx.model_construct(
+        params={"max_completion_tokens": 16000, "temperature": 0.1},
+        max_completion_tokens=16000,
+        model_id="openai/gpt-oss-120b",
+        profile={"max_input_tokens": 131072},
+    )
+    # Raw estimate leaves exactly enough headroom for the old buffer (256) but not for
+    # the safety-margin-inflated estimate plus the larger WatsonX buffer.
+    messages = [{"role": "user", "content": "placeholder"}]
+
+    with patch(
+        "cuga.backend.cuga_graph.utils.token_counter.TokenCounter.count_total_context_tokens",
+        return_value=114_500,
+    ):
+        clamp_watsonx_completion_for_messages(model, messages)
+
+    assert model.params["max_completion_tokens"] < 16000
+    assert model.params["max_completion_tokens"] >= 1
+
+
 def test_update_model_parameters_updates_chat_watsonx_params():
     pytest.importorskip("langchain_ibm")
     from langchain_ibm import ChatWatsonx

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock
 from langchain_core.messages import HumanMessage, AIMessage, BaseMessage
 from cuga.backend.cuga_graph.utils.token_counter import (
     TokenCounter,
+    clamp_completion_tokens,
+    clamp_watsonx_completion_for_messages,
     ensure_model_context_profile,
     lookup_model_context_size,
     resolve_model_identifier,
@@ -243,6 +245,56 @@ class TestTokenCounterWithMockTracker:
         counter = TokenCounter(model_name="gpt-4", tracker=MockTracker())
         usage = counter.get_cumulative_usage()
         assert usage == 1500
+
+
+def test_clamp_completion_tokens_keeps_requested_when_room():
+    assert clamp_completion_tokens(131072, 70000, 16000) == 16000
+
+
+def test_clamp_completion_tokens_never_returns_negative():
+    assert clamp_completion_tokens(8192, 12764, 16000) == 1
+
+
+def test_clamp_watsonx_completion_for_messages_updates_params():
+    pytest.importorskip("langchain_ibm")
+    from langchain_ibm import ChatWatsonx
+
+    model = ChatWatsonx.model_construct(
+        params={"max_completion_tokens": 16000, "temperature": 0.1},
+        max_completion_tokens=16000,
+        model_id="openai/gpt-oss-120b",
+        profile={"max_input_tokens": 131072},
+    )
+    huge_messages = [{"role": "user", "content": "word " * 200_000}]
+
+    clamp_watsonx_completion_for_messages(model, huge_messages)
+
+    assert model.params["max_completion_tokens"] >= 1
+    assert model.params["max_completion_tokens"] < 16000
+
+    small_messages = [{"role": "user", "content": "hello"}]
+    clamp_watsonx_completion_for_messages(model, small_messages)
+
+    assert model.params["max_completion_tokens"] == 16000
+
+
+def test_update_model_parameters_updates_chat_watsonx_params():
+    pytest.importorskip("langchain_ibm")
+    from langchain_ibm import ChatWatsonx
+
+    from cuga.backend.llm.models import LLMManager
+
+    model = ChatWatsonx.model_construct(
+        params={"max_completion_tokens": 1000, "temperature": 0.5},
+        max_tokens=1000,
+        max_completion_tokens=1000,
+        model_id="openai/gpt-oss-120b",
+    )
+    updated = LLMManager()._update_model_parameters(model, temperature=0.2, max_tokens=8000)
+
+    assert updated.params["max_completion_tokens"] == 8000
+    assert updated.params["temperature"] == 0.2
+    assert updated.max_completion_tokens == 8000
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug fix

Fixes #

### Summary

Follow-up to #437 and #434 for WatsonX `gpt-oss-120b` runtime failures in CugaLite:

- **Syntax guard in skills mode:** `validate_syntax()` now runs unconditionally; import/pattern checks still respect relaxed/skills execution. CodeAgent validates before wrap.
- **call_model context budget:** Variables summary and playbook guidance are included in the summarization `system_prompt` before trimming, preventing post-summarization prompt bloat that caused `max_tokens must be at least 1, got -4572` HTTP 400 errors.
- **Reflection path bounded:** Reflection uses `prepare_reflection_context()` (summarize + trim history/output), truncates `skills_prompt_section`, and applies WatsonX completion clamp before invoke.
- **ChatWatsonx params:** `_update_model_parameters()` writes `model.params["max_completion_tokens"]` and temperature (the fields the API actually uses).
- **Completion clamp safety net:** `clamp_watsonx_completion_for_messages()` recalculates from top-level task budget each invoke using `TokenCounter` sizing, avoiding sticky low caps on cached models.

### Root cause

1. Skills/relaxed mode skipped syntax validation bundled with security checks, so truncated LLM code hit raw `exec()` and resurfaced f-string `SyntaxError` tracebacks despite #434.
2. Summarization under-counted the final prompt (variables/playbook appended after summarization; reflection had no summarization at all), so watsonx received prompts exceeding the 128K window and rejected requests with negative `max_tokens`.
3. `ChatWatsonx` task-specific `max_completion_tokens` overrides mutated unused top-level fields while `params` stayed frozen at creation time.

### Solution

Apply the fixes above with targeted unit tests for skills syntax regression, WatsonX param updates, completion clamp restore, and context utility helpers.

### Testing
- [x] Verified fix locally; tests pass
- [x] `uv run pytest tests/unit/test_context_management_utils.py tests/unit/test_token_counter.py::test_clamp_completion_tokens_keeps_requested_when_room tests/unit/test_token_counter.py::test_clamp_completion_tokens_never_returns_negative tests/unit/test_token_counter.py::test_clamp_watsonx_completion_for_messages_updates_params tests/unit/test_token_counter.py::test_update_model_parameters_updates_chat_watsonx_params src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_code_executor.py::test_syntax_error_blocked_before_exec_in_skills_relaxed_mode`
- [x] `uv run ruff check` and `uv run ruff format` on changed files

### Checklist
- [x] Conventional commit title
- [x] DCO signoff on commit
- [x] Unit tests for new behavior
- [x] No unrelated files in commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced prompt context assembly to include available variables and, when present, playbook task guidance.
  * Added smarter reflection context preparation with history/output trimming and summarization.

* **Bug Fixes**
  * Improved Watsonx completion budgeting by clamping max completion tokens to fit within model context limits.
  * Code execution now validates syntax earlier and returns clearer “Python syntax error” responses without leaking tracebacks.

* **Tests**
  * Added/updated unit and regression tests covering context trimming, token clamping, and syntax-error behavior in relaxed modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->