### PR TITLE
chore: require parent epic when filing agent issues

### DIFF
--- a/.bob/commands/cuga-new-feature.md
+++ b/.bob/commands/cuga-new-feature.md
@@ -18,5 +18,17 @@
    | `[Epic]` | Large body of work grouping multiple issues |
    | `[Question]` | Clarification needed, not a task |
 
-5. Write the body using the same sections as `.github/ISSUE_TEMPLATE/feature_request.yml`: What you want and why, How it could work, Links or extra context (if any). Incorporate the user's message and any selected editor/context so the issue is concrete and complete.
-6. Do not add "Made with Cursor" or similar promotional footers to the issue.
+5. **Epic placement (required unless creating an `[Epic]` itself):** Before creating the issue, you **must** search for an existing open epic that this work belongs under. A parent epic is mandatory — do **not** create the issue with no parent. (The only exception elsewhere is a small bug via `/cuga-report-bug`; it does not apply here.) Do not skip this step and do not create the issue until a parent epic is chosen.
+
+   - List open epics from the same upstream repo, e.g. `gh issue list --repo <origin> --label "type: epic" --state open` and also search titles for `[Epic]` / `[EPIC]` so nothing is missed.
+   - Score candidates by topic overlap with the proposed issue (title, summary, components). Prefer epics that clearly own the same capability or area.
+   - Decision rules:
+     - **0 matches:** Tell the user no fitting epic was found. Ask them to either name an existing epic to use, or create a new `[Epic]` first. Do **not** invent a parent and do **not** proceed without one.
+     - **1 clear match:** Confirm that single epic with the user (number + title), then proceed with it.
+     - **2+ matches:** Stop and ask carefully which epic to use. Present each candidate as `#N — title` with a one-line why it might fit. Do not pick for the user. Wait for an explicit choice.
+   - When an epic is chosen: put `Part of #<number>.` at the top of the issue body (before the template sections), create the issue, then **link it as a GitHub sub-issue** under that epic. Do not stop at body text alone — parent/child linking is required.
+   - For list/link/verify `gh` recipes, follow sibling [`github_commands.md`](./github_commands.md) (sections **Epics in this repo**, **Add a sub-issue**, **Verify after linking**). Use GraphQL `addSubIssue`; do not rely on unsupported `gh issue edit --set-parent`.
+   - If the new issue is itself an `[Epic]`, skip parent-epic search.
+
+6. Write the body using the same sections as `.github/ISSUE_TEMPLATE/feature_request.yml`: What you want and why, How it could work, Links or extra context (if any). Incorporate the user's message and any selected editor/context so the issue is concrete and complete.
+7. Do not add "Made with Cursor" or similar promotional footers to the issue.

--- a/.bob/commands/cuga-report-bug.md
+++ b/.bob/commands/cuga-report-bug.md
@@ -3,6 +3,17 @@
 1. Create the issue with the GitHub CLI (`gh issue create`).
 2. Open it against the **origin** upstream (use that remote / repository—not a fork-only default).
 3. Labels: run `gh label list` for that upstream repository (same scope as the issue, e.g. `--repo owner/name` if you are not using the default remote). Only use names that appear in that output. When you run `gh issue create`, pass `--label bug` and repeat `--label <name>` for each other applicable label. Do not invent label names.
-4. Write the body using the same sections as `.github/ISSUE_TEMPLATE/bug_report.yml`: What happened, How to reproduce, Environment, Logs, screenshots, or config (if any). Incorporate the user’s message and any selected editor/context so the issue is concrete and reproducible.
-5. Use a sensible title consistent with the template’s title prefix.
-6. Do not add “Made with Cursor” or similar promotional footers to the issue.
+4. **Epic placement:** Before creating the issue, search for an existing open epic this bug belongs under (`gh issue list --repo <origin> --label "type: epic" --state open`, plus title search for `[Epic]` / `[EPIC]`).
+
+   - **Small bug exception:** A small, self-contained bug (narrow repro, no design change, not part of a larger workstream) may proceed **without** a parent epic. Say so explicitly when filing.
+   - Otherwise a parent epic is required — do **not** file with no parent.
+   - Decision rules when a parent is required:
+     - **0 matches:** Tell the user none fit. Ask them to name an existing epic or create a new `[Epic]` first. Do not invent a parent and do not proceed without one.
+     - **1 clear match:** Confirm that epic (number + title), then proceed.
+     - **2+ matches:** Stop and ask carefully which epic to use. Present each as `#N — title` with a one-line why it might fit. Do not pick for the user.
+   - When an epic is chosen: put `Part of #<number>.` at the top of the issue body (before the template sections), create the issue, then **link it as a GitHub sub-issue** under that epic. Do not stop at body text alone — parent/child linking is required.
+   - For list/link/verify `gh` recipes, follow sibling [`github_commands.md`](./github_commands.md) (sections **Epics in this repo**, **Add a sub-issue**, **Verify after linking**). Use GraphQL `addSubIssue`; do not rely on unsupported `gh issue edit --set-parent`.
+
+5. Write the body using the same sections as `.github/ISSUE_TEMPLATE/bug_report.yml`: What happened, How to reproduce, Environment, Logs, screenshots, or config (if any). Incorporate the user’s message and any selected editor/context so the issue is concrete and reproducible.
+6. Use a sensible title consistent with the template’s title prefix.
+7. Do not add “Made with Cursor” or similar promotional footers to the issue.

