### PR TITLE
fix: route workspace tree to host when sandbox_mode is native/local

### DIFF
--- a/src/cuga/backend/server/workspace_sandbox.py
+++ b/src/cuga/backend/server/workspace_sandbox.py
@@ -20,7 +20,16 @@ _LEGACY_DISPLAY_ROOTS = {"tmp", "cuga_workspace"}  # kept for backward-compat pa
 
 
 def workspace_tree_is_sandbox_backed() -> bool:
-    return bool(getattr(settings.advanced_features, "opensandbox_sandbox", False))
+    """True when workspace APIs should use the OpenSandbox SDK.
+
+    ``opensandbox_sandbox`` alone is not enough: when ``sandbox_mode`` is
+    ``native`` or ``local``, files live on the host even if the OpenSandbox
+    flag is set for other features.
+    """
+    if not bool(getattr(settings.advanced_features, "opensandbox_sandbox", False)):
+        return False
+    mode = str(getattr(settings.advanced_features, "sandbox_mode", "opensandbox") or "opensandbox")
+    return mode not in ("native", "local")
 
 
 def workspace_tree_is_native_backed() -> bool:
@@ -30,12 +39,12 @@ def workspace_tree_is_native_backed() -> bool:
     plan = ExecutionRouter.resolve(settings)
     if plan.filesystem_backend == "host" or plan.shell_backend in ("native", "local"):
         return True
+    mode = str(getattr(settings.advanced_features, "sandbox_mode", "opensandbox") or "opensandbox")
+    if mode in ("native", "local"):
+        return True
     if workspace_tree_is_sandbox_backed():
         return False
-    mode = getattr(settings.advanced_features, "sandbox_mode", "opensandbox")
-    return bool(
-        getattr(settings.advanced_features, "enable_shell_tool", False) and mode in ("native", "local")
-    )
+    return bool(getattr(settings.advanced_features, "enable_shell_tool", False))
 
 
 def _hidden_parts(parts: tuple[str, ...]) -> bool:

--- a/tests/unit/test_workspace_sandbox.py
+++ b/tests/unit/test_workspace_sandbox.py
@@ -13,56 +13,99 @@ from cuga.backend.server.workspace_sandbox import (
 )
 
 
+def _settings(
+    *,
+    opensandbox_sandbox: bool,
+    sandbox_mode: str,
+    enable_shell_tool: bool = False,
+    enable_filesystem_tools: bool = False,
+):
+    class Adv:
+        pass
+
+    adv = Adv()
+    adv.opensandbox_sandbox = opensandbox_sandbox
+    adv.sandbox_mode = sandbox_mode
+    adv.enable_shell_tool = enable_shell_tool
+    adv.enable_filesystem_tools = enable_filesystem_tools
+
+    class Settings:
+        advanced_features = adv
+        execution = type(
+            "Exec",
+            (),
+            {
+                "shell_backend": None,
+                "filesystem_backend": None,
+                "python_backend": None,
+                "workspace_root": None,
+            },
+        )()
+
+    return Settings()
+
+
+@pytest.mark.unit
 def test_workspace_tree_is_native_backed_when_host_shell_with_opensandbox_flag(monkeypatch) -> None:
     from cuga.backend.server import workspace_sandbox as ws
 
-    class Adv:
-        opensandbox_sandbox = True
-        enable_shell_tool = True
-        sandbox_mode = "native"
-        enable_filesystem_tools = True
-
-    class Settings:
-        advanced_features = Adv()
-        execution = type(
-            "Exec",
-            (),
-            {
-                "shell_backend": None,
-                "filesystem_backend": None,
-                "python_backend": None,
-                "workspace_root": None,
-            },
-        )()
-
-    monkeypatch.setattr(ws, "settings", Settings())
+    monkeypatch.setattr(
+        ws,
+        "settings",
+        _settings(
+            opensandbox_sandbox=True,
+            enable_shell_tool=True,
+            sandbox_mode="native",
+            enable_filesystem_tools=True,
+        ),
+    )
     assert ws.workspace_tree_is_native_backed() is True
+    assert ws.workspace_tree_is_sandbox_backed() is False
 
 
+@pytest.mark.unit
 def test_workspace_tree_is_not_native_when_opensandbox_shell_only(monkeypatch) -> None:
     from cuga.backend.server import workspace_sandbox as ws
 
-    class Adv:
-        opensandbox_sandbox = True
-        enable_shell_tool = True
-        sandbox_mode = "opensandbox"
-        enable_filesystem_tools = True
-
-    class Settings:
-        advanced_features = Adv()
-        execution = type(
-            "Exec",
-            (),
-            {
-                "shell_backend": None,
-                "filesystem_backend": None,
-                "python_backend": None,
-                "workspace_root": None,
-            },
-        )()
-
-    monkeypatch.setattr(ws, "settings", Settings())
+    monkeypatch.setattr(
+        ws,
+        "settings",
+        _settings(
+            opensandbox_sandbox=True,
+            enable_shell_tool=True,
+            sandbox_mode="opensandbox",
+            enable_filesystem_tools=True,
+        ),
+    )
     assert ws.workspace_tree_is_native_backed() is False
+    assert ws.workspace_tree_is_sandbox_backed() is True
+
+
+@pytest.mark.unit
+def test_workspace_tree_uses_native_when_sandbox_mode_native_without_shell_tools(monkeypatch) -> None:
+    """Default-ish settings: opensandbox_sandbox=true, sandbox_mode=native, shell tools off."""
+    from cuga.backend.server import workspace_sandbox as ws
+
+    monkeypatch.setattr(
+        ws,
+        "settings",
+        _settings(opensandbox_sandbox=True, sandbox_mode="native"),
+    )
+    assert ws.workspace_tree_is_native_backed() is True
+    assert ws.workspace_tree_is_sandbox_backed() is False
+
+
+@pytest.mark.unit
+def test_workspace_tree_uses_native_when_sandbox_mode_local_with_opensandbox_flag(monkeypatch) -> None:
+    from cuga.backend.server import workspace_sandbox as ws
+
+    monkeypatch.setattr(
+        ws,
+        "settings",
+        _settings(opensandbox_sandbox=True, sandbox_mode="local"),
+    )
+    assert ws.workspace_tree_is_native_backed() is True
+    assert ws.workspace_tree_is_sandbox_backed() is False
 
 
 def test_sandbox_workspace_root() -> None:


### PR DESCRIPTION
## Bug fix

Fixes #484

### Summary
`/api/workspace/tree` was taking the OpenSandbox path whenever `opensandbox_sandbox=true`, even with default `sandbox_mode=native` (and shell tools off). That caused noisy import errors and 503s when the optional OpenSandbox SDK was not installed.

Workspace routing now follows `sandbox_mode`: `native`/`local` use the host thread workspace; OpenSandbox is only required when mode is actually opensandbox-backed.

### Testing
- [x] Verified fix locally; tests pass
- [x] `uv run pytest tests/unit/test_workspace_sandbox.py` — 31 passed
- [x] `uv run pytest tests/unit/test_workspace_upload.py` — 16 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace behavior now correctly respects the selected sandbox mode.
  * Native and local modes consistently use the native workspace, even when shell tools are disabled or sandbox settings are enabled.
  * Other modes continue to select sandbox-backed workspaces when configured. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->