### PR TITLE
docs: point agents at CONTRIBUTING AI issue/PR commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,14 @@ Every new or changed test must be marked with a pytest marker that declares its 
 - `@pytest.mark.windows_smoke` — Windows CI smoke subset
 
 Do not leave tests unmarked when a type marker applies.
+
+## Creating issues and pull requests
+
+When creating a new GitHub issue or pull request, use the AI agent commands documented in [CONTRIBUTING.md](CONTRIBUTING.md#ai-agent-commands) instead of inventing an ad-hoc flow. Prefer:
+
+- `/cuga-report-bug` — open a bug issue from the `bug_report.yml` template
+- `/cuga-new-feature` — open a feature request from the `feature_request.yml` template
+- `/cuga-create-pr` — validate local state, pick the right PR template, and open the PR via `gh`
+- `/cuga-commit` — stage and commit with Conventional Commits before opening a PR
+
+These commands live under `.cursor/commands/`, `.claude/commands/`, and `.bob/commands/` and follow repo conventions (templates, Conventional Commits, DCO signoff expectations, no promotional footers).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,5 @@ When creating a new GitHub issue or pull request, use the AI agent commands docu
 - `/cuga-report-bug` — open a bug issue from the `bug_report.yml` template
 - `/cuga-new-feature` — open a feature request from the `feature_request.yml` template
 - `/cuga-create-pr` — validate local state, pick the right PR template, and open the PR via `gh`
-- `/cuga-commit` — stage and commit with Conventional Commits before opening a PR
 
 These commands live under `.cursor/commands/`, `.claude/commands/`, and `.bob/commands/` and follow repo conventions (templates, Conventional Commits, DCO signoff expectations, no promotional footers).


### PR DESCRIPTION
## Documentation

### Summary

Point AI agents at the existing `/cuga-*` issue and PR workflow commands in `CONTRIBUTING.md` when opening GitHub issues or pull requests.

## Test plan

- [ ] Confirm `AGENTS.md` links to `CONTRIBUTING.md#ai-agent-commands`
- [ ] Confirm listed commands match the AI Agent Commands table in `CONTRIBUTING.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for creating issues and pull requests using the documented AI agent commands.
  * Documented the recommended repo workflow, including template selection for new work and local PR validation steps.
  * Clarified contribution conventions, including commit message expectations and sign-off requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->