--- a/.bob/commands/github_commands.md
+++ b/.bob/commands/github_commands.md
@@ -1,0 +1,317 @@
+---
+name: github-commands
+description: "GitHub issue and epic workflow for cuga-agent: list epics, find orphans, add/remove sub-issues via gh."
+trigger: /github
+---
+
+# GitHub commands (`gh`)
+
+Reference for working with **issues**, **epics**, and **sub-issues** in `cuga-project/cuga-agent`.
+
+**Prerequisites**
+
+```bash
+gh auth status          # must be logged in
+gh repo view            # should show cuga-project/cuga-agent
+```
+
+Set defaults once (optional):
+
+```bash
+export REPO=cuga-project/cuga-agent
+export OWNER=cuga-project
+export NAME=cuga-agent
+```
+
+---
+
+## Epics in this repo
+
+Epics are open issues with the label **`type: epic`**. Child work items are linked as **sub-issues** (GitHub parent/child), not only via labels.
+
+```bash
+gh issue list --state open --label "type: epic" --limit 50 \
+  --json number,title,url \
+  --jq '.[] | "#\(.number): \(.title)"'
+```
+
+---
+
+## List sub-issues of an epic
+
+Replace `238` with the epic number:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issue(number: 238) {
+      number
+      title
+      subIssues(first: 50) {
+        nodes { number title url state }
+      }
+    }
+  }
+}' --jq '.data.repository.issue | "#\(.number): \(.title)", (.subIssues.nodes[] | "  #\(.number): \(.title)")'
+```
+
+---
+
+## Find issues without an epic parent
+
+`gh issue list` cannot filter by parent. Use GraphQL:
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issues(first: 100, after: $cursor, states: OPEN) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        url
+        parent { number title }
+        labels(first: 20) { nodes { name } }
+      }
+    }
+  }
+}' --paginate --jq '
+  [.[] | .data.repository.issues.nodes[] |
+    select(.parent == null) |
+    select([.labels.nodes[].name] | index("type: epic") | not) |
+    "#\(.number): \(.title)"
+  ] | .[]
+'
+```
+
+Issues whose parent has `type: epic` are considered **under an epic**; `parent == null` means no parent at all.
+
+---
+
+## Get issue node IDs (required for sub-issue mutations)
+
+GraphQL mutations use **node IDs** (`I_kwDO...`), not issue numbers.
+
+```bash
+# Single issue
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issue(number: 238) { id number title }
+  }
+}' --jq '.data.repository.issue'
+
+# Parent + child in one call
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    parent: issue(number: 238) { id number title }
+    child: issue(number: 168) { id number title parent { number } }
+  }
+}' --jq '.data.repository'
+```
+
+---
+
+## Add a sub-issue (link child → epic parent)
+
+**Supported today:** `gh api graphql` + `addSubIssue` mutation.
+
+**Not supported in current `gh issue edit`:** `--set-parent`, `--add-sub-issue` (may arrive in a future CLI release).
+
+**REST note:** `POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues` returned 404 in this repo; prefer GraphQL.
+
+### One child
+
+```bash
+PARENT_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:238) { id } } }
+' --jq '.data.repository.issue.id')
+
+CHILD_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:168) { id } } }
+' --jq '.data.repository.issue.id')
+
+gh api graphql -f query="
+mutation {
+  addSubIssue(input: {
+    issueId: \"$PARENT_ID\"
+    subIssueId: \"$CHILD_ID\"
+  }) {
+    issue { number title }
+    subIssue { number title parent { number } }
+  }
+}"
+```
+
+### Multiple children (batch)
+
+```bash
+PARENT=238
+CHILDREN="168 161 104 202"
+
+PARENT_ID=$(gh api graphql -f query="
+{ repository(owner:\"cuga-project\", name:\"cuga-agent\") { issue(number:$PARENT) { id } } }
+" --jq '.data.repository.issue.id')
+
+for num in $CHILDREN; do
+  CHILD_ID=$(gh api graphql -f query="
+  { repository(owner:\"cuga-project\", name:\"cuga-agent\") { issue(number:$num) { id parent { number } } } }
+  " --jq '.data.repository.issue | "\(.id) \(.parent.number // "none")"')
+
+  id="${CHILD_ID%% *}"
+  existing="${CHILD_ID##* }"
+  if [ "$existing" != "none" ]; then
+    echo "#$num: skip (already parent #$existing)"
+    continue
+  fi
+
+  gh api graphql -f query="
+  mutation {
+    addSubIssue(input: { issueId: \"$PARENT_ID\", subIssueId: \"$id\" }) {
+      subIssue { number parent { number } }
+    }
+  }" --jq ".data.addSubIssue.subIssue | \"#\(.number) -> parent #\(.parent.number)\""
+done
+```
+
+### Verify after linking
+
+```bash
+gh issue view 168 --json number,title,parent --jq '{number, title, parent: .parent}'
+```
+
+Or GraphQL:
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") {
+    issue(number:168) { number title parent { number title } }
+}}' --jq '.data.repository.issue'
+```
+
+---
+
+## Remove a sub-issue (unlink parent)
+
+```bash
+PARENT_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:238) { id } } }
+' --jq '.data.repository.issue.id')
+
+CHILD_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:168) { id } } }
+' --jq '.data.repository.issue.id')
+
+gh api graphql -f query="
+mutation {
+  removeSubIssue(input: {
+    issueId: \"$PARENT_ID\"
+    subIssueId: \"$CHILD_ID\"
+  }) {
+    subIssue { number parent { number } }
+  }
+}"
+```
+
+---
+
+## Create an issue
+
+### Standard (no parent)
+
+```bash
+gh issue create \
+  --title "[Feature]: Example title" \
+  --body "## Summary\n..." \
+  --label "enhancement" \
+  --label "component: agent"
+```
+
+### With issue type (REST — supports `type` field)
+
+```bash
+gh api repos/cuga-project/cuga-agent/issues \
+  -X POST \
+  -f title="[Epic] Example epic" \
+  -f body="## Summary\n..." \
+  -f type="Epic" \
+  -f labels[]="type: epic" \
+  -f labels[]="component: agent" \
+  --jq '{number, html_url}'
+```
+
+Then link children with `addSubIssue` (above). Creating a sub-issue with parent in one step is not documented in `gh issue create` for this CLI version.
+
+---
+
+## Update / close issues
+
+```bash
+gh issue edit 168 --add-label "priority: high"
+gh issue close 168 --comment "Fixed in #..."
+gh api repos/cuga-project/cuga-agent/issues/168 \
+  -X PATCH \
+  -f title="Updated title" \
+  --jq '{number, html_url}'
+```
+
+---
+
+## Epic hygiene (conventions)
+
+| Label / pattern | Meaning |
+|-----------------|--------|
+| `type: epic` | Top-level epic issue |
+| `component: *` | Area (agent, frontend, policies, …) |
+| Sub-issue parent | Epic issue number via GitHub parent link |
+
+**When to parent an issue**
+
+- **Must:** Clear scope match to epic title (e.g. multi-provider work → models epic #238).
+- **Should:** Reasonable fit; alternate epic possible.
+- **Skip:** One-off chores (#78-style cleanup) unless using a Platform Health epic.
+
+**Epics with no children** are planning placeholders until sub-issues are linked.
+
+---
+
+## Example: models epic (#238)
+
+Children linked under [#238 Open Source Models](https://github.com/cuga-project/cuga-agent/issues/238):
+
+- #168, #161, #104, #202, #137, #110
+
+Re-list:
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") {
+  issue(number:238) { subIssues(first:20) { nodes { number title } } }
+}}' --jq '.data.repository.issue.subIssues.nodes[] | "#\(.number): \(.title)"'
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `Forbidden` on `gh api graphql` | Run outside sandbox / check `gh auth status` |
+| `addSubIssue` succeeds but UI slow | Refresh issue page; parent shows under "Sub-issues" |
+| Child already has parent | `removeSubIssue` first, or skip |
+| `404` on REST `sub_issues` | Use GraphQL `addSubIssue` instead |
+| Need assignee/labels only | `gh issue edit` — no parent flags needed |
+
+---
+
+## Related
+
+- `cuga-new-feature.md` — create feature issues; must pick a parent epic and link via `addSubIssue`
+- `cuga-report-bug.md` — create bug issues; same epic link flow except small self-contained bugs
+- `.agents/skills/github-issues/SKILL.md` — create/update issues, templates, labels
+- `.agents/skills/github-pr-comments/SKILL.md` — PR comments, inline review, batch feedback
+- `.claude/commands/cuga-create-pr.md` — create PRs, then comment with the PR-comments skill
+- User rule: conventional commits; do not commit unless asked

--- a/.bob/commands/github_commands.md
+++ b/.bob/commands/github_commands.md
@@ -220,17 +220,18 @@ mutation {
 
 ## Create an issue
 
-### Standard (no parent)
+Agent filing commands require a parent epic (see Related), except small self-contained bugs. After create, link with `addSubIssue` (above). Creating a sub-issue with parent in one step is not supported by `gh issue create` for this CLI version.
 
 ```bash
 gh issue create \
   --title "[Feature]: Example title" \
