### PR TITLE
fix(llm): rebind watsonx async client across pytest loops

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-07-21T13:07:16Z",
+  "generated_at": "2026-07-21T13:20:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 905,
+        "line_number": 958,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-07-21T13:20:07Z",
+  "generated_at": "2026-07-21T13:52:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 958,
+        "line_number": 988,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(.*pnpm-lock.*|.*js.*|node_modules|.venv|.*jinja2.*|.*woff2.*)|^.secrets.baseline$|^.env$",
     "lines": null
   },
-  "generated_at": "2026-07-21T10:37:11Z",
+  "generated_at": "2026-07-21T13:07:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -529,7 +529,7 @@
         "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 838,
+        "line_number": 905,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/src/cuga/backend/cuga_graph/policy/tests/conftest.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/conftest.py
@@ -10,5 +10,8 @@ async def _rebind_llm_async_clients():
     # ChatWatsonx caches an httpx.AsyncClient bound to the pytest event loop.
     # Rebind that client to the current loop instead of dropping the whole
     # LLMManager cache (which re-auths to IAM on every test). See #523.
-    LLMManager().rebind_async_clients_to_running_loop()
+    mgr = LLMManager()
+    mgr.rebind_async_clients_to_running_loop()
     yield
+    # Close on this loop before pytest tears it down so the next test does not leak.
+    await mgr.aclose_watsonx_async_clients()

--- a/src/cuga/backend/cuga_graph/policy/tests/conftest.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/conftest.py
@@ -1,15 +1,14 @@
 """Fixtures for policy tests."""
 
-import pytest
+import pytest_asyncio
 
 from cuga.backend.llm.models import LLMManager
 
 
-@pytest.fixture(autouse=True)
-def _clear_llm_manager_cache():
-    # ChatWatsonx binds async httpx to the current event loop; cached models break
-    # the next pytest loop with "Event loop is closed".
-    mgr = LLMManager()
-    mgr.clear_models()
+@pytest_asyncio.fixture(autouse=True)
+async def _rebind_llm_async_clients():
+    # ChatWatsonx caches an httpx.AsyncClient bound to the pytest event loop.
+    # Rebind that client to the current loop instead of dropping the whole
+    # LLMManager cache (which re-auths to IAM on every test). See #523.
+    LLMManager().rebind_async_clients_to_running_loop()
     yield
-    mgr.clear_models()

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -1,6 +1,8 @@
+import asyncio
 import math
 import re
 import threading
+import weakref
 from datetime import date
 from typing import Dict, Any, Optional, Mapping
 import hashlib
@@ -20,6 +22,9 @@ from cuga.backend.cuga_graph.utils.token_counter import ensure_model_context_pro
 from cuga.backend.llm.load_test_mock import clone_load_test_mock_chat_model, is_mock_llm_enabled
 from cuga.backend.secrets import resolve_secret
 from cuga.config import DEFAULT_LLM_HTTP_TIMEOUT, settings
+
+# weakref.ref(loop) on watsonx APIClient for the loop the async httpx client is for.
+_CUGA_ASYNC_LOOP_REF = "_cuga_async_loop_ref"
 
 
 class ReasoningChatOpenAI(ChatOpenAI):
@@ -271,6 +276,68 @@ class LLMManager:
         """Clear the pre-instantiated model and return to normal model creation"""
         self._pre_instantiated_model = None
         logger.info("Pre-instantiated model cleared, returning to normal model creation")
