### PR TITLE
fix(llm): only send top_p when explicitly configured

### DIFF
--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -739,7 +739,11 @@ class LLMManager:
 
             if not is_reasoning:
                 openai_params["temperature"] = temperature
-                openai_params["top_p"] = model_settings.get('top_p', 1.0)
+                # Only send top_p when explicitly configured. Some Bedrock Claude
+                # models (e.g. opus-4-5/4-6, sonnet-4-5) reject requests that
+                # specify both temperature and top_p.
+                if 'top_p' in model_settings:
+                    openai_params["top_p"] = model_settings['top_p']
             else:
                 logger.debug(f"Skipping temperature for reasoning model: {model_name}")
 


### PR DESCRIPTION
## Summary

The `openai` platform path in `models.py` unconditionally sent both `temperature` and `top_p` (defaulting `top_p` to `1.0`) on every request. Several Bedrock-hosted Claude models served via LiteLLM (`aws/claude-opus-4-5`, `aws/claude-opus-4-6`, `aws/claude-sonnet-4-5`) reject requests that specify **both** parameters, so the agent aborted on the very first LLM call:

```
litellm.BadRequestError: BedrockException -
{"message":"`temperature` and `top_p` cannot both be specified for this model. Please use only one."}
```

This PR only includes `top_p` when it is explicitly set in the model settings. Since `settings.openai.toml` specifies only `temperature`, `top_p` is now omitted for those models.

## Change

```python
if not is_reasoning:
    openai_params["temperature"] = temperature
    if 'top_p' in model_settings:
        openai_params["top_p"] = model_settings['top_p']
```

## Testing

Verified end-to-end AppWorld runs succeed with `aws/claude-opus-4-5` and `aws/claude-opus-4-6` via the LiteLLM proxy after this change (both previously failed on the first call).

Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OpenAI requests now include `top_p` only when it’s explicitly configured, avoiding an implicit default value being sent.
  - This makes sampling behavior more consistent with the selected settings and reduces unexpected request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->