-  --body "## Summary\n..." \
+  --body "Part of #<epic>.\n\n## Summary\n..." \
   --label "enhancement" \
+  --label "needs-triage" \
   --label "component: agent"
 ```
 
-### With issue type (REST — supports `type` field)
+### Create an epic (REST — supports `type` field)
 
 ```bash
 gh api repos/cuga-project/cuga-agent/issues \
@@ -242,8 +243,6 @@ gh api repos/cuga-project/cuga-agent/issues \
   -f labels[]="component: agent" \
   --jq '{number, html_url}'
 ```
-
-Then link children with `addSubIssue` (above). Creating a sub-issue with parent in one step is not documented in `gh issue create` for this CLI version.
 
 ---
 
@@ -270,28 +269,11 @@ gh api repos/cuga-project/cuga-agent/issues/168 \
 
 **When to parent an issue**
 
-- **Must:** Clear scope match to epic title (e.g. multi-provider work → models epic #238).
-- **Should:** Reasonable fit; alternate epic possible.
-- **Skip:** One-off chores (#78-style cleanup) unless using a Platform Health epic.
+- **Must:** Features, designs, and non-trivial bugs — clear scope match to an open epic.
+- **Ask:** Two or more epics could fit; do not auto-pick.
+- **Skip:** Small self-contained bugs only (narrow repro, no design change). Not chores/features.
 
 **Epics with no children** are planning placeholders until sub-issues are linked.
-
----
-
-## Example: models epic (#238)
-
-Children linked under [#238 Open Source Models](https://github.com/cuga-project/cuga-agent/issues/238):
-
-- #168, #161, #104, #202, #137, #110
-
-Re-list:
-
-```bash
-gh api graphql -f query='
-{ repository(owner:"cuga-project", name:"cuga-agent") {
-  issue(number:238) { subIssues(first:20) { nodes { number title } } }
-}}' --jq '.data.repository.issue.subIssues.nodes[] | "#\(.number): \(.title)"'
-```
 
 ---
 
@@ -311,7 +293,4 @@ gh api graphql -f query='
 
 - `cuga-new-feature.md` — create feature issues; must pick a parent epic and link via `addSubIssue`
 - `cuga-report-bug.md` — create bug issues; same epic link flow except small self-contained bugs
-- `.agents/skills/github-issues/SKILL.md` — create/update issues, templates, labels
-- `.agents/skills/github-pr-comments/SKILL.md` — PR comments, inline review, batch feedback
-- `.claude/commands/cuga-create-pr.md` — create PRs, then comment with the PR-comments skill
-- User rule: conventional commits; do not commit unless asked
+- `cuga-create-pr.md` — create pull requests against upstream

--- a/.claude/commands/cuga-new-feature.md
+++ b/.claude/commands/cuga-new-feature.md
@@ -18,5 +18,17 @@
    | `[Epic]` | Large body of work grouping multiple issues |
    | `[Question]` | Clarification needed, not a task |
 
-5. Write the body using the same sections as `.github/ISSUE_TEMPLATE/feature_request.yml`: What you want and why, How it could work, Links or extra context (if any). Incorporate the user's message and any selected editor/context so the issue is concrete and complete.
-6. Do not add "Made with Cursor" or similar promotional footers to the issue.
+5. **Epic placement (required unless creating an `[Epic]` itself):** Before creating the issue, you **must** search for an existing open epic that this work belongs under. A parent epic is mandatory — do **not** create the issue with no parent. (The only exception elsewhere is a small bug via `/cuga-report-bug`; it does not apply here.) Do not skip this step and do not create the issue until a parent epic is chosen.
+
+   - List open epics from the same upstream repo, e.g. `gh issue list --repo <origin> --label "type: epic" --state open` and also search titles for `[Epic]` / `[EPIC]` so nothing is missed.
+   - Score candidates by topic overlap with the proposed issue (title, summary, components). Prefer epics that clearly own the same capability or area.
+   - Decision rules:
+     - **0 matches:** Tell the user no fitting epic was found. Ask them to either name an existing epic to use, or create a new `[Epic]` first. Do **not** invent a parent and do **not** proceed without one.
+     - **1 clear match:** Confirm that single epic with the user (number + title), then proceed with it.
+     - **2+ matches:** Stop and ask carefully which epic to use. Present each candidate as `#N — title` with a one-line why it might fit. Do not pick for the user. Wait for an explicit choice.
+   - When an epic is chosen: put `Part of #<number>.` at the top of the issue body (before the template sections), create the issue, then **link it as a GitHub sub-issue** under that epic. Do not stop at body text alone — parent/child linking is required.
+   - For list/link/verify `gh` recipes, follow sibling [`github_commands.md`](./github_commands.md) (sections **Epics in this repo**, **Add a sub-issue**, **Verify after linking**). Use GraphQL `addSubIssue`; do not rely on unsupported `gh issue edit --set-parent`.
+   - If the new issue is itself an `[Epic]`, skip parent-epic search.
+
+6. Write the body using the same sections as `.github/ISSUE_TEMPLATE/feature_request.yml`: What you want and why, How it could work, Links or extra context (if any). Incorporate the user's message and any selected editor/context so the issue is concrete and complete.
+7. Do not add "Made with Cursor" or similar promotional footers to the issue.

