### PR TITLE
fix(policy): keep NL conflict fallback matches above threshold

### DIFF
--- a/src/cuga/backend/cuga_graph/policy/agent.py
+++ b/src/cuga/backend/cuga_graph/policy/agent.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.prompts import ChatPromptTemplate
 from loguru import logger
 from pydantic import BaseModel, Field
 
+from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
 from cuga.backend.cuga_graph.policy.models import (
     AlwaysTrigger,
     AppTrigger,
@@ -626,40 +628,22 @@ Provide:
                 policy_types=policy_types,
             )
 
-            messages = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=user_prompt),
-            ]
-
             logger.debug("  - Sending request to LLM for conflict resolution")
             logger.debug(f"    User prompt length: {len(user_prompt)} chars")
             logger.debug(f"    Number of policies in prompt: {len(policies_with_nl_triggers)}")
 
-            # Use structured output for reliable JSON parsing.
-            # method="json_schema" (matching OutputFormatter in enactment.py) is enforced
-            # server-side by IBM Watsonx. The default (function_calling) returns None on
-            # gpt-oss-120b when it emits no tool call, which raised AttributeError below and
-            # silently dropped the policy match.
-            # Retry once on parse failures — intermittent empty/invalid JSON is a known flake.
-            structured_llm = self.llm.with_structured_output(PolicyConflictResolution, method="json_schema")
-            result: Optional[PolicyConflictResolution] = None
-            last_error: Optional[Exception] = None
-            for attempt in range(2):
-                try:
-                    result = await structured_llm.ainvoke(messages)
-                    break
-                except Exception as e:
-                    last_error = e
-                    if attempt == 0:
-                        logger.warning(
-                            f"⚠️  LLM conflict resolution attempt {attempt + 1} failed "
-                            f"({type(e).__name__}: {e}); retrying once"
-                        )
-                        continue
-                    raise
-
-            if result is None:
-                raise last_error or RuntimeError("LLM conflict resolution returned no result")
+            # Reuse BaseAgent structured-output chain: json_schema with json_mode
+            # fallback on missing parsed/refusal, plus with_retry(stop_after_attempt=3).
+            prompt_template = ChatPromptTemplate.from_messages(
+                [
+                    ("system", system_prompt),
+                    ("human", "{user_prompt}"),
+                ]
+            )
+            chain = BaseAgent.get_chain(prompt_template, self.llm, PolicyConflictResolution)
+            result = await chain.ainvoke({"user_prompt": user_prompt})
+            if isinstance(result, dict):
+                result = PolicyConflictResolution(**result)
 
             logger.debug("  - Received structured LLM response:")
             logger.debug(f"    - matched_policy_index: {result.matched_policy_index}")

--- a/src/cuga/backend/cuga_graph/policy/agent.py
+++ b/src/cuga/backend/cuga_graph/policy/agent.py
@@ -518,16 +518,20 @@ Which policy (if any) best matches the context above?"""
 Which policy (if any) best matches the user's intent?"""
 
     @staticmethod
-    def _fallback_confidence(nl_triggers: List[NaturalLanguageTrigger]) -> float:
-        """Confidence for non-LLM fallback selection.
+    def _min_nl_threshold(nl_triggers: List[NaturalLanguageTrigger]) -> float:
+        """Minimum NL threshold across triggers (most strict gate)."""
+        return min(t.threshold for t in nl_triggers)
 
-        Must be >= the policy's NL threshold, otherwise
-        ``_evaluate_natural_language_policies`` discards the fallback match.
+    @staticmethod
+    def _fallback_confidence(nl_triggers: List[NaturalLanguageTrigger]) -> float:
+        """Gate-clearing confidence for non-LLM fallback selection.
+
+        Not an estimated match-quality score: exactly the policy's minimum NL
+        threshold so ``_evaluate_natural_language_policies`` keeps the match.
+        Lower thresholds therefore yield lower fallback confidence and can lose
+        to higher-confidence keyword matches in ``match_policy`` — intentional.
         """
-        thresholds = [t.threshold for t in nl_triggers if hasattr(t, "threshold")]
-        if thresholds:
-            return min(thresholds)
-        return 0.5
+        return PolicyAgent._min_nl_threshold(nl_triggers)
 
     async def _resolve_nl_trigger_conflicts(
         self,
@@ -541,7 +545,10 @@ Which policy (if any) best matches the user's intent?"""
         Use LLM to resolve conflicts when multiple policies have Natural Language triggers.
 
         Args:
-            policies_with_nl_triggers: List of (policy, nl_triggers) tuples
+            policies_with_nl_triggers: List of (policy, nl_triggers) tuples. Order is
+                embedding/priority-sorted only when embeddings are configured and
+                search succeeds; otherwise storage order. Exception fallback uses
+                index 0 of this list — not guaranteed to be the semantic best.
             context: Current context
             target: Target field being evaluated (e.g., "intent", "agent_response")
             target_text: The actual text from the target field (includes combined user input + agent response for agent_response)
