### PR TITLE
fix(cuga-lite): JSON-safe set/frozenset variable storage for stream events

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/variable_bridge.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/execution/variable_bridge.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+
 
 class VariableBridge:
     """Utility for copying variables between agents."""
@@ -23,9 +25,14 @@ class VariableBridge:
         """Convert ``variables_storage`` serialised format → ``{name: raw_value}``.
 
         Entries that lack a ``'value'`` key are silently skipped so callers
-        never need to guard against malformed storage.
+        never need to guard against malformed storage. Tagged set/frozenset
+        values are hydrated back to Python containers.
         """
-        return {name: meta["value"] for name, meta in variables_storage.items() if "value" in meta}
+        return {
+            name: VariableUtils.hydrate_value(meta["value"])
+            for name, meta in variables_storage.items()
+            if "value" in meta
+        }
 
     @staticmethod
     def bridge(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_variable_bridge.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_variable_bridge.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from cuga.backend.cuga_graph.state.agent_state import VariablesManager
 
 
@@ -48,6 +50,22 @@ def test_extract_values_empty_storage_returns_empty():
     from cuga.backend.cuga_graph.nodes.cuga_agent_core.execution.variable_bridge import VariableBridge
 
     assert VariableBridge.extract_values({}) == {}
+
+
+@pytest.mark.unit
+def test_extract_values_hydrates_tagged_sets():
+    from cuga.backend.cuga_graph.nodes.cuga_agent_core.execution.variable_bridge import VariableBridge
+
+    storage = {
+        "emails": {
+            "value": {"__set_type__": "set", "items": ["a@x.com", "b@y.com"]},
+            "type": "set",
+            "created_at": "...",
+            "count_items": 2,
+        }
+    }
+    result = VariableBridge.extract_values(storage)
+    assert result["emails"] == {"a@x.com", "b@y.com"}
 
 
 def test_bridge_copies_values_into_target_manager():

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_variable_bridge.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_variable_bridge.py
@@ -58,7 +58,7 @@ def test_extract_values_hydrates_tagged_sets():
 
     storage = {
         "emails": {
-            "value": {"__set_type__": "set", "items": ["a@x.com", "b@y.com"]},
+            "value": {"__set_type__": "set", "items": ["a@x.com", "b@y.com"], "__cuga_enc__": True},
             "type": "set",
             "created_at": "...",
             "count_items": 2,

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_variable_bridge.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_variable_bridge.py
@@ -62,10 +62,19 @@ def test_extract_values_hydrates_tagged_sets():
             "type": "set",
             "created_at": "...",
             "count_items": 2,
-        }
+        },
+        "frozen": {
+            "value": {"__set_type__": "frozenset", "items": ["x", "y"], "__cuga_enc__": True},
+            "type": "frozenset",
+            "created_at": "...",
+            "count_items": 2,
+        },
     }
     result = VariableBridge.extract_values(storage)
+    assert type(result["emails"]) is set
     assert result["emails"] == {"a@x.com", "b@y.com"}
+    assert type(result["frozen"]) is frozenset
+    assert result["frozen"] == frozenset({"x", "y"})
 
 
 def test_bridge_copies_values_into_target_manager():

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
@@ -154,14 +154,22 @@ class VariableUtils:
 
     @staticmethod
     def _sanitize_set_element(obj: Any) -> Any:
-        """Sanitize a set/frozenset element; recursively tag nested tuples."""
+        """Sanitize a set/frozenset element; recursively tag nested tuples.
+
+        Values that sanitize to unhashable containers (e.g. complex → dict) are
+        stored as ``repr(obj)`` so the set remains constructible after JSON
+        round-trip. We do not attempt full type coverage for every scalar.
+        """
         if isinstance(obj, tuple):
             return {
                 _TUPLE_TYPE_KEY: "tuple",
                 "items": [VariableUtils._sanitize_set_element(v) for v in obj],
                 _ENC_KEY: True,
             }
-        return VariableUtils._sanitize_recursive(obj)
+        sanitized = VariableUtils._sanitize_recursive(obj)
+        if isinstance(sanitized, (dict, list)):
+            return repr(obj)
+        return sanitized
 
     @staticmethod
     def _hydrate_mapping(value: dict) -> Any:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
