### PR TITLE
fix(deps): pin mcp[cli] below 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ dependencies = [
     "browsergym-core==0.13.0",
     "python-dotenv",
     "loguru",
-    "mcp[cli]>=1.23.0",
+    # <2: mcp 2.0.0 removed mcp.server.fastmcp, which server/mcp_servers/cuga.py and
+    # registry/mcp_manager/adapter.py import. Lift once those move to the standalone fastmcp.
+    "mcp[cli]>=1.23.0,<2",
     "psutil>=7.0.0",
     "typer>=0.15.3",
     "typer-slim>=0.15.3", # explicit: docling pulls typer meta-package which needs typer-slim

--- a/uv.lock
+++ b/uv.lock
@@ -1139,7 +1139,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.84.0" },
     { name = "loguru" },
     { name = "markdownify" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.23.0,<2" },
     { name = "openlit", marker = "extra == 'observability'", specifier = ">=1.40.3" },
     { name = "opensandbox", marker = "extra == 'opensandbox'" },
     { name = "opensandbox-code-interpreter", marker = "extra == 'opensandbox'" },


### PR DESCRIPTION
## Bug fix

Fixes #566

### Summary

`mcp` 2.0.0 (published 2026-07-28T13:45Z) removed `mcp.server.fastmcp`, which `server/mcp_servers/cuga.py` and `registry/mcp_manager/adapter.py` import. The constraint had no upper bound, so every fresh resolve since that release installs 2.0.0 and dies at import — breaking the **"Wheel install + demo_crm OpenAPI"** job on every open PR (it installs the built wheel from PyPI rather than via `uv.lock`, so it's the only job exposed; lockfile-based jobs and local dev still see the pinned 1.27.0). In CI it surfaces as `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` → `Registry server did not become ready after 120.0 seconds`.

Every wheel job run on/after 2026-07-29 fails; every run before the release passed — no PR's own changes are involved.

### Testing
- [x] Verified fix locally; tests pass — resolved the constraint in a clean venv both ways:
  - `mcp[cli]==2.0.0` → `mcp.server.fastmcp` **MISSING** (reproduces CI)
  - `mcp[cli]>=1.23.0,<2` → resolves **1.29.0**, `from mcp.server.fastmcp import FastMCP` **OK**
  
  Both import sites load, and `registry/tests/` is green (85 passed). `uv lock` re-run; the only lockfile change is the recorded specifier.

Note: `fastmcp>=3.2.0` is already a direct dependency, so the follow-up is migrating those two call sites to the standalone package and lifting this pin — filed as the rationale in the code comment rather than done here, since fastmcp 3.x has API differences worth a separate review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MCP CLI dependency constraint to improve compatibility with the current release series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->