--- a/.claude/commands/cuga-report-bug.md
+++ b/.claude/commands/cuga-report-bug.md
@@ -3,6 +3,17 @@
 1. Create the issue with the GitHub CLI (`gh issue create`).
 2. Open it against the **origin** upstream (use that remote / repository—not a fork-only default).
 3. Labels: run `gh label list` for that upstream repository (same scope as the issue, e.g. `--repo owner/name` if you are not using the default remote). Only use names that appear in that output. When you run `gh issue create`, pass `--label bug` and repeat `--label <name>` for each other applicable label. Do not invent label names.
-4. Write the body using the same sections as `.github/ISSUE_TEMPLATE/bug_report.yml`: What happened, How to reproduce, Environment, Logs, screenshots, or config (if any). Incorporate the user’s message and any selected editor/context so the issue is concrete and reproducible.
-5. Use a sensible title consistent with the template’s title prefix.
-6. Do not add “Made with Cursor” or similar promotional footers to the issue.
+4. **Epic placement:** Before creating the issue, search for an existing open epic this bug belongs under (`gh issue list --repo <origin> --label "type: epic" --state open`, plus title search for `[Epic]` / `[EPIC]`).
+
+   - **Small bug exception:** A small, self-contained bug (narrow repro, no design change, not part of a larger workstream) may proceed **without** a parent epic. Say so explicitly when filing.
+   - Otherwise a parent epic is required — do **not** file with no parent.
+   - Decision rules when a parent is required:
+     - **0 matches:** Tell the user none fit. Ask them to name an existing epic or create a new `[Epic]` first. Do not invent a parent and do not proceed without one.
+     - **1 clear match:** Confirm that epic (number + title), then proceed.
+     - **2+ matches:** Stop and ask carefully which epic to use. Present each as `#N — title` with a one-line why it might fit. Do not pick for the user.
+   - When an epic is chosen: put `Part of #<number>.` at the top of the issue body (before the template sections), create the issue, then **link it as a GitHub sub-issue** under that epic. Do not stop at body text alone — parent/child linking is required.
+   - For list/link/verify `gh` recipes, follow sibling [`github_commands.md`](./github_commands.md) (sections **Epics in this repo**, **Add a sub-issue**, **Verify after linking**). Use GraphQL `addSubIssue`; do not rely on unsupported `gh issue edit --set-parent`.
+
+5. Write the body using the same sections as `.github/ISSUE_TEMPLATE/bug_report.yml`: What happened, How to reproduce, Environment, Logs, screenshots, or config (if any). Incorporate the user’s message and any selected editor/context so the issue is concrete and reproducible.
+6. Use a sensible title consistent with the template’s title prefix.
+7. Do not add “Made with Cursor” or similar promotional footers to the issue.