@@ -6,10 +6,30 @@ from loguru import logger
 _TODO_CONFIRMATION_VALUES = frozenset({"Todos updated", "Todos have been updated"})
 _SET_TYPE_KEY = "__set_type__"
 _TUPLE_TYPE_KEY = "__tuple_type__"
+# Marks envelopes we created so ordinary user dicts with the same keys stay dicts.
+_ENC_KEY = "__cuga_enc__"
 
 
 class VariableUtils:
     """Utilities for managing variables during code execution."""
+
+    @staticmethod
+    def _is_set_tag(value: Any) -> bool:
+        return (
+            isinstance(value, dict)
+            and value.get(_ENC_KEY) is True
+            and value.get(_SET_TYPE_KEY) in ("set", "frozenset")
+            and set(value.keys()) == {_SET_TYPE_KEY, "items", _ENC_KEY}
+        )
+
+    @staticmethod
+    def _is_tuple_tag(value: Any) -> bool:
+        return (
+            isinstance(value, dict)
+            and value.get(_ENC_KEY) is True
+            and value.get(_TUPLE_TYPE_KEY) == "tuple"
+            and set(value.keys()) == {_TUPLE_TYPE_KEY, "items", _ENC_KEY}
+        )
 
     @staticmethod
     def strip_todo_confirmation_only_vars(new_vars: dict[str, Any]) -> dict[str, Any]:
@@ -111,6 +131,9 @@ class VariableUtils:
 
         # --- containers ---
         if isinstance(obj, dict):
+            # Already-encoded envelopes from a prior sanitize — leave intact.
+            if VariableUtils._is_set_tag(obj) or VariableUtils._is_tuple_tag(obj):
+                return obj
             return {k: VariableUtils._sanitize_recursive(v) for k, v in obj.items()}
         if isinstance(obj, list):
             return [VariableUtils._sanitize_recursive(v) for v in obj]
@@ -118,11 +141,13 @@ class VariableUtils:
             return {
                 _SET_TYPE_KEY: "set",
                 "items": [VariableUtils._sanitize_set_element(v) for v in obj],
+                _ENC_KEY: True,
             }
         if isinstance(obj, frozenset):
             return {
                 _SET_TYPE_KEY: "frozenset",
                 "items": [VariableUtils._sanitize_set_element(v) for v in obj],
+                _ENC_KEY: True,
             }
 
         return obj
@@ -134,23 +159,46 @@ class VariableUtils:
             return {
                 _TUPLE_TYPE_KEY: "tuple",
                 "items": [VariableUtils._sanitize_set_element(v) for v in obj],
+                _ENC_KEY: True,
             }
         return VariableUtils._sanitize_recursive(obj)
+
+    @staticmethod
+    def _hydrate_mapping(value: dict) -> Any:
+        """Hydrate dict values; preserve identity when nothing changes."""
+        out = {}
+        changed = False
+        for k, v in value.items():
+            hv = VariableUtils.hydrate_value(v)
+            if hv is not v:
+                changed = True
+            out[k] = hv
+        return out if changed else value
+
+    @staticmethod
+    def _hydrate_sequence(value: list) -> Any:
+        """Hydrate list values; preserve identity when nothing changes."""
+        out = []
+        changed = False
+        for v in value:
+            hv = VariableUtils.hydrate_value(v)
+            if hv is not v:
+                changed = True
+            out.append(hv)
+        return out if changed else value
 
     @staticmethod
     def hydrate_value(value: Any) -> Any:
         """Restore set/frozenset/tuple tags produced by sanitize_value."""
         if isinstance(value, dict):
-            keys = set(value.keys())
-            set_kind = value.get(_SET_TYPE_KEY)
-            if set_kind in ("set", "frozenset") and keys == {_SET_TYPE_KEY, "items"}:
+            if VariableUtils._is_set_tag(value):
                 items = [VariableUtils.hydrate_value(v) for v in value["items"]]
