### PR TITLE
chore: run frontend build.sh in CI and release

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,60 @@
+# Build the packaged web UI via src/frontend_workspaces/frontend/build.sh.
+# Keeps release artifacts honest and catches broken frontend builds before merge.
+# See: https://github.com/cuga-project/cuga-agent/issues/536
+name: Frontend Build
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "src/frontend_workspaces/**"
+      - ".github/workflows/frontend-build.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-frontend:
+    name: Build frontend (build.sh)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 10.28.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: src/frontend_workspaces/pnpm-lock.yaml
+
+      - name: Install workspace dependencies
+        working-directory: src/frontend_workspaces
+        run: pnpm install --frozen-lockfile
+
+      - name: Production build into src/cuga/frontend/dist
+        working-directory: src/frontend_workspaces/frontend
+        run: bash ./build.sh
+
+      - name: Upload frontend dist artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cuga-frontend-dist-${{ github.sha }}
+          path: src/cuga/frontend/dist
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,36 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+
+      # Fresh UI into src/cuga/frontend/dist before the wheel is built (#536).
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 10.28.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: src/frontend_workspaces/pnpm-lock.yaml
+
+      - name: Install frontend workspace dependencies
+        working-directory: src/frontend_workspaces
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend into package
+        working-directory: src/frontend_workspaces/frontend
+        run: bash ./build.sh
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+
       - name: Install Python 3.12
         run: uv python install 3.12
+
       - name: Build
         run: uv build
+
       - name: Publish
         run: uv publish


### PR DESCRIPTION
## Chore

Closes #536

### Summary

Stop relying on a manual `src/frontend_workspaces/frontend/build.sh` for packaged UI freshness.

- Add `.github/workflows/frontend-build.yml` that runs the production build on pushes to `main`/`develop`, on PRs that touch `src/frontend_workspaces/**`, and via `workflow_dispatch`
- Upload `src/cuga/frontend/dist` as a CI artifact (useful when reviewing a shared branch without building locally)
- Run the same build in `release.yml` before `uv build` so PyPI wheels always ship a freshly built UI

Local/shared-branch UI testing is unchanged: use `pnpm start` / `pnpm dev:real`, or run `./build.sh` when you need the packaged path.

Related: #520 (stop tracking committed `dist/` long-term)

### Testing
- [x] Workflow YAML validated locally
- [ ] Confirm `Frontend Build` job passes on this PR
- [ ] Confirm release path still builds (optional / on next tag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated frontend build checks for relevant code changes and pull requests.
  * Frontend build outputs are now retained as downloadable build artifacts.
  * Release publishing now builds the frontend before creating and publishing the Python package.
  * Added manual triggering and automatic cancellation of superseded builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->