### PR TITLE
ci: wire watsonx vars and secrets into github actions jobs

### DIFF
--- a/.github/workflows/external-fork-tests.yml
+++ b/.github/workflows/external-fork-tests.yml
@@ -31,11 +31,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: external-testing
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
+      WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+      WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}
+      WATSONX_URL: ${{ vars.WATSONX_URL }}
       MODEL_NAME: ${{ secrets.MODEL_NAME }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.WATSONX_API_KEY }}
-      AGENT_SETTING_CONFIG: ${{ secrets.AGENT_SETTING_CONFIG }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
 
     steps:
       - name: Checkout fork head
@@ -119,11 +122,14 @@ jobs:
     timeout-minutes: 25
     environment: external-testing
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
+      WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+      WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}
+      WATSONX_URL: ${{ vars.WATSONX_URL }}
       MODEL_NAME: ${{ secrets.MODEL_NAME }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.WATSONX_API_KEY }}
-      AGENT_SETTING_CONFIG: ${{ secrets.AGENT_SETTING_CONFIG }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
 
     steps:
       - name: Checkout fork head
@@ -150,11 +156,14 @@ jobs:
     timeout-minutes: 60
     environment: external-testing
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
+      WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+      WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}
+      WATSONX_URL: ${{ vars.WATSONX_URL }}
       MODEL_NAME: ${{ secrets.MODEL_NAME }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.WATSONX_API_KEY }}
-      AGENT_SETTING_CONFIG: ${{ secrets.AGENT_SETTING_CONFIG }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
       PYTHONIOENCODING: utf-8
       CUGA_THREAD_WORKSPACE_SEED: crm
 

--- a/.github/workflows/smoke-pip-install.yml
+++ b/.github/workflows/smoke-pip-install.yml
@@ -18,11 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
+      WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+      WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}
+      WATSONX_URL: ${{ vars.WATSONX_URL }}
       MODEL_NAME: ${{ secrets.MODEL_NAME }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.WATSONX_API_KEY }}
-      AGENT_SETTING_CONFIG: ${{ secrets.AGENT_SETTING_CONFIG }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -23,11 +23,14 @@ jobs:
           - "3.12"
           - "3.13"
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
+      WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+      WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}
+      WATSONX_URL: ${{ vars.WATSONX_URL }}
       MODEL_NAME: ${{ secrets.MODEL_NAME }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.WATSONX_API_KEY }}
-      AGENT_SETTING_CONFIG: ${{ secrets.AGENT_SETTING_CONFIG }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
       PYTHONIOENCODING: utf-8
       CUGA_THREAD_WORKSPACE_SEED: crm
 
@@ -63,11 +66,14 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
+      WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+      WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}
+      WATSONX_URL: ${{ vars.WATSONX_URL }}
       MODEL_NAME: ${{ secrets.MODEL_NAME }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
-      AGENT_SETTING_CONFIG: ${{ secrets.AGENT_SETTING_CONFIG }}
       UV_NO_PROGRESS: 1
       UV_QUIET: 1
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # WatsonX is configured via repo Variables + WATSONX_APIKEY secret.
-      # AGENT_SETTING_CONFIG / WATSONX_* are Variables (vars.*), not Secrets.
+      # AGENT_SETTING_CONFIG, WATSONX_PROJECT_ID, and WATSONX_URL are Variables.
+      # WATSONX_APIKEY remains a Secret.
       AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
       WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
       WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,17 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # WatsonX is configured via repo Variables + WATSONX_APIKEY secret.
+      # AGENT_SETTING_CONFIG / WATSONX_* are Variables (vars.*), not Secrets.
+      AGENT_SETTING_CONFIG: ${{ vars.AGENT_SETTING_CONFIG }}
+      WATSONX_APIKEY: ${{ secrets.WATSONX_APIKEY }}
+      WATSONX_PROJECT_ID: ${{ vars.WATSONX_PROJECT_ID }}
+      WATSONX_URL: ${{ vars.WATSONX_URL }}
       MODEL_NAME: ${{ secrets.MODEL_NAME }}
+      # Optional fallbacks for openai/groq-compatible paths
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      OPENAI_BASE_URL: ${{ secrets.WATSONX_API_KEY }}
-      AGENT_SETTING_CONFIG: ${{ secrets.AGENT_SETTING_CONFIG }}
+      OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
 
     steps:
       - name: Checkout code

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-07-13T15:52:27Z",
+  "generated_at": "2026-07-21T10:35:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 837,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-07-21T10:35:18Z",
+  "generated_at": "2026-07-21T10:37:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 837,
+        "line_number": 838,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/cuga/backend/cuga_graph/policy/tests/conftest.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Fixtures for policy tests."""
+
+import pytest
+
+from cuga.backend.llm.models import LLMManager
+
+
+@pytest.fixture(autouse=True)
+def _clear_llm_manager_cache():
+    # ChatWatsonx binds async httpx to the current event loop; cached models break
+    # the next pytest loop with "Event loop is closed".
+    mgr = LLMManager()
+    mgr._models.clear()
+    yield
+    mgr._models.clear()

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -265,6 +265,7 @@ class LLMManager:
     def clear_models(self) -> None:
         """Drop cached LLM instances (e.g. between pytest event loops)."""
         self._models.clear()
+        self._pre_instantiated_model = None
 
     def clear_pre_instantiated_model(self) -> None:
         """Clear the pre-instantiated model and return to normal model creation"""

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -262,6 +262,10 @@ class LLMManager:
         )
         return model
 
+    def clear_models(self) -> None:
+        """Drop cached LLM instances (e.g. between pytest event loops)."""
+        self._models.clear()
+
     def clear_pre_instantiated_model(self) -> None:
         """Clear the pre-instantiated model and return to normal model creation"""
         self._pre_instantiated_model = None

--- a/src/cuga/sdk_core/tests/conftest.py
+++ b/src/cuga/sdk_core/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Fixtures for policy tests."""
+"""Fixtures for SDK core tests."""
 
 import pytest
 


### PR DESCRIPTION
## Bug fix

Fixes #

### Summary
CI jobs were reading `AGENT_SETTING_CONFIG` and WatsonX settings from Secrets (`secrets.*`) even though they are repo Variables (`vars.*`), and never injected `WATSONX_APIKEY` / `WATSONX_PROJECT_ID` / `WATSONX_URL`. Empty `AGENT_SETTING_CONFIG` fell back to `settings.openai.toml`, so e2e tests hit OpenAI with a Groq `gsk_` key (401).

This wires the correct `vars.*` / `secrets.WATSONX_APIKEY` into tests, stability, smoke-pip, and external-fork workflows, and restores `OPENAI_BASE_URL` to `secrets.OPENAI_BASE_URL`.

### Testing
- [ ] Verified fix locally; tests pass
- [x] Workflow YAML updated for all LLM-backed CI jobs
- [ ] Confirm CI logs show `loaded llm settings *settings.watsonx.toml*` after merge/run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `OPENAI_BASE_URL` sourcing in automated CI workflows so it no longer uses the wrong secret value.
  * Standardized Watsonx/agent environment-variable injection across unit, smoke-install, stability, and external-fork workflows, ensuring correct secret vs. variable usage and consistent ordering.
* **Tests**
  * Improved pytest reliability by clearing cached LLM models before/after each test run to prevent event-loop related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->