@@ -566,23 +573,8 @@ Which policy (if any) best matches the user's intent?"""
             logger.debug(f"       Description: {policy.description[:100]}...")
             logger.debug(f"       NL Triggers: {[t.value for t in nl_triggers]}")
 
+        # Production callers already return before invoking when llm/query is missing.
         if not self.llm or not query_text:
-            # Fallback: return first policy
-            logger.warning("⚠️  Cannot use LLM conflict resolution:")
-            logger.warning(f"    - LLM available: {self.llm is not None}")
-            logger.warning(f"    - Query text available: {query_text is not None}")
-            if policies_with_nl_triggers:
-                policy, triggers = policies_with_nl_triggers[0]
-                confidence = self._fallback_confidence(triggers)
-                logger.debug(
-                    f"  - Falling back to first policy: '{policy.name}' (confidence={confidence:.2f})"
-                )
-                return (
-                    policy,
-                    confidence,
-                    "No LLM or query text available for conflict resolution, using first policy",
-                )
-            logger.debug("  - No policies to resolve, returning None")
             return None
 
         try:
@@ -632,8 +624,10 @@ Provide:
             logger.debug(f"    User prompt length: {len(user_prompt)} chars")
             logger.debug(f"    Number of policies in prompt: {len(policies_with_nl_triggers)}")
 