--- a/.claude/commands/github_commands.md
+++ b/.claude/commands/github_commands.md
@@ -1,0 +1,317 @@
+---
+name: github-commands
+description: "GitHub issue and epic workflow for cuga-agent: list epics, find orphans, add/remove sub-issues via gh."
+trigger: /github
+---
+
+# GitHub commands (`gh`)
+
+Reference for working with **issues**, **epics**, and **sub-issues** in `cuga-project/cuga-agent`.
+
+**Prerequisites**
+
+```bash
+gh auth status          # must be logged in
+gh repo view            # should show cuga-project/cuga-agent
+```
+
+Set defaults once (optional):
+
+```bash
+export REPO=cuga-project/cuga-agent
+export OWNER=cuga-project
+export NAME=cuga-agent
+```
+
+---
+
+## Epics in this repo
+
+Epics are open issues with the label **`type: epic`**. Child work items are linked as **sub-issues** (GitHub parent/child), not only via labels.
+
+```bash
+gh issue list --state open --label "type: epic" --limit 50 \
+  --json number,title,url \
+  --jq '.[] | "#\(.number): \(.title)"'
+```
+
+---
+
+## List sub-issues of an epic
+
+Replace `238` with the epic number:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issue(number: 238) {
+      number
+      title
+      subIssues(first: 50) {
+        nodes { number title url state }
+      }
+    }
+  }
+}' --jq '.data.repository.issue | "#\(.number): \(.title)", (.subIssues.nodes[] | "  #\(.number): \(.title)")'
+```
+
+---
+
+## Find issues without an epic parent
+
+`gh issue list` cannot filter by parent. Use GraphQL:
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issues(first: 100, after: $cursor, states: OPEN) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        url
+        parent { number title }
+        labels(first: 20) { nodes { name } }
+      }
+    }
+  }
+}' --paginate --jq '
+  [.[] | .data.repository.issues.nodes[] |
+    select(.parent == null) |
+    select([.labels.nodes[].name] | index("type: epic") | not) |
+    "#\(.number): \(.title)"
+  ] | .[]
+'
+```
+
+Issues whose parent has `type: epic` are considered **under an epic**; `parent == null` means no parent at all.
+
+---
+
+## Get issue node IDs (required for sub-issue mutations)
+
+GraphQL mutations use **node IDs** (`I_kwDO...`), not issue numbers.
+
+```bash
+# Single issue
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issue(number: 238) { id number title }
+  }
+}' --jq '.data.repository.issue'
+
+# Parent + child in one call
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    parent: issue(number: 238) { id number title }
+    child: issue(number: 168) { id number title parent { number } }
+  }
+}' --jq '.data.repository'
+```
+
+---
+
+## Add a sub-issue (link child → epic parent)
+
+**Supported today:** `gh api graphql` + `addSubIssue` mutation.
+
+**Not supported in current `gh issue edit`:** `--set-parent`, `--add-sub-issue` (may arrive in a future CLI release).
+
+**REST note:** `POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues` returned 404 in this repo; prefer GraphQL.
+
+### One child
+
+```bash
+PARENT_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:238) { id } } }
+' --jq '.data.repository.issue.id')
+
+CHILD_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:168) { id } } }
+' --jq '.data.repository.issue.id')
+
+gh api graphql -f query="
+mutation {
+  addSubIssue(input: {
+    issueId: \"$PARENT_ID\"
+    subIssueId: \"$CHILD_ID\"
+  }) {
+    issue { number title }
+    subIssue { number title parent { number } }
+  }
+}"
+```
+
+### Multiple children (batch)
+
+```bash
+PARENT=238
+CHILDREN="168 161 104 202"
+
+PARENT_ID=$(gh api graphql -f query="
+{ repository(owner:\"cuga-project\", name:\"cuga-agent\") { issue(number:$PARENT) { id } } }
+" --jq '.data.repository.issue.id')
+
+for num in $CHILDREN; do
+  CHILD_ID=$(gh api graphql -f query="
+  { repository(owner:\"cuga-project\", name:\"cuga-agent\") { issue(number:$num) { id parent { number } } } }
+  " --jq '.data.repository.issue | "\(.id) \(.parent.number // "none")"')
+
+  id="${CHILD_ID%% *}"
+  existing="${CHILD_ID##* }"
+  if [ "$existing" != "none" ]; then
+    echo "#$num: skip (already parent #$existing)"
+    continue
+  fi
+
+  gh api graphql -f query="
+  mutation {
+    addSubIssue(input: { issueId: \"$PARENT_ID\", subIssueId: \"$id\" }) {
+      subIssue { number parent { number } }
+    }
+  }" --jq ".data.addSubIssue.subIssue | \"#\(.number) -> parent #\(.parent.number)\""
+done
+```
+
+### Verify after linking
+
+```bash
+gh issue view 168 --json number,title,parent --jq '{number, title, parent: .parent}'
+```
+
+Or GraphQL:
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") {
+    issue(number:168) { number title parent { number title } }
+}}' --jq '.data.repository.issue'
+```
+
+---
+
+## Remove a sub-issue (unlink parent)
+
+```bash
+PARENT_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:238) { id } } }
+' --jq '.data.repository.issue.id')
+
+CHILD_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:168) { id } } }
+' --jq '.data.repository.issue.id')
+
+gh api graphql -f query="
+mutation {
+  removeSubIssue(input: {
+    issueId: \"$PARENT_ID\"
+    subIssueId: \"$CHILD_ID\"
+  }) {
+    subIssue { number parent { number } }
+  }
+}"
+```
+
+---
+
+## Create an issue
+
+### Standard (no parent)
+
+```bash
+gh issue create \
+  --title "[Feature]: Example title" \
+  --body "## Summary\n..." \
+  --label "enhancement" \
+  --label "component: agent"
+```
+
+### With issue type (REST — supports `type` field)
+
+```bash
+gh api repos/cuga-project/cuga-agent/issues \
+  -X POST \
+  -f title="[Epic] Example epic" \
+  -f body="## Summary\n..." \
+  -f type="Epic" \
+  -f labels[]="type: epic" \
+  -f labels[]="component: agent" \
+  --jq '{number, html_url}'
+```
+
+Then link children with `addSubIssue` (above). Creating a sub-issue with parent in one step is not documented in `gh issue create` for this CLI version.
+
+---
+
+## Update / close issues
+
+```bash
+gh issue edit 168 --add-label "priority: high"
+gh issue close 168 --comment "Fixed in #..."
+gh api repos/cuga-project/cuga-agent/issues/168 \
+  -X PATCH \
+  -f title="Updated title" \
+  --jq '{number, html_url}'
+```
+
+---
+
+## Epic hygiene (conventions)
+
+| Label / pattern | Meaning |
+|-----------------|--------|
+| `type: epic` | Top-level epic issue |
+| `component: *` | Area (agent, frontend, policies, …) |
+| Sub-issue parent | Epic issue number via GitHub parent link |
+
+**When to parent an issue**
+
+- **Must:** Clear scope match to epic title (e.g. multi-provider work → models epic #238).
+- **Should:** Reasonable fit; alternate epic possible.
+- **Skip:** One-off chores (#78-style cleanup) unless using a Platform Health epic.
+
+**Epics with no children** are planning placeholders until sub-issues are linked.
+
+---
+
+## Example: models epic (#238)
+
+Children linked under [#238 Open Source Models](https://github.com/cuga-project/cuga-agent/issues/238):
+
+- #168, #161, #104, #202, #137, #110
+
+Re-list:
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") {
+  issue(number:238) { subIssues(first:20) { nodes { number title } } }
+}}' --jq '.data.repository.issue.subIssues.nodes[] | "#\(.number): \(.title)"'
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `Forbidden` on `gh api graphql` | Run outside sandbox / check `gh auth status` |
+| `addSubIssue` succeeds but UI slow | Refresh issue page; parent shows under "Sub-issues" |
+| Child already has parent | `removeSubIssue` first, or skip |
+| `404` on REST `sub_issues` | Use GraphQL `addSubIssue` instead |
+| Need assignee/labels only | `gh issue edit` — no parent flags needed |
+
+---
+
+## Related
+
+- `cuga-new-feature.md` — create feature issues; must pick a parent epic and link via `addSubIssue`
+- `cuga-report-bug.md` — create bug issues; same epic link flow except small self-contained bugs
+- `.agents/skills/github-issues/SKILL.md` — create/update issues, templates, labels
+- `.agents/skills/github-pr-comments/SKILL.md` — PR comments, inline review, batch feedback
+- `.claude/commands/cuga-create-pr.md` — create PRs, then comment with the PR-comments skill
+- User rule: conventional commits; do not commit unless asked

--- a/.claude/commands/github_commands.md
+++ b/.claude/commands/github_commands.md
@@ -220,17 +220,18 @@ mutation {
 
 ## Create an issue
 
-### Standard (no parent)
+Agent filing commands require a parent epic (see Related), except small self-contained bugs. After create, link with `addSubIssue` (above). Creating a sub-issue with parent in one step is not supported by `gh issue create` for this CLI version.
 
 ```bash
 gh issue create \
   --title "[Feature]: Example title" \
-  --body "## Summary\n..." \
+  --body "Part of #<epic>.\n\n## Summary\n..." \
   --label "enhancement" \
+  --label "needs-triage" \
   --label "component: agent"
 ```
 
-### With issue type (REST — supports `type` field)
+### Create an epic (REST — supports `type` field)
 
 ```bash
 gh api repos/cuga-project/cuga-agent/issues \