-                return set(items) if set_kind == "set" else frozenset(items)
-            if value.get(_TUPLE_TYPE_KEY) == "tuple" and keys == {_TUPLE_TYPE_KEY, "items"}:
+                return set(items) if value[_SET_TYPE_KEY] == "set" else frozenset(items)
+            if VariableUtils._is_tuple_tag(value):
                 return tuple(VariableUtils.hydrate_value(v) for v in value["items"])
-            return {k: VariableUtils.hydrate_value(v) for k, v in value.items()}
+            return VariableUtils._hydrate_mapping(value)
         if isinstance(value, list):
-            return [VariableUtils.hydrate_value(v) for v in value]
+            return VariableUtils._hydrate_sequence(value)
         return value
 
     @staticmethod

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
@@ -4,6 +4,8 @@ from typing import Any, Optional, Set
 from loguru import logger
 
 _TODO_CONFIRMATION_VALUES = frozenset({"Todos updated", "Todos have been updated"})
+_SET_TYPE_KEY = "__set_type__"
+_TUPLE_TYPE_KEY = "__tuple_type__"
 
 
 class VariableUtils:
@@ -39,7 +41,9 @@ class VariableUtils:
         - Python datetime: datetime/date/time → ISO string, timedelta → seconds
         - bytes: UTF-8 string if decodable, else base64-encoded ASCII string
         - complex: {"real": float, "imag": float}
-        - dict / list / set / frozenset: recursive traversal
+        - dict / list: recursive traversal
+        - set / frozenset: tagged JSON-safe dicts (see hydrate_value)
+        - tuples inside sets: tagged so nested hashables round-trip
 
         DataFrame and Series are intentionally excluded; sanitize_value wraps
         those with metadata before delegating cell content here.
@@ -111,11 +115,42 @@ class VariableUtils:
         if isinstance(obj, list):
             return [VariableUtils._sanitize_recursive(v) for v in obj]
         if isinstance(obj, set):
-            return {VariableUtils._sanitize_recursive(v) for v in obj}
+            return {
+                _SET_TYPE_KEY: "set",
+                "items": [VariableUtils._sanitize_set_element(v) for v in obj],
+            }
         if isinstance(obj, frozenset):
-            return frozenset(VariableUtils._sanitize_recursive(v) for v in obj)
+            return {
+                _SET_TYPE_KEY: "frozenset",
+                "items": [VariableUtils._sanitize_set_element(v) for v in obj],
+            }
 
         return obj
