### PR TITLE
Support MiniMax China endpoint selection

### DIFF
--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -573,6 +573,14 @@ class LLMManager:
                 logger.info(f"Using MINIMAX_BASE_URL from environment: {env_base_url}")
                 return env_base_url
 
+            # MiniMax exposes separate OpenAI-compatible endpoints for the
+            # global English and China Chinese regions.  Keep the global
+            # endpoint as the default while allowing deployments to select
+            # the China endpoint explicitly.
+            region = os.environ.get("MINIMAX_REGION", "global_en").lower()
+            if region in {"cn", "cn_zh", "china"}:
+                return "https://api.minimaxi.com/v1"
+
             # Check TOML settings
             toml_url = model_settings.get('url')
             if toml_url:

--- a/tests/unit/test_llm_minimax_provider.py
+++ b/tests/unit/test_llm_minimax_provider.py
@@ -67,6 +67,12 @@ class TestMinimaxBaseUrl:
         mgr = LLMManager()
         assert mgr._get_base_url({}, "minimax") == "https://env.minimax/v1"
 
+    def test_china_region_endpoint(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_BASE_URL", raising=False)
+        monkeypatch.setenv("MINIMAX_REGION", "cn_zh")
+        mgr = LLMManager()
+        assert mgr._get_base_url({}, "minimax") == "https://api.minimaxi.com/v1"
+
 
 class TestMinimaxCreateInstance:
     def test_client_receives_key_base_url_and_timeout(self, monkeypatch):


### PR DESCRIPTION
Reason: Refresh MiniMax target model parameters by representing both global and China endpoints.

Added explicit MiniMax region selection for the China OpenAI-compatible endpoint while preserving the global default and deployment URL override. Added a unit test covering the China region mapping.

Tests: `pytest -q tests/unit/test_llm_minimax_provider.py` (fails during collection because the repository's root conftest imports unavailable `system_tests`.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added regional endpoint support for MiniMax.
  - Configure `MINIMAX_REGION` to use the China endpoint for `cn`, `cn_zh`, or `china`; other configurations continue using the global endpoint.

- **Bug Fixes**
  - Improved MiniMax connection routing for China-based deployments when no custom base URL is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->