-            # Reuse BaseAgent structured-output chain: json_schema with json_mode
-            # fallback on missing parsed/refusal, plus with_retry(stop_after_attempt=3).
+            # BaseAgent.get_chain: structured parse + retry for OpenAI/Groq/Watsonx
+            # response_format paths. ChatOpenAI models with "GCP"/"Claude" in the
+            # name return an unparsed chain and land in the exception fallback
+            # below (nothing we ship uses that path for policy matching today).
             prompt_template = ChatPromptTemplate.from_messages(
                 [
                     ("system", system_prompt),
@@ -657,22 +651,18 @@ Provide:
             if matched_index and 1 <= matched_index <= len(policies_with_nl_triggers):
                 policy, nl_triggers = policies_with_nl_triggers[matched_index - 1]
 
-                # Validate confidence against threshold(s) from the selected policy's triggers
-                # Use minimum threshold (most strict) if multiple triggers exist
-                thresholds = [trigger.threshold for trigger in nl_triggers if hasattr(trigger, 'threshold')]
-                if thresholds:
-                    min_threshold = min(thresholds)
-                    if confidence < min_threshold:
-                        logger.info(
-                            f"❌ LLM conflict resolution confidence ({confidence:.2f}) "
-                            f"below threshold ({min_threshold:.2f}) for policy '{policy.name}'"
-                        )
-                        logger.debug(
-                            f"    - Confidence: {confidence:.2f}, Threshold: {min_threshold:.2f}, "
-                            f"Policy: {policy.name}"
-                        )
-                        return None
-                    logger.debug(f"    - Confidence {confidence:.2f} meets threshold {min_threshold:.2f}")
+                min_threshold = self._min_nl_threshold(nl_triggers)
+                if confidence < min_threshold:
+                    logger.info(
+                        f"❌ LLM conflict resolution confidence ({confidence:.2f}) "
+                        f"below threshold ({min_threshold:.2f}) for policy '{policy.name}'"
+                    )
+                    logger.debug(
+                        f"    - Confidence: {confidence:.2f}, Threshold: {min_threshold:.2f}, "
+                        f"Policy: {policy.name}"
+                    )
+                    return None
+                logger.debug(f"    - Confidence {confidence:.2f} meets threshold {min_threshold:.2f}")
 
                 logger.info(
                     f"✅ LLM resolved conflict: selected '{policy.name}' (confidence: {confidence:.2f})"
@@ -691,8 +681,11 @@ Provide:
             import traceback
 
             logger.debug(f"    - Traceback: {traceback.format_exc()}")
-            # Fallback: return first policy with confidence that still clears its threshold.
-            # Hardcoded 0.5 previously caused matches to be discarded when threshold is 0.7 (#577).
+            # Intentional: on LLM/parse failure, prefer first candidate over no match.
+            # A successful LLM "no match" or below-threshold result still returns None,
+            # so a parse error is more likely to trigger a policy than a working model
+            # that rejects — same first-policy fallback as before #577; only confidence
+            # now clears the shared threshold helper instead of a hardcoded 0.5.
             if policies_with_nl_triggers:
                 policy, triggers = policies_with_nl_triggers[0]
                 confidence = self._fallback_confidence(triggers)
@@ -895,27 +888,21 @@ Provide:
             and (t.target == target or (target == "intent" and t.target in ("intent", "user_input")))
         ]
 
-        # Validate confidence against threshold(s) from the policy's NL triggers
-        # Use minimum threshold (most strict) if multiple triggers exist
         if nl_triggers_for_policy:
-            thresholds = [
-                trigger.threshold for trigger in nl_triggers_for_policy if hasattr(trigger, 'threshold')
-            ]
-            if thresholds:
-                min_threshold = min(thresholds)
-                if confidence < min_threshold:
-                    logger.info(
-                        f"❌ LLM conflict resolution confidence ({confidence:.2f}) "
-                        f"below threshold ({min_threshold:.2f}) for policy '{resolved_policy.name}'"
-                    )
-                    logger.debug(
-                        f"    - Confidence: {confidence:.2f}, Threshold: {min_threshold:.2f}, "
-                        f"Policy: {resolved_policy.name}"
-                    )
-                    return None
-                logger.debug(
-                    f"✅ Confidence {confidence:.2f} meets threshold {min_threshold:.2f} for policy '{resolved_policy.name}'"
+            min_threshold = self._min_nl_threshold(nl_triggers_for_policy)
+            if confidence < min_threshold:
+                logger.info(
+                    f"❌ LLM conflict resolution confidence ({confidence:.2f}) "
+                    f"below threshold ({min_threshold:.2f}) for policy '{resolved_policy.name}'"
                 )
+                logger.debug(
+                    f"    - Confidence: {confidence:.2f}, Threshold: {min_threshold:.2f}, "
+                    f"Policy: {resolved_policy.name}"
+                )
+                return None
+            logger.debug(
+                f"✅ Confidence {confidence:.2f} meets threshold {min_threshold:.2f} for policy '{resolved_policy.name}'"
+            )
 
         all_matched, full_confidence, trigger_details = await self._check_policy_triggers(
             resolved_policy, context, skip_nl_triggers=True
@@ -925,20 +912,15 @@ Provide:
             logger.debug(f"Resolved policy '{resolved_policy.name}' did not match all non-NL triggers")
             return None
 
-        # Final confidence must also meet the threshold
         final_confidence = max(confidence, full_confidence)
         if nl_triggers_for_policy:
-            thresholds = [
-                trigger.threshold for trigger in nl_triggers_for_policy if hasattr(trigger, 'threshold')
-            ]
-            if thresholds:
-                min_threshold = min(thresholds)
-                if final_confidence < min_threshold:
-                    logger.info(
-                        f"❌ Final confidence ({final_confidence:.2f}) "
-                        f"below threshold ({min_threshold:.2f}) for policy '{resolved_policy.name}'"
-                    )
-                    return None
+            min_threshold = self._min_nl_threshold(nl_triggers_for_policy)
+            if final_confidence < min_threshold:
+                logger.info(
+                    f"❌ Final confidence ({final_confidence:.2f}) "
+                    f"below threshold ({min_threshold:.2f}) for policy '{resolved_policy.name}'"
+                )
+                return None
 
         final_reasoning = f"NL-triggered policy (LLM-validated): {reasoning}"
 

--- a/src/cuga/backend/cuga_graph/policy/agent.py
+++ b/src/cuga/backend/cuga_graph/policy/agent.py
@@ -515,6 +515,18 @@ Which policy (if any) best matches the context above?"""
 
 Which policy (if any) best matches the user's intent?"""
 
+    @staticmethod
+    def _fallback_confidence(nl_triggers: List[NaturalLanguageTrigger]) -> float:
+        """Confidence for non-LLM fallback selection.
+
+        Must be >= the policy's NL threshold, otherwise
+        ``_evaluate_natural_language_policies`` discards the fallback match.
+        """
+        thresholds = [t.threshold for t in nl_triggers if hasattr(t, "threshold")]
+        if thresholds:
+            return min(thresholds)
+        return 0.5
+
     async def _resolve_nl_trigger_conflicts(
         self,
         policies_with_nl_triggers: List[tuple[Policy, List[NaturalLanguageTrigger]]],
@@ -559,10 +571,13 @@ Which policy (if any) best matches the user's intent?"""
             logger.warning(f"    - Query text available: {query_text is not None}")
             if policies_with_nl_triggers:
                 policy, triggers = policies_with_nl_triggers[0]
-                logger.debug(f"  - Falling back to first policy: '{policy.name}'")
+                confidence = self._fallback_confidence(triggers)
+                logger.debug(
+                    f"  - Falling back to first policy: '{policy.name}' (confidence={confidence:.2f})"
+                )
                 return (
                     policy,
-                    0.5,
+                    confidence,
                     "No LLM or query text available for conflict resolution, using first policy",
                 )
             logger.debug("  - No policies to resolve, returning None")
@@ -625,8 +640,26 @@ Provide:
             # server-side by IBM Watsonx. The default (function_calling) returns None on
             # gpt-oss-120b when it emits no tool call, which raised AttributeError below and
             # silently dropped the policy match.
+            # Retry once on parse failures — intermittent empty/invalid JSON is a known flake.
             structured_llm = self.llm.with_structured_output(PolicyConflictResolution, method="json_schema")
-            result: PolicyConflictResolution = await structured_llm.ainvoke(messages)
+            result: Optional[PolicyConflictResolution] = None
+            last_error: Optional[Exception] = None
+            for attempt in range(2):
+                try:
+                    result = await structured_llm.ainvoke(messages)
+                    break
+                except Exception as e:
+                    last_error = e
+                    if attempt == 0:
+                        logger.warning(
+                            f"⚠️  LLM conflict resolution attempt {attempt + 1} failed "
+                            f"({type(e).__name__}: {e}); retrying once"
+                        )
+                        continue
+                    raise
+
+            if result is None:
+                raise last_error or RuntimeError("LLM conflict resolution returned no result")
 
             logger.debug("  - Received structured LLM response:")
             logger.debug(f"    - matched_policy_index: {result.matched_policy_index}")
@@ -674,11 +707,13 @@ Provide:
             import traceback
 
             logger.debug(f"    - Traceback: {traceback.format_exc()}")
-            # Fallback: return first policy
+            # Fallback: return first policy with confidence that still clears its threshold.
+            # Hardcoded 0.5 previously caused matches to be discarded when threshold is 0.7 (#577).
             if policies_with_nl_triggers:
-                policy, _ = policies_with_nl_triggers[0]
-                logger.debug(f"    - Falling back to first policy: '{policy.name}'")
-                return policy, 0.5, f"Error in conflict resolution, using first policy: {e}"
+                policy, triggers = policies_with_nl_triggers[0]
+                confidence = self._fallback_confidence(triggers)
+                logger.warning(f"Falling back to first policy: '{policy.name}' (confidence={confidence:.2f})")
+                return policy, confidence, f"Error in conflict resolution, using first policy: {e}"
             logger.debug("    - No policies available for fallback, returning None")
             return None
 

--- a/src/cuga/backend/cuga_graph/policy/tests/test_nl_trigger_conflict_fallback.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/test_nl_trigger_conflict_fallback.py
@@ -1,8 +1,9 @@
 """Unit tests: NL conflict-resolution fallback must still produce a policy match."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from langchain_core.exceptions import OutputParserException
-from unittest.mock import AsyncMock, MagicMock
 
 from cuga.backend.cuga_graph.policy.agent import (
     PolicyAgent,
@@ -31,12 +32,13 @@ def _playbook() -> Playbook:
     )
 
 
-def _llm_with_structured(side_effect_or_result):
-    structured = MagicMock()
-    structured.ainvoke = AsyncMock(side_effect=side_effect_or_result)
-    llm = MagicMock()
-    llm.with_structured_output = MagicMock(return_value=structured)
-    return llm, structured
+def _chain_mock(*, return_value=None, side_effect=None):
+    chain = MagicMock()
+    if side_effect is not None:
+        chain.ainvoke = AsyncMock(side_effect=side_effect)
+    else:
+        chain.ainvoke = AsyncMock(return_value=return_value)
+    return chain
 
 
 @pytest.mark.unit
@@ -54,23 +56,28 @@ async def test_conflict_resolution_error_fallback_meets_threshold():
         playbook = _playbook()
         await storage.add_policy(playbook)
 
-        llm, structured = _llm_with_structured(
-            OutputParserException("Invalid json output:\nOUTPUT_PARSING_FAILURE")
-        )
-        agent = PolicyAgent(storage=storage, llm=llm, embedding_function=None)
+        agent = PolicyAgent(storage=storage, llm=MagicMock(), embedding_function=None)
         context = PolicyContext(
             user_input="get my daughter's claims",
             chat_messages=[],
             sub_task="",
             agent_response="",
         )
+        chain = _chain_mock(side_effect=OutputParserException("Invalid json output:\nOUTPUT_PARSING_FAILURE"))
 
-        resolution = await agent._resolve_nl_trigger_conflicts(
-            [(playbook, playbook.triggers)],
-            context,
-            target="intent",
-            target_text=context.user_input,
-        )
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ) as get_chain:
+            resolution = await agent._resolve_nl_trigger_conflicts(
+                [(playbook, playbook.triggers)],
+                context,
+                target="intent",
+                target_text=context.user_input,
+            )
+            get_chain.assert_called_once()
+            assert get_chain.call_args.args[2] is PolicyConflictResolution
+
         assert resolution is not None, "Fallback should select first policy on LLM parse error"
         resolved_policy, confidence, reasoning = resolution
         assert resolved_policy.name == "Family Healthcare Plan Navigation"
@@ -78,9 +85,12 @@ async def test_conflict_resolution_error_fallback_meets_threshold():
             f"Fallback confidence {confidence} must meet trigger threshold 0.7 "
             f"(otherwise evaluate path rejects the match). Reasoning: {reasoning}"
         )
-        assert structured.ainvoke.await_count == 2, "Should retry once before falling back"
 
-        evaluated = await agent._evaluate_natural_language_policies("intent", context)
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ):
+            evaluated = await agent._evaluate_natural_language_policies("intent", context)
         assert evaluated is not None, (
             "NL evaluation must match after conflict-resolution parse failure "
             "(fallback was discarding matches with confidence 0.5 < threshold 0.7)"
@@ -94,9 +104,9 @@ async def test_conflict_resolution_error_fallback_meets_threshold():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_conflict_resolution_retries_then_succeeds():
-    """Parse failure on first attempt should retry and accept a valid second response."""
-    storage = PolicyStorage(collection_name="test_nl_conflict_retry")
+async def test_conflict_resolution_uses_base_agent_chain_result():
+    """Successful BaseAgent.get_chain structured output is used as the match."""
+    storage = PolicyStorage(collection_name="test_nl_conflict_chain_ok")
     await storage.initialize_async()
 
     try:
@@ -108,31 +118,33 @@ async def test_conflict_resolution_retries_then_succeeds():
             confidence=0.9,
             reasoning="Matches family claims playbook",
         )
-        llm, structured = _llm_with_structured(
-            [
-                OutputParserException("Invalid json output:\nOUTPUT_PARSING_FAILURE"),
-                success,
-            ]
-        )
-        agent = PolicyAgent(storage=storage, llm=llm, embedding_function=None)
+        agent = PolicyAgent(storage=storage, llm=MagicMock(), embedding_function=None)
         context = PolicyContext(
             user_input="get my daughter's claims",
             chat_messages=[],
             sub_task="",
             agent_response="",
         )
+        chain = _chain_mock(return_value=success)
 
-        resolution = await agent._resolve_nl_trigger_conflicts(
-            [(playbook, playbook.triggers)],
-            context,
-            target="intent",
-            target_text=context.user_input,
-        )
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ) as get_chain:
+            resolution = await agent._resolve_nl_trigger_conflicts(
+                [(playbook, playbook.triggers)],
+                context,
+                target="intent",
+                target_text=context.user_input,
+            )
+            get_chain.assert_called_once()
+            assert get_chain.call_args.args[2] is PolicyConflictResolution
+
         assert resolution is not None
         resolved_policy, confidence, reasoning = resolution
         assert resolved_policy.name == "Family Healthcare Plan Navigation"
         assert confidence == 0.9
         assert "LLM conflict resolution" in reasoning
-        assert structured.ainvoke.await_count == 2
+        chain.ainvoke.assert_awaited_once()
     finally:
         await storage.disconnect()

--- a/src/cuga/backend/cuga_graph/policy/tests/test_nl_trigger_conflict_fallback.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/test_nl_trigger_conflict_fallback.py
@@ -14,18 +14,25 @@ from cuga.backend.cuga_graph.policy.models import NaturalLanguageTrigger, Playbo
 from cuga.backend.cuga_graph.policy.storage import PolicyStorage
 
 
-def _playbook() -> Playbook:
-    return Playbook(
-        id="playbook_family_claims",
-        name="Family Healthcare Plan Navigation",
-        description="Guide for navigating family healthcare plans and claims",
-        triggers=[
+def _playbook(
+    *,
+    playbook_id: str = "playbook_family_claims",
+    name: str = "Family Healthcare Plan Navigation",
+    triggers: list[NaturalLanguageTrigger] | None = None,
+) -> Playbook:
+    if triggers is None:
+        triggers = [
             NaturalLanguageTrigger(
                 value=["get my daughter's claims", "family member claims"],
                 target="intent",
                 threshold=0.7,
             ),
-        ],
+        ]
+    return Playbook(
+        id=playbook_id,
+        name=name,
+        description="Guide for navigating family healthcare plans and claims",
+        triggers=triggers,
         markdown_content="# Family Healthcare Plan Navigation\n\nUse get_plan then get_claims.",
         priority=50,
         enabled=True,
@@ -39,6 +46,21 @@ def _chain_mock(*, return_value=None, side_effect=None):
     else:
         chain.ainvoke = AsyncMock(return_value=return_value)
     return chain
+
+
+def _parse_error_chain():
+    return _chain_mock(side_effect=OutputParserException("Invalid json output:\nOUTPUT_PARSING_FAILURE"))
+
+
+@pytest.mark.unit
+def test_min_nl_threshold_uses_strictest_trigger():
+    triggers = [
+        NaturalLanguageTrigger(value=["a"], target="intent", threshold=0.8),
+        NaturalLanguageTrigger(value=["b"], target="intent", threshold=0.3),
+        NaturalLanguageTrigger(value=["c"], target="agent_response", threshold=0.9),
+    ]
+    assert PolicyAgent._min_nl_threshold(triggers) == 0.3
+    assert PolicyAgent._fallback_confidence(triggers) == 0.3
 
 
 @pytest.mark.unit
@@ -63,7 +85,7 @@ async def test_conflict_resolution_error_fallback_meets_threshold():
             sub_task="",
             agent_response="",
         )
-        chain = _chain_mock(side_effect=OutputParserException("Invalid json output:\nOUTPUT_PARSING_FAILURE"))
+        chain = _parse_error_chain()
 
         with patch(
             "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
@@ -100,6 +122,239 @@ async def test_conflict_resolution_error_fallback_meets_threshold():
         assert match_confidence >= 0.7
     finally:
         await storage.disconnect()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conflict_resolution_fallback_uses_min_of_multiple_triggers():
+    """Fallback confidence is min(threshold) across multiple NL triggers on one policy."""
+    storage = PolicyStorage(collection_name="test_nl_conflict_multi_trigger")
+    await storage.initialize_async()
+
+    try:
+        playbook = _playbook(
+            triggers=[
+                NaturalLanguageTrigger(
+                    value=["family member claims"],
+                    target="intent",
+                    threshold=0.8,
+                ),
+                NaturalLanguageTrigger(
+                    value=["daughter claims"],
+                    target="intent",
+                    threshold=0.6,
+                ),
+            ]
+        )
+        await storage.add_policy(playbook)
+        agent = PolicyAgent(storage=storage, llm=MagicMock(), embedding_function=None)
+        context = PolicyContext(
+            user_input="get my daughter's claims",
+            chat_messages=[],
+            sub_task="",
+            agent_response="",
+        )
+        chain = _parse_error_chain()
+        intent_triggers = [t for t in playbook.triggers if t.target == "intent"]
+
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ):
+            resolution = await agent._resolve_nl_trigger_conflicts(
+                [(playbook, intent_triggers)],
+                context,
+                target="intent",
+                target_text=context.user_input,
+            )
+
+        assert resolution is not None
+        _, confidence, _ = resolution
+        assert confidence == 0.6
+
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ):
+            evaluated = await agent._evaluate_natural_language_policies("intent", context)
+        assert evaluated is not None
+        _, match_confidence, _, _ = evaluated
+        assert match_confidence == 0.6
+    finally:
+        await storage.disconnect()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conflict_resolution_fallback_threshold_below_half():
+    """Thresholds under 0.5 produce fallback confidence under 0.5 (clears that gate)."""
+    storage = PolicyStorage(collection_name="test_nl_conflict_low_threshold")
+    await storage.initialize_async()
+
+    try:
+        playbook = _playbook(
+            triggers=[
+                NaturalLanguageTrigger(
+                    value=["family member claims"],
+                    target="intent",
+                    threshold=0.8,
+                ),
+                NaturalLanguageTrigger(
+                    value=["loose match"],
+                    target="intent",
+                    threshold=0.3,
+                ),
+            ]
+        )
+        await storage.add_policy(playbook)
+        agent = PolicyAgent(storage=storage, llm=MagicMock(), embedding_function=None)
+        context = PolicyContext(
+            user_input="get my daughter's claims",
+            chat_messages=[],
+            sub_task="",
+            agent_response="",
+        )
+        chain = _parse_error_chain()
+
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ):
+            resolution = await agent._resolve_nl_trigger_conflicts(
+                [(playbook, playbook.triggers)],
+                context,
+                target="intent",
+                target_text=context.user_input,
+            )
+            evaluated = await agent._evaluate_natural_language_policies("intent", context)
+
+        assert resolution is not None
+        _, confidence, _ = resolution
+        assert confidence == 0.3
+        assert evaluated is not None
+        _, match_confidence, _, _ = evaluated
+        assert match_confidence == 0.3
+    finally:
+        await storage.disconnect()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conflict_resolution_fallback_filters_by_target():
+    """Evaluate path only applies thresholds for triggers matching the target."""
+    storage = PolicyStorage(collection_name="test_nl_conflict_mixed_targets")
+    await storage.initialize_async()
+
+    try:
+        playbook = _playbook(
+            triggers=[
+                NaturalLanguageTrigger(
+                    value=["family member claims"],
+                    target="intent",
+                    threshold=0.55,
+                ),
+                NaturalLanguageTrigger(
+                    value=["format claims response"],
+                    target="agent_response",
+                    threshold=0.95,
+                ),
+            ]
+        )
+        await storage.add_policy(playbook)
+        agent = PolicyAgent(storage=storage, llm=MagicMock(), embedding_function=None)
+        context = PolicyContext(
+            user_input="get my daughter's claims",
+            chat_messages=[],
+            sub_task="",
+            agent_response="",
+        )
+        chain = _parse_error_chain()
+
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ):
+            evaluated = await agent._evaluate_natural_language_policies("intent", context)
+
+        assert evaluated is not None
+        _, match_confidence, _, _ = evaluated
+        assert match_confidence == 0.55
+    finally:
+        await storage.disconnect()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conflict_resolution_fallback_uses_first_of_multiple_policies():
+    """On parse error, fallback selects index 0 of the candidate list."""
+    storage = PolicyStorage(collection_name="test_nl_conflict_multi_policy")
+    await storage.initialize_async()
+
+    try:
+        first = _playbook(
+            playbook_id="playbook_first",
+            name="First Playbook",
+            triggers=[
+                NaturalLanguageTrigger(value=["first intent"], target="intent", threshold=0.65),
+            ],
+        )
+        second = _playbook(
+            playbook_id="playbook_second",
+            name="Second Playbook",
+            triggers=[
+                NaturalLanguageTrigger(value=["second intent"], target="intent", threshold=0.9),
+            ],
+        )
+        await storage.add_policy(first)
+        await storage.add_policy(second)
+        agent = PolicyAgent(storage=storage, llm=MagicMock(), embedding_function=None)
+        context = PolicyContext(
+            user_input="ambiguous request",
+            chat_messages=[],
+            sub_task="",
+            agent_response="",
+        )
+        chain = _parse_error_chain()
+        candidates = [(first, first.triggers), (second, second.triggers)]
+
+        with patch(
+            "cuga.backend.cuga_graph.policy.agent.BaseAgent.get_chain",
+            return_value=chain,
+        ):
+            resolution = await agent._resolve_nl_trigger_conflicts(
+                candidates,
+                context,
+                target="intent",
+                target_text=context.user_input,
+            )
+
+        assert resolution is not None
+        resolved_policy, confidence, _ = resolution
+        assert resolved_policy.name == "First Playbook"
+        assert confidence == 0.65
+    finally:
+        await storage.disconnect()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conflict_resolution_no_llm_returns_none():
+    """Defensive early exit: no llm / no query text does not invent a match."""
+    agent = PolicyAgent(storage=MagicMock(), llm=None, embedding_function=None)
+    playbook = _playbook()
+    context = PolicyContext(
+        user_input="get my daughter's claims",
+        chat_messages=[],
+        sub_task="",
+        agent_response="",
+    )
+    resolution = await agent._resolve_nl_trigger_conflicts(
+        [(playbook, playbook.triggers)],
+        context,
+        target="intent",
+        target_text=context.user_input,
+    )
+    assert resolution is None
 
 
 @pytest.mark.unit

--- a/src/cuga/backend/cuga_graph/policy/tests/test_nl_trigger_conflict_fallback.py
+++ b/src/cuga/backend/cuga_graph/policy/tests/test_nl_trigger_conflict_fallback.py
@@ -1,0 +1,138 @@
+"""Unit tests: NL conflict-resolution fallback must still produce a policy match."""
+
+import pytest
+from langchain_core.exceptions import OutputParserException
+from unittest.mock import AsyncMock, MagicMock
+
+from cuga.backend.cuga_graph.policy.agent import (
+    PolicyAgent,
+    PolicyConflictResolution,
+    PolicyContext,
+)
+from cuga.backend.cuga_graph.policy.models import NaturalLanguageTrigger, Playbook
+from cuga.backend.cuga_graph.policy.storage import PolicyStorage
+
+
+def _playbook() -> Playbook:
+    return Playbook(
+        id="playbook_family_claims",
+        name="Family Healthcare Plan Navigation",
+        description="Guide for navigating family healthcare plans and claims",
+        triggers=[
+            NaturalLanguageTrigger(
+                value=["get my daughter's claims", "family member claims"],
+                target="intent",
+                threshold=0.7,
+            ),
+        ],
+        markdown_content="# Family Healthcare Plan Navigation\n\nUse get_plan then get_claims.",
+        priority=50,
+        enabled=True,
+    )
+
+
+def _llm_with_structured(side_effect_or_result):
+    structured = MagicMock()
+    structured.ainvoke = AsyncMock(side_effect=side_effect_or_result)
+    llm = MagicMock()
+    llm.with_structured_output = MagicMock(return_value=structured)
+    return llm, structured
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conflict_resolution_error_fallback_meets_threshold():
+    """
+    When LLM conflict resolution fails to parse JSON, fallback selects the first
+    policy. That selection must use confidence >= the policy's NL threshold so
+    _evaluate_natural_language_policies does not discard it (issue #577).
+    """
+    storage = PolicyStorage(collection_name="test_nl_conflict_fallback")
+    await storage.initialize_async()
+
+    try:
+        playbook = _playbook()
+        await storage.add_policy(playbook)
+
+        llm, structured = _llm_with_structured(
+            OutputParserException("Invalid json output:\nOUTPUT_PARSING_FAILURE")
+        )
+        agent = PolicyAgent(storage=storage, llm=llm, embedding_function=None)
+        context = PolicyContext(
+            user_input="get my daughter's claims",
+            chat_messages=[],
+            sub_task="",
+            agent_response="",
+        )
+
+        resolution = await agent._resolve_nl_trigger_conflicts(
+            [(playbook, playbook.triggers)],
+            context,
+            target="intent",
+            target_text=context.user_input,
+        )
+        assert resolution is not None, "Fallback should select first policy on LLM parse error"
+        resolved_policy, confidence, reasoning = resolution
+        assert resolved_policy.name == "Family Healthcare Plan Navigation"
+        assert confidence >= 0.7, (
+            f"Fallback confidence {confidence} must meet trigger threshold 0.7 "
+            f"(otherwise evaluate path rejects the match). Reasoning: {reasoning}"
+        )
+        assert structured.ainvoke.await_count == 2, "Should retry once before falling back"
+
+        evaluated = await agent._evaluate_natural_language_policies("intent", context)
+        assert evaluated is not None, (
+            "NL evaluation must match after conflict-resolution parse failure "
+            "(fallback was discarding matches with confidence 0.5 < threshold 0.7)"
+        )
+        matched_policy, match_confidence, _, _ = evaluated
+        assert matched_policy.name == "Family Healthcare Plan Navigation"
+        assert match_confidence >= 0.7
+    finally:
+        await storage.disconnect()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_conflict_resolution_retries_then_succeeds():
+    """Parse failure on first attempt should retry and accept a valid second response."""
+    storage = PolicyStorage(collection_name="test_nl_conflict_retry")
+    await storage.initialize_async()
+
+    try:
+        playbook = _playbook()
+        await storage.add_policy(playbook)
+
+        success = PolicyConflictResolution(
+            matched_policy_index=1,
+            confidence=0.9,
+            reasoning="Matches family claims playbook",
+        )
+        llm, structured = _llm_with_structured(
+            [
+                OutputParserException("Invalid json output:\nOUTPUT_PARSING_FAILURE"),
+                success,
+            ]
+        )
+        agent = PolicyAgent(storage=storage, llm=llm, embedding_function=None)
+        context = PolicyContext(
+            user_input="get my daughter's claims",
+            chat_messages=[],
+            sub_task="",
+            agent_response="",
+        )
+
+        resolution = await agent._resolve_nl_trigger_conflicts(
+            [(playbook, playbook.triggers)],
+            context,
+            target="intent",
+            target_text=context.user_input,
+        )
+        assert resolution is not None
+        resolved_policy, confidence, reasoning = resolution
+        assert resolved_policy.name == "Family Healthcare Plan Navigation"
+        assert confidence == 0.9
+        assert "LLM conflict resolution" in reasoning
+        assert structured.ainvoke.await_count == 2
+    finally:
+        await storage.disconnect()


### PR DESCRIPTION
## Bug fix

Fixes #577

### Summary
NL conflict-resolution fallback after LLM JSON parse failures used hardcoded confidence `0.5`. Policies with threshold `0.7` (e.g. healthcare family-claims playbook) were then discarded by `_evaluate_natural_language_policies`, so CI logged “Falling back to first policy” but `policy_matched` stayed missing.

- Fall back with confidence that clears the selected policy’s NL threshold
- Retry structured-output once before falling back
- Add unit coverage for fallback + retry paths

### Testing
- [x] Verified fix locally; tests pass
  - `uv run pytest src/cuga/backend/cuga_graph/policy/tests/test_nl_trigger_conflict_fallback.py test_keyword_operator.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy conflict resolution with reliable structured-response retries.
  * Fallback decisions now use configured natural-language trigger thresholds for more accurate confidence handling.
  * Preserved valid policy matches during fallback evaluation, including when multiple candidates are available.
  * Improved handling when no language model is available or a response cannot be parsed.

* **Tests**
  * Added coverage for threshold calculations, candidate filtering, fallback selection, retry behavior, and successful structured responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->