+
+    @staticmethod
+    def _sanitize_set_element(obj: Any) -> Any:
+        """Sanitize a set/frozenset element; tag tuples so JSON round-trips."""
+        if isinstance(obj, tuple):
+            return {
+                _TUPLE_TYPE_KEY: "tuple",
+                "items": [VariableUtils._sanitize_recursive(v) for v in obj],
+            }
+        return VariableUtils._sanitize_recursive(obj)
+
+    @staticmethod
+    def hydrate_value(value: Any) -> Any:
+        """Restore set/frozenset/tuple tags produced by sanitize_value."""
+        if isinstance(value, dict):
+            set_kind = value.get(_SET_TYPE_KEY)
+            if set_kind in ("set", "frozenset") and "items" in value:
+                items = [VariableUtils.hydrate_value(v) for v in value["items"]]
+                return set(items) if set_kind == "set" else frozenset(items)
+            if value.get(_TUPLE_TYPE_KEY) == "tuple" and "items" in value:
+                return tuple(VariableUtils.hydrate_value(v) for v in value["items"])
+            return {k: VariableUtils.hydrate_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [VariableUtils.hydrate_value(v) for v in value]
+        return value
 
     @staticmethod
     def sanitize_value(value: Any) -> Any:
@@ -123,6 +158,7 @@ class VariableUtils:
 
         - pd.DataFrame → dict with records (cells recursively sanitized)
         - pd.Series    → dict with data list (values recursively sanitized)
+        - set / frozenset → tagged dicts for stream/checkpoint JSON
         - All other types → delegated to _sanitize_recursive
 
         All other values are returned unchanged.

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/variable_utils.py
@@ -129,11 +129,11 @@ class VariableUtils:
 
     @staticmethod
     def _sanitize_set_element(obj: Any) -> Any:
-        """Sanitize a set/frozenset element; tag tuples so JSON round-trips."""
+        """Sanitize a set/frozenset element; recursively tag nested tuples."""
         if isinstance(obj, tuple):
             return {
                 _TUPLE_TYPE_KEY: "tuple",
-                "items": [VariableUtils._sanitize_recursive(v) for v in obj],
+                "items": [VariableUtils._sanitize_set_element(v) for v in obj],
             }
         return VariableUtils._sanitize_recursive(obj)
 
@@ -141,11 +141,12 @@ class VariableUtils:
     def hydrate_value(value: Any) -> Any:
         """Restore set/frozenset/tuple tags produced by sanitize_value."""
         if isinstance(value, dict):
+            keys = set(value.keys())
             set_kind = value.get(_SET_TYPE_KEY)
-            if set_kind in ("set", "frozenset") and "items" in value:
+            if set_kind in ("set", "frozenset") and keys == {_SET_TYPE_KEY, "items"}:
                 items = [VariableUtils.hydrate_value(v) for v in value["items"]]
                 return set(items) if set_kind == "set" else frozenset(items)
-            if value.get(_TUPLE_TYPE_KEY) == "tuple" and "items" in value:
+            if value.get(_TUPLE_TYPE_KEY) == "tuple" and keys == {_TUPLE_TYPE_KEY, "items"}:
                 return tuple(VariableUtils.hydrate_value(v) for v in value["items"])
             return {k: VariableUtils.hydrate_value(v) for k, v in value.items()}
         if isinstance(value, list):

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
@@ -117,6 +117,16 @@ class TestFilterNewVariables:
         assert state.variables_manager.get_variable("d") == {"a": 1, "b": 2}
 
     @pytest.mark.unit
+    def test_set_with_complex_members_round_trips_without_crash(self):
+        """Unhandled set members (complex→dict) stringify so hydrate stays hashable."""
+        original = {1 + 2j, (3 + 4j, 5)}
+        sanitized = VariableUtils.sanitize_value(original)
+        restored = VariableUtils.hydrate_value(json.loads(json.dumps(sanitized)))
+        assert isinstance(restored, set)
+        assert repr(1 + 2j) in restored
+        assert any(isinstance(x, tuple) for x in restored)
+
+    @pytest.mark.unit
     def test_is_serializable_accepts_sets(self):
         assert VariableUtils.is_serializable({1, 2, 3}) is True
         assert VariableUtils.is_serializable(frozenset({"a", "b"})) is True

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
@@ -61,6 +61,7 @@ class TestFilterNewVariables:
             'my_set': {1, 2, 3},
             'my_frozenset': frozenset({4, 5}),
             'nested_set': {1, (2, 3)},
+            'deep_nested_set': {((1, 2), 3)},
             'set_of_unserializable': {object()},
         }
 
@@ -70,6 +71,7 @@ class TestFilterNewVariables:
         assert VariableUtils.hydrate_value(round_tripped['my_set']) == {1, 2, 3}
         assert VariableUtils.hydrate_value(round_tripped['my_frozenset']) == frozenset({4, 5})
         assert VariableUtils.hydrate_value(round_tripped['nested_set']) == {1, (2, 3)}
+        assert VariableUtils.hydrate_value(round_tripped['deep_nested_set']) == {((1, 2), 3)}
         assert 'set_of_unserializable' not in result
 
     @pytest.mark.unit
@@ -85,6 +87,34 @@ class TestFilterNewVariables:
         assert restored["emails"] == original["emails"]
         assert restored["nested"] == original["nested"]
         assert restored["frozen"] == original["frozen"]
