### PR TITLE
fix(cuga-lite): persist set/frozenset variables across code steps

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
@@ -39,7 +39,7 @@ class VariableUtils:
         - Python datetime: datetime/date/time → ISO string, timedelta → seconds
         - bytes: UTF-8 string if decodable, else base64-encoded ASCII string
         - complex: {"real": float, "imag": float}
-        - dict / list: recursive traversal
+        - dict / list / set / frozenset: recursive traversal
 
         DataFrame and Series are intentionally excluded; sanitize_value wraps
         those with metadata before delegating cell content here.
@@ -110,6 +110,10 @@ class VariableUtils:
             return {k: VariableUtils._sanitize_recursive(v) for k, v in obj.items()}
         if isinstance(obj, list):
             return [VariableUtils._sanitize_recursive(v) for v in obj]
+        if isinstance(obj, set):
+            return {VariableUtils._sanitize_recursive(v) for v in obj}
+        if isinstance(obj, frozenset):
+            return frozenset(VariableUtils._sanitize_recursive(v) for v in obj)
 
         return obj
 
@@ -158,7 +162,7 @@ class VariableUtils:
         if isinstance(value, (str, int, float, bool, type(None))):
             return True
 
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, (list, tuple, set, frozenset)):
             return all(VariableUtils.is_serializable(item) for item in value)
 
         if isinstance(value, dict):

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
@@ -51,6 +51,31 @@ class TestFilterNewVariables:
         assert result['my_tuple'] == (1, 2, 3)
         assert result['nested'] == {'list': [1, 2], 'dict': {'x': 10}}
 
+    @pytest.mark.unit
+    def test_filter_sets_and_frozensets(self):
+        """Sets/frozensets with serializable elements must persist across steps."""
+        original_keys = set()
+        all_locals = {
+            'my_set': {1, 2, 3},
+            'my_frozenset': frozenset({4, 5}),
+            'nested_set': {1, (2, 3)},
+            'set_of_unserializable': {object()},
+        }
+
+        result = VariableUtils.filter_new_variables(all_locals, original_keys)
+
+        assert result['my_set'] == {1, 2, 3}
+        assert result['my_frozenset'] == frozenset({4, 5})
+        assert result['nested_set'] == {1, (2, 3)}
+        assert 'set_of_unserializable' not in result
+
+    @pytest.mark.unit
+    def test_is_serializable_accepts_sets(self):
+        assert VariableUtils.is_serializable({1, 2, 3}) is True
+        assert VariableUtils.is_serializable(frozenset({"a", "b"})) is True
+        assert VariableUtils.is_serializable(set()) is True
+        assert VariableUtils.is_serializable({object()}) is False
+
     def test_filter_excludes_internal_variables(self):
         """Test that internal variables (starting with _) are filtered out."""
         original_keys = set()
@@ -100,6 +125,38 @@ class TestFilterNewVariables:
         result = VariableUtils.filter_new_variables(all_locals, original_keys)
 
         assert result == {}
+
+
+class TestLocalSandboxSetPersistence:
+    """Regression: set/frozenset vars must survive across local CodeExecutor steps (#550)."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_set_persists_across_two_steps(self):
+        state = AgentState(input="test", url="")
+
+        code1 = """
+nums = [3, 4, 5, 6]
+product_set = {a * b for a in nums for b in nums}
+print(len(product_set))
+"""
+        _, new_vars1 = await CodeExecutor.eval_with_tools_async(
+            code=code1, _locals={}, state=state, mode="local"
+        )
+        assert "product_set" in new_vars1
+        assert isinstance(new_vars1["product_set"], set)
+
+        _locals = {
+            name: state.variables_manager.get_variable(name)
+            for name in state.variables_manager.get_variable_names()
+        }
+
+        code2 = "print(len(nums), len(product_set))"
+        result2, _ = await CodeExecutor.eval_with_tools_async(
+            code=code2, _locals=_locals, state=state, mode="local"
+        )
+        assert "NameError" not in result2
+        assert "4 10" in result2
 
 
 class TestExecuteInE2BSandbox:


### PR DESCRIPTION
## Bug fix

Fixes #550

### Summary
Local/native sandbox was dropping `set`/`frozenset` variables between `CodeExecutor` steps because `VariableUtils.is_serializable` only accepted `list`/`tuple` containers. That led to silent skips (`Skipping non-serializable variable ...: set`) and later `NameError`s when the model reused those names.

This change:
- Treats `set`/`frozenset` like other recursive containers in `is_serializable`
- Recursively sanitizes set/frozenset values so nested serializable elements stay intact
- Adds unit tests for filtering plus a two-step local persistence regression from the issue MRE

### Testing
- [x] Verified fix locally; tests pass
  - `uv run pytest .../test_e2b_lite.py::TestFilterNewVariables ...::TestLocalSandboxSetPersistence -q` → 8 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sets and frozensets during variable serialization and filtering.
  * Set-based variables now persist correctly across consecutive local execution steps.
  * Values containing unsupported elements are safely excluded from serialized results.

* **Tests**
  * Added coverage for set and frozenset serialization, filtering, and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->