+
+    @staticmethod
+    def _watsonx_api_client(model: Any) -> Any:
+        client = getattr(model, "watsonx_client", None)
+        if client is not None:
+            return client
+        watsonx_model = getattr(model, "watsonx_model", None)
+        return getattr(watsonx_model, "_client", None) if watsonx_model is not None else None
+
+    @classmethod
+    def _rebind_watsonx_async_client(cls, model: Any, loop: asyncio.AbstractEventLoop) -> bool:
+        """Replace ChatWatsonx async httpx client if it was bound to another loop.
+
+        Keeps the authenticated APIClient (avoids IAM re-auth). Returns True when
+        a rebind happened.
+        """
+        if not isinstance(model, ChatWatsonx):
+            return False
+        client = cls._watsonx_api_client(model)
+        if client is None:
+            return False
+        loop_ref = getattr(client, _CUGA_ASYNC_LOOP_REF, None)
+        if loop_ref is None:
+            # First sighting under a running loop — tag without recreating.
+            setattr(client, _CUGA_ASYNC_LOOP_REF, weakref.ref(loop))
+            return False
+        bound_loop = loop_ref()
+        if bound_loop is loop:
+            return False
+        try:
+            from ibm_watsonx_ai._wrappers.httpx_wrapper import _get_async_httpx_client
+        except ImportError:
+            logger.debug("ibm_watsonx_ai httpx wrapper unavailable; cannot rebind async client")
+            return False
+
+        # Assign directly — the property setter schedules aclose via create_task,
+        # which fails when the previous pytest loop is already closed.
+        client._async_httpx_client = _get_async_httpx_client(client)
+        setattr(client, _CUGA_ASYNC_LOOP_REF, weakref.ref(loop))
+        logger.debug("Rebound watsonx async httpx client for new event loop")
+        return True
+
+    def rebind_async_clients_to_running_loop(self) -> int:
+        """Rebind loop-bound async HTTP clients on cached models to the running loop.
+
+        ChatWatsonx / ibm_watsonx_ai keep an ``httpx.AsyncClient`` that must not be
+        reused across pytest-asyncio function-scoped loops. Prefer this over
+        :meth:`clear_models` so IAM tokens stay cached.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return 0
+
+        rebound = 0
+        for model in list(self._models.values()):
+            if self._rebind_watsonx_async_client(model, loop):
+                rebound += 1
+        if self._pre_instantiated_model is not None:
+            if self._rebind_watsonx_async_client(self._pre_instantiated_model, loop):
+                rebound += 1
+        return rebound
 
     def _create_cache_key(self, model_settings: Dict[str, Any]) -> str:
         """Create a unique cache key from model settings including resolved values"""
@@ -1018,6 +1085,7 @@ class LLMManager:
         # Check if pre-instantiated model is available
         if self._pre_instantiated_model is not None:
             logger.debug(f"Using pre-instantiated model: {type(self._pre_instantiated_model).__name__}")
+            self.rebind_async_clients_to_running_loop()
             # Update parameters for the task
             updated_model = self._update_model_parameters(
                 self._pre_instantiated_model,
@@ -1038,8 +1106,8 @@ class LLMManager:
             logger.debug(
                 f"Returning cached model: {platform}/{model_name} (api_version={api_version}, base_url={base_url})"
             )
-            # Update parameters for the task
             cached_model = self._models[cache_key]
+            self.rebind_async_clients_to_running_loop()
             updated_model = self._update_model_parameters(
                 cached_model,
                 temperature=model_settings.get('temperature', 0.1),
@@ -1054,6 +1122,7 @@ class LLMManager:
         )
         model = self._create_llm_instance(model_settings)
         self._models[cache_key] = model
+        self.rebind_async_clients_to_running_loop()
 
         # Update parameters for the task
         updated_model = self._update_model_parameters(

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -311,12 +311,65 @@ class LLMManager:
             logger.debug("ibm_watsonx_ai httpx wrapper unavailable; cannot rebind async client")
             return False
 
-        # Assign directly — the property setter schedules aclose via create_task,
-        # which fails when the previous pytest loop is already closed.
+        old_async = getattr(client, "_async_httpx_client", None)
+        # Assign directly — the property setter schedules aclose via create_task on
+        # the *current* loop, which fails when the previous pytest loop is closed.
         client._async_httpx_client = _get_async_httpx_client(client)
         setattr(client, _CUGA_ASYNC_LOOP_REF, weakref.ref(loop))
+        cls._best_effort_aclose_async_client(old_async, bound_loop)
         logger.debug("Rebound watsonx async httpx client for new event loop")
         return True
+
+    @staticmethod
+    def _best_effort_aclose_async_client(
+        async_client: Any, owning_loop: Optional[asyncio.AbstractEventLoop]
+    ) -> None:
+        """Close a displaced AsyncClient on its owning loop when that loop is still open."""
+        if async_client is None:
+            return
+        if owning_loop is None or owning_loop.is_closed():
+            return
+        try:
+            if owning_loop.is_running():
+                owning_loop.call_soon_threadsafe(lambda: owning_loop.create_task(async_client.aclose()))
+            else:
+                owning_loop.run_until_complete(async_client.aclose())
+        except Exception as exc:
+            logger.debug("Could not aclose displaced watsonx async httpx client: {}", exc)
+
+    async def aclose_watsonx_async_clients(self) -> int:
+        """Await-close cached watsonx async clients on the running loop (fixture teardown)."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return 0
+
+        closed = 0
+        models = list(self._models.values())
+        if self._pre_instantiated_model is not None:
+            models.append(self._pre_instantiated_model)
+        for model in models:
+            if not isinstance(model, ChatWatsonx):
+                continue
+            client = self._watsonx_api_client(model)
+            if client is None:
+                continue
+            loop_ref = getattr(client, _CUGA_ASYNC_LOOP_REF, None)
+            bound = loop_ref() if loop_ref is not None else None
+            if bound is not None and bound is not loop:
+                continue
+            async_client = getattr(client, "_async_httpx_client", None)
+            if async_client is None:
+                continue
+            try:
+                if not getattr(async_client, "is_closed", False):
+                    await async_client.aclose()
+                    closed += 1
+            except Exception as exc:
+                logger.debug("Could not aclose watsonx async httpx client on teardown: {}", exc)
+            if hasattr(client, _CUGA_ASYNC_LOOP_REF):
+                delattr(client, _CUGA_ASYNC_LOOP_REF)
+        return closed
 
     def rebind_async_clients_to_running_loop(self) -> int:
         """Rebind loop-bound async HTTP clients on cached models to the running loop.

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -286,25 +286,13 @@ class LLMManager:
         return getattr(watsonx_model, "_client", None) if watsonx_model is not None else None
 
     @classmethod
-    def _rebind_watsonx_async_client(cls, model: Any, loop: asyncio.AbstractEventLoop) -> bool:
-        """Replace ChatWatsonx async httpx client if it was bound to another loop.
-
-        Keeps the authenticated APIClient (avoids IAM re-auth). Returns True when
-        a rebind happened.
-        """
-        if not isinstance(model, ChatWatsonx):
-            return False
-        client = cls._watsonx_api_client(model)
-        if client is None:
-            return False
-        loop_ref = getattr(client, _CUGA_ASYNC_LOOP_REF, None)
-        if loop_ref is None:
-            # First sighting under a running loop — tag without recreating.
-            setattr(client, _CUGA_ASYNC_LOOP_REF, weakref.ref(loop))
-            return False
-        bound_loop = loop_ref()
-        if bound_loop is loop:
-            return False
+    def _replace_watsonx_async_client(
+        cls,
+        client: Any,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        old_owning_loop: Optional[asyncio.AbstractEventLoop],
+    ) -> bool:
         try:
             from ibm_watsonx_ai._wrappers.httpx_wrapper import _get_async_httpx_client
         except ImportError:
@@ -316,9 +304,40 @@ class LLMManager:
         # the *current* loop, which fails when the previous pytest loop is closed.
         client._async_httpx_client = _get_async_httpx_client(client)
         setattr(client, _CUGA_ASYNC_LOOP_REF, weakref.ref(loop))
-        cls._best_effort_aclose_async_client(old_async, bound_loop)
-        logger.debug("Rebound watsonx async httpx client for new event loop")
+        cls._best_effort_aclose_async_client(old_async, old_owning_loop)
         return True
+
+    @classmethod
+    def _rebind_watsonx_async_client(cls, model: Any, loop: asyncio.AbstractEventLoop) -> bool:
+        """Replace ChatWatsonx async httpx client if it was bound to another loop.
+
+        Keeps the authenticated APIClient (avoids IAM re-auth). Returns True when
+        a rebind happened.
+        """
+        if not isinstance(model, ChatWatsonx):
+            return False
+        client = cls._watsonx_api_client(model)
+        if client is None:
+            return False
+
+        async_client = getattr(client, "_async_httpx_client", None)
+        client_closed = async_client is None or getattr(async_client, "is_closed", False)
+        loop_ref = getattr(client, _CUGA_ASYNC_LOOP_REF, None)
+        bound_loop = loop_ref() if loop_ref is not None else None
+
+        if not client_closed and bound_loop is loop:
+            return False
+
+        if not client_closed and loop_ref is None:
+            # First sighting under a running loop — tag without recreating.
+            setattr(client, _CUGA_ASYNC_LOOP_REF, weakref.ref(loop))
+            return False
+
+        # Closed client (e.g. after fixture teardown aclose) or different/dead loop.
+        if cls._replace_watsonx_async_client(client, loop, old_owning_loop=bound_loop):
+            logger.debug("Rebound watsonx async httpx client for new event loop")
+            return True
+        return False
 
     @staticmethod
     def _best_effort_aclose_async_client(
@@ -338,7 +357,11 @@ class LLMManager:
             logger.debug("Could not aclose displaced watsonx async httpx client: {}", exc)
 
     async def aclose_watsonx_async_clients(self) -> int:
-        """Await-close cached watsonx async clients on the running loop (fixture teardown)."""
+        """Await-close cached watsonx async clients on the running loop (fixture teardown).
+
+        After close, installs a fresh open client and clears the loop tag so the next
+        test's rebind does not reuse a closed httpx client.
+        """
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -367,6 +390,13 @@ class LLMManager:
                     closed += 1
             except Exception as exc:
                 logger.debug("Could not aclose watsonx async httpx client on teardown: {}", exc)
+            # Leave an open replacement; next test will tag it to its loop.
+            try:
+                from ibm_watsonx_ai._wrappers.httpx_wrapper import _get_async_httpx_client
+
+                client._async_httpx_client = _get_async_httpx_client(client)
+            except ImportError:
+                pass
             if hasattr(client, _CUGA_ASYNC_LOOP_REF):
                 delattr(client, _CUGA_ASYNC_LOOP_REF)
         return closed

--- a/src/cuga/sdk_core/tests/conftest.py
+++ b/src/cuga/sdk_core/tests/conftest.py
@@ -10,5 +10,8 @@ async def _rebind_llm_async_clients():
     # ChatWatsonx caches an httpx.AsyncClient bound to the pytest event loop.
     # Rebind that client to the current loop instead of dropping the whole
     # LLMManager cache (which re-auths to IAM on every test). See #523.
-    LLMManager().rebind_async_clients_to_running_loop()
+    mgr = LLMManager()
+    mgr.rebind_async_clients_to_running_loop()
     yield
+    # Close on this loop before pytest tears it down so the next test does not leak.
+    await mgr.aclose_watsonx_async_clients()

--- a/src/cuga/sdk_core/tests/conftest.py
+++ b/src/cuga/sdk_core/tests/conftest.py
@@ -1,15 +1,14 @@
 """Fixtures for SDK core tests."""
 
-import pytest
+import pytest_asyncio
 
 from cuga.backend.llm.models import LLMManager
 
 
-@pytest.fixture(autouse=True)
-def _clear_llm_manager_cache():
-    # ChatWatsonx binds async httpx to the current event loop; cached models break
-    # the next pytest loop with "Event loop is closed".
-    mgr = LLMManager()
-    mgr.clear_models()
+@pytest_asyncio.fixture(autouse=True)
+async def _rebind_llm_async_clients():
+    # ChatWatsonx caches an httpx.AsyncClient bound to the pytest event loop.
+    # Rebind that client to the current loop instead of dropping the whole
+    # LLMManager cache (which re-auths to IAM on every test). See #523.
+    LLMManager().rebind_async_clients_to_running_loop()
     yield
-    mgr.clear_models()

--- a/tests/unit/test_llm_watsonx_loop_rebind.py
+++ b/tests/unit/test_llm_watsonx_loop_rebind.py
@@ -101,3 +101,29 @@ def test_clear_models_still_drops_cache():
     mgr.clear_models()
     assert mgr._models == {}
     assert mgr._pre_instantiated_model is None
+
+
+@pytest.mark.unit
+def test_aclose_watsonx_async_clients_on_owning_loop():
+    closed = {"n": 0}
+
+    class _AsyncClient:
+        is_closed = False
+
+        async def aclose(self):
+            closed["n"] += 1
+            self.is_closed = True
+
+    async_client = _AsyncClient()
+    model = _DummyWatsonx(async_client)
+    mgr = LLMManager()
+    mgr._models["k"] = model
+
+    async def _run():
+        with patch("cuga.backend.llm.models.ChatWatsonx", _DummyWatsonx):
+            assert mgr.rebind_async_clients_to_running_loop() == 0
+            assert await mgr.aclose_watsonx_async_clients() == 1
+            assert closed["n"] == 1
+            assert not hasattr(model.watsonx_client, _CUGA_ASYNC_LOOP_REF)
+
+    asyncio.run(_run())

--- a/tests/unit/test_llm_watsonx_loop_rebind.py
+++ b/tests/unit/test_llm_watsonx_loop_rebind.py
@@ -30,6 +30,24 @@ class _DummyWatsonx:
 
 
 @pytest.mark.unit
+def test_watsonx_api_client_prefers_watsonx_client_then_model_client():
+    """langchain_ibm sets watsonx_client from watsonx_model._client on init; cover both."""
+    direct = SimpleNamespace(_async_httpx_client=object())
+    nested = SimpleNamespace(_async_httpx_client=object())
+
+    via_direct = SimpleNamespace(watsonx_client=direct, watsonx_model=None)
+    assert LLMManager._watsonx_api_client(via_direct) is direct
+
+    via_model = SimpleNamespace(
+        watsonx_client=None,
+        watsonx_model=SimpleNamespace(_client=nested),
+    )
+    assert LLMManager._watsonx_api_client(via_model) is nested
+
+    assert LLMManager._watsonx_api_client(SimpleNamespace(watsonx_client=None, watsonx_model=None)) is None
+
+
+@pytest.mark.unit
 def test_rebind_noop_without_running_loop():
     mgr = LLMManager()
     assert mgr.rebind_async_clients_to_running_loop() == 0

--- a/tests/unit/test_llm_watsonx_loop_rebind.py
+++ b/tests/unit/test_llm_watsonx_loop_rebind.py
@@ -106,6 +106,7 @@ def test_clear_models_still_drops_cache():
 @pytest.mark.unit
 def test_aclose_watsonx_async_clients_on_owning_loop():
     closed = {"n": 0}
+    fresh = object()
 
     class _AsyncClient:
         is_closed = False
@@ -120,10 +121,43 @@ def test_aclose_watsonx_async_clients_on_owning_loop():
     mgr._models["k"] = model
 
     async def _run():
-        with patch("cuga.backend.llm.models.ChatWatsonx", _DummyWatsonx):
+        with (
+            patch("cuga.backend.llm.models.ChatWatsonx", _DummyWatsonx),
+            patch(
+                "ibm_watsonx_ai._wrappers.httpx_wrapper._get_async_httpx_client",
+                return_value=fresh,
+            ),
+        ):
             assert mgr.rebind_async_clients_to_running_loop() == 0
             assert await mgr.aclose_watsonx_async_clients() == 1
             assert closed["n"] == 1
+            assert model.watsonx_client._async_httpx_client is fresh
             assert not hasattr(model.watsonx_client, _CUGA_ASYNC_LOOP_REF)
+            # Next loop must not reuse a closed client — tag the fresh one.
+            assert mgr.rebind_async_clients_to_running_loop() == 0
+            assert model.watsonx_client._async_httpx_client is fresh
+
+    asyncio.run(_run())
+
+
+@pytest.mark.unit
+def test_rebind_replaces_closed_client_even_on_same_loop():
+    closed_client = SimpleNamespace(is_closed=True)
+    fresh = object()
+    model = _DummyWatsonx(closed_client)
+    mgr = LLMManager()
+    mgr._models["k"] = model
+
+    async def _run():
+        with (
+            patch("cuga.backend.llm.models.ChatWatsonx", _DummyWatsonx),
+            patch(
+                "ibm_watsonx_ai._wrappers.httpx_wrapper._get_async_httpx_client",
+                return_value=fresh,
+            ) as factory,
+        ):
+            assert mgr.rebind_async_clients_to_running_loop() == 1
+            assert model.watsonx_client._async_httpx_client is fresh
+            factory.assert_called_once_with(model.watsonx_client)
 
     asyncio.run(_run())

--- a/tests/unit/test_llm_watsonx_loop_rebind.py
+++ b/tests/unit/test_llm_watsonx_loop_rebind.py
@@ -1,0 +1,103 @@
+"""Tests for watsonx async-client rebind across event loops (#523)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cuga.backend.llm.models import LLMManager, _CUGA_ASYNC_LOOP_REF, set_current_llm_override
+
+
+@pytest.fixture(autouse=True)
+def reset_llm_state():
+    mgr = LLMManager()
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+    yield
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+
+
+class _DummyWatsonx:
+    def __init__(self, async_client: object):
+        self.watsonx_client = SimpleNamespace(_async_httpx_client=async_client)
+        self.watsonx_model = None
+
+
+@pytest.mark.unit
+def test_rebind_noop_without_running_loop():
+    mgr = LLMManager()
+    assert mgr.rebind_async_clients_to_running_loop() == 0
+
+
+@pytest.mark.unit
+def test_rebind_tags_then_replaces_async_client_across_loops():
+    old_client = object()
+    new_client = object()
+    model = _DummyWatsonx(old_client)
+    mgr = LLMManager()
+    mgr._models["k"] = model
+    loops_seen: list[asyncio.AbstractEventLoop] = []
+
+    async def first_loop():
+        loops_seen.append(asyncio.get_running_loop())
+        with (
+            patch("cuga.backend.llm.models.ChatWatsonx", _DummyWatsonx),
+            patch(
+                "ibm_watsonx_ai._wrappers.httpx_wrapper._get_async_httpx_client",
+                return_value=new_client,
+            ) as factory,
+        ):
+            assert mgr.rebind_async_clients_to_running_loop() == 0
+            ref = getattr(model.watsonx_client, _CUGA_ASYNC_LOOP_REF)
+            assert ref() is asyncio.get_running_loop()
+            assert model.watsonx_client._async_httpx_client is old_client
+            factory.assert_not_called()
+
+    asyncio.run(first_loop())
+
+    async def second_loop():
+        loops_seen.append(asyncio.get_running_loop())
+        with (
+            patch("cuga.backend.llm.models.ChatWatsonx", _DummyWatsonx),
+            patch(
+                "ibm_watsonx_ai._wrappers.httpx_wrapper._get_async_httpx_client",
+                return_value=new_client,
+            ) as factory,
+        ):
+            assert mgr.rebind_async_clients_to_running_loop() == 1
+            assert model.watsonx_client._async_httpx_client is new_client
+            assert getattr(model.watsonx_client, _CUGA_ASYNC_LOOP_REF)() is asyncio.get_running_loop()
+            factory.assert_called_once_with(model.watsonx_client)
+            assert mgr.rebind_async_clients_to_running_loop() == 0
+            factory.assert_called_once()
+
+    asyncio.run(second_loop())
+    assert loops_seen[0] is not loops_seen[1]
+    assert "k" in mgr._models
+
+
+@pytest.mark.unit
+def test_rebind_skips_non_watsonx_models():
+    mgr = LLMManager()
+    mgr._models["plain"] = MagicMock()
+
+    async def _run():
+        assert mgr.rebind_async_clients_to_running_loop() == 0
+
+    asyncio.run(_run())
+
+
+@pytest.mark.unit
+def test_clear_models_still_drops_cache():
+    mgr = LLMManager()
+    mgr._models["k"] = MagicMock()
+    mgr._pre_instantiated_model = MagicMock()
+    mgr.clear_models()
+    assert mgr._models == {}
+    assert mgr._pre_instantiated_model is None


### PR DESCRIPTION
## Bug fix

Fixes #523

### Summary

PR #515 cleared `LLMManager` cache around every policy/sdk_core test to avoid Watsonx `Event loop is closed` crashes. That forced IAM re-auth on each `ChatWatsonx` reconstruct and roughly doubled the policy+SDK CI step (~6.7 → ~12 min).

Keep the authenticated model cache and rebind only the loop-bound `httpx.AsyncClient` when the running pytest event loop changes (`LLMManager.rebind_async_clients_to_running_loop`), including from `get_model()` and the policy/sdk_core autouse fixtures.

### Testing
- [x] Verified fix locally; tests pass
- [x] `uv run pytest tests/unit/test_llm_watsonx_loop_rebind.py`
- [x] `uv run pytest src/cuga/backend/cuga_graph/policy/tests/test_utils.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reusing IBM Watsonx models across asynchronous event loops by automatically rebinding cached async HTTP clients to the active loop.
  * Added safer cleanup by closing loop-bound Watsonx async clients and preventing stale client reuse across loop lifecycles.
* **Tests**
  * Added unit tests covering loop rebinding/no-op behavior without an active loop, ignoring non-Watsonx models, and ensuring async client cleanup.
  * Updated test fixtures to use async autouse setup/teardown instead of synchronous cache clearing.
* **Chores**
  * Refreshed secrets baseline metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->