+
+    @pytest.mark.unit
+    def test_tag_shaped_user_dicts_round_trip_as_dicts(self):
+        """Ordinary dicts matching reserved tag shapes must not become sets/tuples."""
+        originals = {
+            "looks_like_set": {"__set_type__": "set", "items": [1, 2, 3]},
+            "looks_like_frozenset": {"__set_type__": "frozenset", "items": ["a"]},
+            "looks_like_tuple": {"__tuple_type__": "tuple", "items": [1, 2]},
+        }
+        sanitized = VariableUtils.sanitize_value(originals)
+        restored = VariableUtils.hydrate_value(json.loads(json.dumps(sanitized)))
+        assert restored == originals
+        assert isinstance(restored["looks_like_set"], dict)
+
+    @pytest.mark.unit
+    def test_hydrate_preserves_plain_container_identity(self):
+        """In-place mutations must hit the stored object when no tags are present."""
+        state = AgentState(input="test", url="")
+        state.variables_manager.add_variable([1], name="lst")
+        state.variables_manager.add_variable({"a": 1}, name="d")
+        got_list = state.variables_manager.get_variable("lst")
+        got_dict = state.variables_manager.get_variable("d")
+        assert got_list is state.variables_storage["lst"]["value"]
+        assert got_dict is state.variables_storage["d"]["value"]
+        got_list.append(2)
+        got_dict["b"] = 2
+        assert state.variables_manager.get_variable("lst") == [1, 2]
+        assert state.variables_manager.get_variable("d") == {"a": 1, "b": 2}
 
     @pytest.mark.unit
     def test_is_serializable_accepts_sets(self):

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
@@ -1,5 +1,7 @@
 """Unit tests for E2B sandbox integration in CUGA Lite mode."""
 
+import json
+
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -53,7 +55,7 @@ class TestFilterNewVariables:
 
     @pytest.mark.unit
     def test_filter_sets_and_frozensets(self):
-        """Sets/frozensets with serializable elements must persist across steps."""
+        """Sets/frozensets persist as JSON-safe tagged forms that hydrate back."""
         original_keys = set()
         all_locals = {
             'my_set': {1, 2, 3},
@@ -64,10 +66,29 @@ class TestFilterNewVariables:
 
         result = VariableUtils.filter_new_variables(all_locals, original_keys)
 
-        assert result['my_set'] == {1, 2, 3}
-        assert result['my_frozenset'] == frozenset({4, 5})
-        assert result['nested_set'] == {1, (2, 3)}
+        json.dumps(result)
+        assert VariableUtils.hydrate_value(result['my_set']) == {1, 2, 3}
+        assert VariableUtils.hydrate_value(result['my_frozenset']) == frozenset({4, 5})
+        assert VariableUtils.hydrate_value(result['nested_set']) == {1, (2, 3)}
         assert 'set_of_unserializable' not in result
+
+    @pytest.mark.unit
+    def test_sanitize_sets_are_json_dumpsable(self):
+        """Stream path json.dumps(variables_storage) must not fail on sets (#572 regression)."""
+        sanitized = VariableUtils.sanitize_value({"emails": {"a@x.com", "b@y.com"}})
+        payload = {
+            "code": "",
+            "execution_output": "ok",
+            "variables": {
+                "emails": {
+                    "value": sanitized["emails"],
+                    "type": "set",
+                    "description": "Created during code execution",
+                }
+            },
+        }
+        encoded = json.dumps(payload)
+        assert "a@x.com" in encoded
 
     @pytest.mark.unit
     def test_is_serializable_accepts_sets(self):
@@ -144,7 +165,12 @@ print(len(product_set))
             code=code1, _locals={}, state=state, mode="local"
         )
         assert "product_set" in new_vars1
-        assert isinstance(new_vars1["product_set"], set)
+        json.dumps({"variables": state.variables_storage})
+        assert isinstance(
+            VariableUtils.hydrate_value(new_vars1["product_set"]),
+            set,
+        )
+        assert isinstance(state.variables_manager.get_variable("product_set"), set)
 
         _locals = {
             name: state.variables_manager.get_variable(name)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py
@@ -65,30 +65,26 @@ class TestFilterNewVariables:
         }
 
         result = VariableUtils.filter_new_variables(all_locals, original_keys)
+        round_tripped = json.loads(json.dumps(result))
 
