### PR TITLE
fix: confine ingest_knowledge file paths to workspace (CWE-22/73)

### DIFF
--- a/src/cuga/backend/knowledge/mcp_server.py
+++ b/src/cuga/backend/knowledge/mcp_server.py
@@ -15,6 +15,11 @@ from typing import Any
 import httpx
 from fastmcp import FastMCP
 
+from cuga.backend.cuga_graph.nodes.cuga_lite.executors.filesystem.paths import (
+    VIRTUAL_WORKSPACE_ROOT,
+    resolve_workspace_path,
+)
+
 logger = logging.getLogger("cuga.knowledge")
 
 # --- Configuration ---
@@ -140,6 +145,40 @@ def _get_agent_id() -> str:
     return "cuga-default"
 
 
+_LEGACY_VIRTUAL_ROOTS = ("/tmp", "/private/tmp")
+
+
+def _is_allowed_virtual_absolute(posix_path: str) -> bool:
+    if posix_path == VIRTUAL_WORKSPACE_ROOT or posix_path.startswith(f"{VIRTUAL_WORKSPACE_ROOT}/"):
+        return True
+    return any(
+        posix_path == legacy or posix_path.startswith(f"{legacy}/") for legacy in _LEGACY_VIRTUAL_ROOTS
+    )
+
+
+def _resolve_ingest_file_path(file_path: str, *, thread_id: str) -> Path:
+    """Resolve and confine ingest paths to the agent workspace (CWE-22/73)."""
+    raw = (file_path or "").strip()
+    if not raw:
+        raise ValueError("file_path is required")
+
+    posix = raw.replace("\\", "/")
+    if posix.startswith("/") and not _is_allowed_virtual_absolute(posix):
+        raise ValueError(
+            "file_path must be under /workspace; "
+            f"absolute paths outside the workspace are not allowed: {file_path!r}"
+        )
+
+    resolved = resolve_workspace_path(
+        raw,
+        thread_id=thread_id or None,
+        operation="ingest_knowledge",
+    )
+    if not resolved.is_file():
+        raise FileNotFoundError(f"File not found: {file_path}")
+    return resolved
+
+
 def _identity_headers(agent_id: str = "", thread_id: str = "") -> dict[str, str]:
     """Build identity headers. Uses explicit agent_id if provided, else auto-discovers."""
     aid = agent_id if agent_id else _get_agent_id()
@@ -225,18 +264,21 @@ async def ingest_knowledge(
     Supports PDF, DOCX, XLSX, PPTX, HTML, Markdown, images (with OCR), and more.
     Use only scopes enabled for the current agent.
     When using scope="session", thread_id is required.
+
+    ``file_path`` must resolve under the agent workspace (``/workspace/...`` or a
+    relative path within it). Host-absolute paths such as ``/etc/passwd`` are rejected.
     """
-    import os
+    try:
+        resolved = _resolve_ingest_file_path(file_path, thread_id=thread_id)
+    except (ValueError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
 
-    if not os.path.exists(file_path):
-        return {"error": f"File not found: {file_path}"}
-
-    with open(file_path, "rb") as f:
+    with open(resolved, "rb") as f:
         resp = await _request(
             "POST",
             "/api/knowledge/documents",
             headers=_identity_headers(agent_id, thread_id),
-            files={"files": (os.path.basename(file_path), f)},
+            files={"files": (resolved.name, f)},
             data={"scope": scope, "replace_duplicates": str(replace_duplicates).lower()},
         )
     return resp.json()

--- a/tests/unit/test_knowledge_mcp_server.py
+++ b/tests/unit/test_knowledge_mcp_server.py
@@ -1,0 +1,59 @@
+"""Security and path-resolution tests for the knowledge MCP server."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cuga.backend.knowledge.mcp_server import _resolve_ingest_file_path
+
+
+def test_resolve_ingest_file_path_rejects_host_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="absolute paths outside the workspace"):
+        _resolve_ingest_file_path("/etc/passwd", thread_id="")
+
+
+def test_resolve_ingest_file_path_rejects_traversal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError, match="traversal"):
+        _resolve_ingest_file_path("../../etc/passwd", thread_id="")
+
+
+def test_resolve_ingest_file_path_accepts_workspace_relative_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    doc = tmp_path / "cuga_workspace" / "notes.txt"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("hello", encoding="utf-8")
+
+    resolved = _resolve_ingest_file_path("notes.txt", thread_id="")
+    assert resolved == doc.resolve()
+
+
+def test_resolve_ingest_file_path_accepts_virtual_workspace_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    doc = tmp_path / "cuga_workspace" / "thread-1" / "uploads" / "report.pdf"
+    doc.parent.mkdir(parents=True)
+    doc.write_bytes(b"%PDF-1.4")
+
+    resolved = _resolve_ingest_file_path(
+        "/workspace/uploads/report.pdf",
+        thread_id="thread-1",
+    )
+    assert resolved == doc.resolve()
+
+
+def test_resolve_ingest_file_path_rejects_missing_workspace_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "cuga_workspace").mkdir()
+    with pytest.raises(FileNotFoundError, match="File not found"):
+        _resolve_ingest_file_path("/workspace/missing.txt", thread_id="")


### PR DESCRIPTION
## Summary

- Fixes a **High** severity path traversal in `ingest_knowledge` (CWE-22 / CWE-73) where model-controlled `file_path` arguments were opened with only an existence check, allowing arbitrary host file reads and exfiltration via `search_knowledge`.
- Resolves `file_path` through the existing workspace path guard (`resolve_workspace_path`) and rejects host-absolute paths outside `/workspace` before `open()`.
- Adds regression tests covering the reported PoC (`/etc/passwd`), `..` traversal, valid workspace paths, and missing files.

**`ingest_knowledge_url` SSRF review:** the backend crawler already validates URLs in `KnowledgeEngine._validate_url` (scheme/port allowlist, blocked hostnames, DNS resolution to private/loopback/link-local/reserved ranges, redirect re-validation). No additional MCP-layer change required for SSRF.

## Security impact

| Before | After |
|--------|-------|
| `ingest_knowledge(file_path="/etc/passwd")` reads arbitrary host files | Rejected: `file_path must be under /workspace` |
| Exfiltrated via `search_knowledge` | Blocked at open time |

## CVE / disclosure

This PR is intended for coordinated disclosure. Maintainer action items after merge:

1. Publish a GitHub Security Advisory and request a CVE ID.
2. Cut a patched release (affects v0.3.0 and earlier).
3. Credit the reporter per their 90-day embargo timeline.

## Test plan

- [x] `uv run pytest tests/unit/test_knowledge_mcp_server.py -v` (5 passed)
- [x] Rejects `/etc/passwd` (PoC path)
- [x] Rejects `../../etc/passwd`
- [x] Accepts `/workspace/uploads/report.pdf` under per-thread workspace
- [x] Accepts relative workspace paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file ingestion to only accept paths inside the active workspace.
  * Added clearer error responses for empty, missing, invalid, or out-of-bounds file paths.
  * Prevented ingestion from using unsafe host-absolute or traversal-based paths.
  * Ensured workspace-based file uploads use the resolved file location consistently.

* **Tests**
  * Added coverage for accepted workspace paths and rejected invalid path cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->