@@ -242,8 +243,6 @@ gh api repos/cuga-project/cuga-agent/issues \
   -f labels[]="component: agent" \
   --jq '{number, html_url}'
 ```
-
-Then link children with `addSubIssue` (above). Creating a sub-issue with parent in one step is not documented in `gh issue create` for this CLI version.
 
 ---
 
@@ -270,28 +269,11 @@ gh api repos/cuga-project/cuga-agent/issues/168 \
 
 **When to parent an issue**
 
-- **Must:** Clear scope match to epic title (e.g. multi-provider work → models epic #238).
-- **Should:** Reasonable fit; alternate epic possible.
-- **Skip:** One-off chores (#78-style cleanup) unless using a Platform Health epic.
+- **Must:** Features, designs, and non-trivial bugs — clear scope match to an open epic.
+- **Ask:** Two or more epics could fit; do not auto-pick.
+- **Skip:** Small self-contained bugs only (narrow repro, no design change). Not chores/features.
 
 **Epics with no children** are planning placeholders until sub-issues are linked.
-
----
-
-## Example: models epic (#238)
-
-Children linked under [#238 Open Source Models](https://github.com/cuga-project/cuga-agent/issues/238):
-
-- #168, #161, #104, #202, #137, #110
-
-Re-list:
-
-```bash
-gh api graphql -f query='
-{ repository(owner:"cuga-project", name:"cuga-agent") {
-  issue(number:238) { subIssues(first:20) { nodes { number title } } }
-}}' --jq '.data.repository.issue.subIssues.nodes[] | "#\(.number): \(.title)"'
-```
 
 ---
 
@@ -311,7 +293,4 @@ gh api graphql -f query='
 
 - `cuga-new-feature.md` — create feature issues; must pick a parent epic and link via `addSubIssue`
 - `cuga-report-bug.md` — create bug issues; same epic link flow except small self-contained bugs
-- `.agents/skills/github-issues/SKILL.md` — create/update issues, templates, labels
-- `.agents/skills/github-pr-comments/SKILL.md` — PR comments, inline review, batch feedback
-- `.claude/commands/cuga-create-pr.md` — create PRs, then comment with the PR-comments skill
-- User rule: conventional commits; do not commit unless asked
+- `cuga-create-pr.md` — create pull requests against upstream

--- a/.cursor/commands/cuga-new-feature.md
+++ b/.cursor/commands/cuga-new-feature.md
@@ -18,5 +18,17 @@
    | `[Epic]` | Large body of work grouping multiple issues |
    | `[Question]` | Clarification needed, not a task |
 
-5. Write the body using the same sections as `.github/ISSUE_TEMPLATE/feature_request.yml`: What you want and why, How it could work, Links or extra context (if any). Incorporate the user's message and any selected editor/context so the issue is concrete and complete.
-6. Do not add "Made with Cursor" or similar promotional footers to the issue.
+5. **Epic placement (required unless creating an `[Epic]` itself):** Before creating the issue, you **must** search for an existing open epic that this work belongs under. A parent epic is mandatory — do **not** create the issue with no parent. (The only exception elsewhere is a small bug via `/cuga-report-bug`; it does not apply here.) Do not skip this step and do not create the issue until a parent epic is chosen.
+
+   - List open epics from the same upstream repo, e.g. `gh issue list --repo <origin> --label "type: epic" --state open` and also search titles for `[Epic]` / `[EPIC]` so nothing is missed.
+   - Score candidates by topic overlap with the proposed issue (title, summary, components). Prefer epics that clearly own the same capability or area.
+   - Decision rules:
+     - **0 matches:** Tell the user no fitting epic was found. Ask them to either name an existing epic to use, or create a new `[Epic]` first. Do **not** invent a parent and do **not** proceed without one.
+     - **1 clear match:** Confirm that single epic with the user (number + title), then proceed with it.
+     - **2+ matches:** Stop and ask carefully which epic to use. Present each candidate as `#N — title` with a one-line why it might fit. Do not pick for the user. Wait for an explicit choice.
+   - When an epic is chosen: put `Part of #<number>.` at the top of the issue body (before the template sections), create the issue, then **link it as a GitHub sub-issue** under that epic. Do not stop at body text alone — parent/child linking is required.
+   - For list/link/verify `gh` recipes, follow sibling [`github_commands.md`](./github_commands.md) (sections **Epics in this repo**, **Add a sub-issue**, **Verify after linking**). Use GraphQL `addSubIssue`; do not rely on unsupported `gh issue edit --set-parent`.
+   - If the new issue is itself an `[Epic]`, skip parent-epic search.
+
+6. Write the body using the same sections as `.github/ISSUE_TEMPLATE/feature_request.yml`: What you want and why, How it could work, Links or extra context (if any). Incorporate the user's message and any selected editor/context so the issue is concrete and complete.
+7. Do not add "Made with Cursor" or similar promotional footers to the issue.

--- a/.cursor/commands/cuga-report-bug.md
+++ b/.cursor/commands/cuga-report-bug.md
@@ -3,6 +3,17 @@
 1. Create the issue with the GitHub CLI (`gh issue create`).
 2. Open it against the **origin** upstream (use that remote / repository—not a fork-only default).
 3. Labels: run `gh label list` for that upstream repository (same scope as the issue, e.g. `--repo owner/name` if you are not using the default remote). Only use names that appear in that output. When you run `gh issue create`, pass `--label bug` and repeat `--label <name>` for each other applicable label. Do not invent label names.
-4. Write the body using the same sections as `.github/ISSUE_TEMPLATE/bug_report.yml`: What happened, How to reproduce, Environment, Logs, screenshots, or config (if any). Incorporate the user’s message and any selected editor/context so the issue is concrete and reproducible.
-5. Use a sensible title consistent with the template’s title prefix.
-6. Do not add “Made with Cursor” or similar promotional footers to the issue.
+4. **Epic placement:** Before creating the issue, search for an existing open epic this bug belongs under (`gh issue list --repo <origin> --label "type: epic" --state open`, plus title search for `[Epic]` / `[EPIC]`).
+
+   - **Small bug exception:** A small, self-contained bug (narrow repro, no design change, not part of a larger workstream) may proceed **without** a parent epic. Say so explicitly when filing.
+   - Otherwise a parent epic is required — do **not** file with no parent.
+   - Decision rules when a parent is required:
+     - **0 matches:** Tell the user none fit. Ask them to name an existing epic or create a new `[Epic]` first. Do not invent a parent and do not proceed without one.
+     - **1 clear match:** Confirm that epic (number + title), then proceed.
+     - **2+ matches:** Stop and ask carefully which epic to use. Present each as `#N — title` with a one-line why it might fit. Do not pick for the user.
+   - When an epic is chosen: put `Part of #<number>.` at the top of the issue body (before the template sections), create the issue, then **link it as a GitHub sub-issue** under that epic. Do not stop at body text alone — parent/child linking is required.
+   - For list/link/verify `gh` recipes, follow sibling [`github_commands.md`](./github_commands.md) (sections **Epics in this repo**, **Add a sub-issue**, **Verify after linking**). Use GraphQL `addSubIssue`; do not rely on unsupported `gh issue edit --set-parent`.
+
+5. Write the body using the same sections as `.github/ISSUE_TEMPLATE/bug_report.yml`: What happened, How to reproduce, Environment, Logs, screenshots, or config (if any). Incorporate the user’s message and any selected editor/context so the issue is concrete and reproducible.
+6. Use a sensible title consistent with the template’s title prefix.
+7. Do not add “Made with Cursor” or similar promotional footers to the issue.