-        json.dumps(result)
-        assert VariableUtils.hydrate_value(result['my_set']) == {1, 2, 3}
-        assert VariableUtils.hydrate_value(result['my_frozenset']) == frozenset({4, 5})
-        assert VariableUtils.hydrate_value(result['nested_set']) == {1, (2, 3)}
+        assert VariableUtils.hydrate_value(round_tripped['my_set']) == {1, 2, 3}
+        assert VariableUtils.hydrate_value(round_tripped['my_frozenset']) == frozenset({4, 5})
+        assert VariableUtils.hydrate_value(round_tripped['nested_set']) == {1, (2, 3)}
         assert 'set_of_unserializable' not in result
 
     @pytest.mark.unit
-    def test_sanitize_sets_are_json_dumpsable(self):
-        """Stream path json.dumps(variables_storage) must not fail on sets (#572 regression)."""
-        sanitized = VariableUtils.sanitize_value({"emails": {"a@x.com", "b@y.com"}})
-        payload = {
-            "code": "",
-            "execution_output": "ok",
-            "variables": {
-                "emails": {
-                    "value": sanitized["emails"],
-                    "type": "set",
-                    "description": "Created during code execution",
-                }
-            },
+    def test_sanitize_sets_survive_json_loads_round_trip(self):
+        """Stream/checkpoint path must dump and reload sets including nested tuples."""
+        original = {
+            "emails": {"a@x.com", "b@y.com"},
+            "nested": {((1, 2), (3, 4)), (1, (2, 3))},
+            "frozen": frozenset({"x", "y"}),
         }
-        encoded = json.dumps(payload)
-        assert "a@x.com" in encoded
+        sanitized = VariableUtils.sanitize_value(original)
+        restored = VariableUtils.hydrate_value(json.loads(json.dumps(sanitized)))
+        assert restored["emails"] == original["emails"]
+        assert restored["nested"] == original["nested"]
+        assert restored["frozen"] == original["frozen"]
 
     @pytest.mark.unit
     def test_is_serializable_accepts_sets(self):
@@ -165,12 +161,15 @@ print(len(product_set))
             code=code1, _locals={}, state=state, mode="local"
         )
         assert "product_set" in new_vars1
-        json.dumps({"variables": state.variables_storage})
+        reloaded = json.loads(json.dumps({"variables": state.variables_storage}))
         assert isinstance(
-            VariableUtils.hydrate_value(new_vars1["product_set"]),
+            VariableUtils.hydrate_value(reloaded["variables"]["product_set"]["value"]),
             set,
         )
         assert isinstance(state.variables_manager.get_variable("product_set"), set)