--- a/.cursor/commands/github_commands.md
+++ b/.cursor/commands/github_commands.md
@@ -1,0 +1,317 @@
+---
+name: github-commands
+description: "GitHub issue and epic workflow for cuga-agent: list epics, find orphans, add/remove sub-issues via gh."
+trigger: /github
+---
+
+# GitHub commands (`gh`)
+
+Reference for working with **issues**, **epics**, and **sub-issues** in `cuga-project/cuga-agent`.
+
+**Prerequisites**
+
+```bash
+gh auth status          # must be logged in
+gh repo view            # should show cuga-project/cuga-agent
+```
+
+Set defaults once (optional):
+
+```bash
+export REPO=cuga-project/cuga-agent
+export OWNER=cuga-project
+export NAME=cuga-agent
+```
+
+---
+
+## Epics in this repo
+
+Epics are open issues with the label **`type: epic`**. Child work items are linked as **sub-issues** (GitHub parent/child), not only via labels.
+
+```bash
+gh issue list --state open --label "type: epic" --limit 50 \
+  --json number,title,url \
+  --jq '.[] | "#\(.number): \(.title)"'
+```
+
+---
+
+## List sub-issues of an epic
+
+Replace `238` with the epic number:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issue(number: 238) {
+      number
+      title
+      subIssues(first: 50) {
+        nodes { number title url state }
+      }
+    }
+  }
+}' --jq '.data.repository.issue | "#\(.number): \(.title)", (.subIssues.nodes[] | "  #\(.number): \(.title)")'
+```
+
+---
+
+## Find issues without an epic parent
+
+`gh issue list` cannot filter by parent. Use GraphQL:
+
+```bash
+gh api graphql -f query='
+query($cursor: String) {
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issues(first: 100, after: $cursor, states: OPEN) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        title
+        url
+        parent { number title }
+        labels(first: 20) { nodes { name } }
+      }
+    }
+  }
+}' --paginate --jq '
+  [.[] | .data.repository.issues.nodes[] |
+    select(.parent == null) |
+    select([.labels.nodes[].name] | index("type: epic") | not) |
+    "#\(.number): \(.title)"
+  ] | .[]
+'
+```
+
+Issues whose parent has `type: epic` are considered **under an epic**; `parent == null` means no parent at all.
+
+---
+
+## Get issue node IDs (required for sub-issue mutations)
+
+GraphQL mutations use **node IDs** (`I_kwDO...`), not issue numbers.
+
+```bash
+# Single issue
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    issue(number: 238) { id number title }
+  }
+}' --jq '.data.repository.issue'
+
+# Parent + child in one call
+gh api graphql -f query='
+{
+  repository(owner: "cuga-project", name: "cuga-agent") {
+    parent: issue(number: 238) { id number title }
+    child: issue(number: 168) { id number title parent { number } }
+  }
+}' --jq '.data.repository'
+```
+
+---
+
+## Add a sub-issue (link child → epic parent)
+
+**Supported today:** `gh api graphql` + `addSubIssue` mutation.
+
+**Not supported in current `gh issue edit`:** `--set-parent`, `--add-sub-issue` (may arrive in a future CLI release).
+
+**REST note:** `POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues` returned 404 in this repo; prefer GraphQL.
+
+### One child
+
+```bash
+PARENT_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:238) { id } } }
+' --jq '.data.repository.issue.id')
+
+CHILD_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:168) { id } } }
+' --jq '.data.repository.issue.id')
+
+gh api graphql -f query="
+mutation {
+  addSubIssue(input: {
+    issueId: \"$PARENT_ID\"
+    subIssueId: \"$CHILD_ID\"
+  }) {
+    issue { number title }
+    subIssue { number title parent { number } }
+  }
+}"
+```
+
+### Multiple children (batch)
+
+```bash
+PARENT=238
+CHILDREN="168 161 104 202"
+
+PARENT_ID=$(gh api graphql -f query="
+{ repository(owner:\"cuga-project\", name:\"cuga-agent\") { issue(number:$PARENT) { id } } }
+" --jq '.data.repository.issue.id')
+
+for num in $CHILDREN; do
+  CHILD_ID=$(gh api graphql -f query="
+  { repository(owner:\"cuga-project\", name:\"cuga-agent\") { issue(number:$num) { id parent { number } } } }
+  " --jq '.data.repository.issue | "\(.id) \(.parent.number // "none")"')
+
+  id="${CHILD_ID%% *}"
+  existing="${CHILD_ID##* }"
+  if [ "$existing" != "none" ]; then
+    echo "#$num: skip (already parent #$existing)"
+    continue
+  fi
+
+  gh api graphql -f query="
+  mutation {
+    addSubIssue(input: { issueId: \"$PARENT_ID\", subIssueId: \"$id\" }) {
+      subIssue { number parent { number } }
+    }
+  }" --jq ".data.addSubIssue.subIssue | \"#\(.number) -> parent #\(.parent.number)\""
+done
+```
+
+### Verify after linking
+
+```bash
+gh issue view 168 --json number,title,parent --jq '{number, title, parent: .parent}'
+```
+
+Or GraphQL:
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") {
+    issue(number:168) { number title parent { number title } }
+}}' --jq '.data.repository.issue'
+```
+
+---
+
+## Remove a sub-issue (unlink parent)
+
+```bash
+PARENT_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:238) { id } } }
+' --jq '.data.repository.issue.id')
+
+CHILD_ID=$(gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") { issue(number:168) { id } } }
+' --jq '.data.repository.issue.id')
+
+gh api graphql -f query="
+mutation {
+  removeSubIssue(input: {
+    issueId: \"$PARENT_ID\"
+    subIssueId: \"$CHILD_ID\"
+  }) {
+    subIssue { number parent { number } }
+  }
+}"
+```
+
+---
+
+## Create an issue
+
+### Standard (no parent)
+
+```bash
+gh issue create \
+  --title "[Feature]: Example title" \
+  --body "## Summary\n..." \
+  --label "enhancement" \
+  --label "component: agent"
+```
+
+### With issue type (REST — supports `type` field)
+
+```bash
+gh api repos/cuga-project/cuga-agent/issues \
+  -X POST \
+  -f title="[Epic] Example epic" \
+  -f body="## Summary\n..." \
+  -f type="Epic" \
+  -f labels[]="type: epic" \
+  -f labels[]="component: agent" \
+  --jq '{number, html_url}'
+```
+
+Then link children with `addSubIssue` (above). Creating a sub-issue with parent in one step is not documented in `gh issue create` for this CLI version.
+
+---
+
+## Update / close issues
+
+```bash
+gh issue edit 168 --add-label "priority: high"
+gh issue close 168 --comment "Fixed in #..."
+gh api repos/cuga-project/cuga-agent/issues/168 \
+  -X PATCH \
+  -f title="Updated title" \
+  --jq '{number, html_url}'
+```
+
+---
+
+## Epic hygiene (conventions)
+
+| Label / pattern | Meaning |
+|-----------------|--------|
+| `type: epic` | Top-level epic issue |
+| `component: *` | Area (agent, frontend, policies, …) |
+| Sub-issue parent | Epic issue number via GitHub parent link |
+
+**When to parent an issue**
+
+- **Must:** Clear scope match to epic title (e.g. multi-provider work → models epic #238).
+- **Should:** Reasonable fit; alternate epic possible.
+- **Skip:** One-off chores (#78-style cleanup) unless using a Platform Health epic.
+
+**Epics with no children** are planning placeholders until sub-issues are linked.
+
+---
+
+## Example: models epic (#238)
+
+Children linked under [#238 Open Source Models](https://github.com/cuga-project/cuga-agent/issues/238):
+
+- #168, #161, #104, #202, #137, #110
+
+Re-list:
+
+```bash
+gh api graphql -f query='
+{ repository(owner:"cuga-project", name:"cuga-agent") {
+  issue(number:238) { subIssues(first:20) { nodes { number title } } }
+}}' --jq '.data.repository.issue.subIssues.nodes[] | "#\(.number): \(.title)"'
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `Forbidden` on `gh api graphql` | Run outside sandbox / check `gh auth status` |
+| `addSubIssue` succeeds but UI slow | Refresh issue page; parent shows under "Sub-issues" |
+| Child already has parent | `removeSubIssue` first, or skip |
+| `404` on REST `sub_issues` | Use GraphQL `addSubIssue` instead |
+| Need assignee/labels only | `gh issue edit` — no parent flags needed |
+
+---
+
+## Related
+
+- `cuga-new-feature.md` — create feature issues; must pick a parent epic and link via `addSubIssue`
+- `cuga-report-bug.md` — create bug issues; same epic link flow except small self-contained bugs
+- `.agents/skills/github-issues/SKILL.md` — create/update issues, templates, labels
+- `.agents/skills/github-pr-comments/SKILL.md` — PR comments, inline review, batch feedback
+- `.claude/commands/cuga-create-pr.md` — create PRs, then comment with the PR-comments skill
+- User rule: conventional commits; do not commit unless asked

--- a/.cursor/commands/github_commands.md
+++ b/.cursor/commands/github_commands.md
@@ -220,17 +220,18 @@ mutation {
 
 ## Create an issue
 
-### Standard (no parent)
+Agent filing commands require a parent epic (see Related), except small self-contained bugs. After create, link with `addSubIssue` (above). Creating a sub-issue with parent in one step is not supported by `gh issue create` for this CLI version.
 
 ```bash
 gh issue create \
   --title "[Feature]: Example title" \
-  --body "## Summary\n..." \
+  --body "Part of #<epic>.\n\n## Summary\n..." \
   --label "enhancement" \
+  --label "needs-triage" \
   --label "component: agent"
 ```
 
-### With issue type (REST — supports `type` field)
+### Create an epic (REST — supports `type` field)
 
 ```bash
 gh api repos/cuga-project/cuga-agent/issues \
@@ -242,8 +243,6 @@ gh api repos/cuga-project/cuga-agent/issues \
   -f labels[]="component: agent" \
   --jq '{number, html_url}'
 ```
-
-Then link children with `addSubIssue` (above). Creating a sub-issue with parent in one step is not documented in `gh issue create` for this CLI version.
 
 ---
 
@@ -270,28 +269,11 @@ gh api repos/cuga-project/cuga-agent/issues/168 \
 
 **When to parent an issue**
 
-- **Must:** Clear scope match to epic title (e.g. multi-provider work → models epic #238).
-- **Should:** Reasonable fit; alternate epic possible.
-- **Skip:** One-off chores (#78-style cleanup) unless using a Platform Health epic.
+- **Must:** Features, designs, and non-trivial bugs — clear scope match to an open epic.
+- **Ask:** Two or more epics could fit; do not auto-pick.
+- **Skip:** Small self-contained bugs only (narrow repro, no design change). Not chores/features.
 
 **Epics with no children** are planning placeholders until sub-issues are linked.
-
----
-
-## Example: models epic (#238)
-
-Children linked under [#238 Open Source Models](https://github.com/cuga-project/cuga-agent/issues/238):
-
-- #168, #161, #104, #202, #137, #110
-
-Re-list:
-
-```bash
-gh api graphql -f query='
-{ repository(owner:"cuga-project", name:"cuga-agent") {
-  issue(number:238) { subIssues(first:20) { nodes { number title } } }
-}}' --jq '.data.repository.issue.subIssues.nodes[] | "#\(.number): \(.title)"'
-```
 
 ---
 
@@ -311,7 +293,4 @@ gh api graphql -f query='
 
 - `cuga-new-feature.md` — create feature issues; must pick a parent epic and link via `addSubIssue`
 - `cuga-report-bug.md` — create bug issues; same epic link flow except small self-contained bugs
-- `.agents/skills/github-issues/SKILL.md` — create/update issues, templates, labels
-- `.agents/skills/github-pr-comments/SKILL.md` — PR comments, inline review, batch feedback
-- `.claude/commands/cuga-create-pr.md` — create PRs, then comment with the PR-comments skill
-- User rule: conventional commits; do not commit unless asked
+- `cuga-create-pr.md` — create pull requests against upstream

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ logs/
 .bob
 !.bob/commands/
 !.bob/commands/cuga-*.md
+!.bob/commands/github_commands.md
 test_workspace/
 *.logs
 
@@ -81,6 +82,7 @@ cuga.egg-info
 .cursor/
 !.cursor/commands/
 !.cursor/commands/cuga-*.md
+!.cursor/commands/github_commands.md
 
 # Local TLS certs for HTTPS (e.g. IBM Verify)
 deployment/certs/*.key


### PR DESCRIPTION
## Chore

### Summary

Require parent-epic placement when filing issues via agent commands:

- `/cuga-new-feature` must find/confirm an open epic (ask when 2+ match); no filing without a parent
- `/cuga-report-bug` same flow, except small self-contained bugs
- After create, link the issue as a GitHub sub-issue via GraphQL `addSubIssue`
- Add shared `github_commands.md` (`gh` recipes) and allow it in `.gitignore` under `.cursor` / `.bob` commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Issue creation now supports selecting and linking an appropriate open parent epic.
  - Bug reports can be associated with parent epics, with safeguards for ambiguous or missing matches.
  - Selected parent epics are referenced in issue descriptions and linked as sub-issues.

- **Documentation**
  - Added comprehensive guidance for managing issues, epics, and sub-issue relationships through GitHub.
  - Documented discovery, creation, updates, troubleshooting, and parenting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->