+        summary = state.variables_manager.get_variables_summary(variable_names=["product_set"])
+        assert "Type: set" in summary
+        assert "__set_type__" not in summary
 
         _locals = {
             name: state.variables_manager.get_variable(name)

--- a/src/cuga/backend/cuga_graph/state/agent_state.py
+++ b/src/cuga/backend/cuga_graph/state/agent_state.py
@@ -218,8 +218,12 @@ class VariablesManager(object):
         Returns:
             Any: The value of the variable, or None if not found
         """
+        from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+
         metadata = self.variables.get(name)
-        return metadata.value if metadata else None
+        if not metadata:
+            return None
+        return VariableUtils.hydrate_value(metadata.value)
 
     def get_variable_metadata(self, name: str) -> Optional[VariableMetadata]:
         """

--- a/src/cuga/backend/cuga_graph/state/agent_state.py
+++ b/src/cuga/backend/cuga_graph/state/agent_state.py
@@ -50,8 +50,10 @@ class VariableMetadata:
     def _tagged_set_kind(value: Any) -> Optional[str]:
         if not isinstance(value, dict):
             return None
+        if value.get("__cuga_enc__") is not True:
+            return None
         kind = value.get("__set_type__")
-        if kind in ("set", "frozenset") and set(value.keys()) == {"__set_type__", "items"}:
+        if kind in ("set", "frozenset") and set(value.keys()) == {"__set_type__", "items", "__cuga_enc__"}:
             return kind
         return None
 

--- a/src/cuga/backend/cuga_graph/state/agent_state.py
+++ b/src/cuga/backend/cuga_graph/state/agent_state.py
@@ -43,13 +43,29 @@ class VariableMetadata:
     def __init__(self, value: Any, description: Optional[str] = None, created_at: Optional[datetime] = None):
         self.value = value
         self.description = description or ""
-        self.type = type(value).__name__
+        self.type, self.count_items = self._type_and_count(value)
         self.created_at = created_at if created_at is not None else datetime.now()
-        self.count_items = self._calculate_count(value)
 
-    def _calculate_count(self, value: Any) -> int:
+    @staticmethod
+    def _tagged_set_kind(value: Any) -> Optional[str]:
+        if not isinstance(value, dict):
+            return None
+        kind = value.get("__set_type__")
+        if kind in ("set", "frozenset") and set(value.keys()) == {"__set_type__", "items"}:
+            return kind
+        return None
+
+    @classmethod
+    def _type_and_count(cls, value: Any) -> tuple[str, int]:
+        tagged = cls._tagged_set_kind(value)
+        if tagged is not None:
+            return tagged, len(value.get("items") or [])
+        return type(value).__name__, cls._calculate_count(value)
+
+    @staticmethod
+    def _calculate_count(value: Any) -> int:
         """Calculate the count of items in the value based on its type."""
-        if isinstance(value, (list, tuple, set)):
+        if isinstance(value, (list, tuple, set, frozenset)):
             return len(value)
         elif isinstance(value, dict):
             return len(value)
@@ -337,6 +353,9 @@ class VariablesManager(object):
 
     def _get_value_preview(self, value: Any, max_length: int = 5000) -> str:
         """Get a structured preview of the value, truncating nested content when large."""
+        from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+
+        value = VariableUtils.hydrate_value(value)
 
         try:
             full_repr = repr(value)
@@ -344,7 +363,6 @@ class VariablesManager(object):
                 return full_repr
         except Exception:
             pass
-
         max_string_chars = max(50, min(200, max_length // 4))
         max_list_items = 10
         max_depth = 6

--- a/src/cuga/backend/cuga_graph/state/agent_state.py
+++ b/src/cuga/backend/cuga_graph/state/agent_state.py
@@ -48,13 +48,10 @@ class VariableMetadata:
 
     @staticmethod
     def _tagged_set_kind(value: Any) -> Optional[str]:
-        if not isinstance(value, dict):
-            return None
-        if value.get("__cuga_enc__") is not True:
-            return None
-        kind = value.get("__set_type__")
-        if kind in ("set", "frozenset") and set(value.keys()) == {"__set_type__", "items", "__cuga_enc__"}:
-            return kind
+        from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+
+        if VariableUtils._is_set_tag(value):
+            return value["__set_type__"]
         return None
 
     @classmethod


### PR DESCRIPTION
## Bug fix

Related to #550 / #572

### Summary

Stability Tests on `main` have been red since #572: CRM CodeAgent runs that create Python `set`/`frozenset` variables crash the stream with `Object of type set is not JSON serializable`, so no `Answer` event is emitted and the 88% stability threshold fails on Python 3.12/3.13.

#572 correctly allowed sets to persist across CodeExecutor steps, but left them as native sets in `variables_storage`. `agent_loop` then does `json.dumps(...)` when emitting CodeAgent SSE frames.

This change:
- Sanitizes `set`/`frozenset` to tagged JSON-safe dicts (and tags nested tuples inside sets so they round-trip)
- Hydrates those tags back to real containers in `VariablesManager.get_variable` and `VariableBridge.extract_values`
- Adds regression coverage that `json.dumps(variables_storage)` succeeds after set creation

### Testing
- [x] Verified fix locally; tests pass
  - `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py::TestFilterNewVariables src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_lite.py::TestLocalSandboxSetPersistence src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/execution/test_variable_bridge.py -q` → 19 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persistence and retrieval of set and frozenset values.
  - Set-based data now remains intact when serialized, streamed, stored, and restored.
  - Added support for sets containing tuple elements and deeply nested values.
  - Malformed or ambiguous serialized entries continue to be handled safely.
  - Variable previews and retrieved values now accurately reflect restored collection types.

- **Tests**
  - Expanded coverage for JSON-compatible storage, streaming payloads, checkpoint round trips, and value restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->