### PR TITLE
fix: disable agent_spawn by default

### DIFF
--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -79,7 +79,8 @@ sandbox_mode = "native"
 [agent_spawn]
 # When false, sub-agent spawning via spawn_agent / get_agent_result is fully disabled.
 # Zero overhead in prompt, tools, and timing when disabled (NFR-1).
-enabled = true
+# Opt-in: set enabled = true (or DYNACONF_AGENT_SPAWN__ENABLED=true) to enable.
+enabled = false
 max_spawn_depth = 2
 forward_sync_subagent_events = true
 

--- a/tests/unit/test_agent_spawn.py
+++ b/tests/unit/test_agent_spawn.py
@@ -42,6 +42,7 @@ def _get_prompt_template():
 def test_agent_spawn_defaults():
     from cuga.config import settings
 
+    assert settings.agent_spawn.enabled is False
     assert settings.agent_spawn.max_spawn_depth == 2
     assert settings.agent_spawn.forward_sync_subagent_events is True
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug fix

No linked issue.

### Summary

`DYNACONF_AGENT_SPAWN__ENABLED` / `[agent_spawn].enabled` controls general-purpose sub-agent spawning (`spawn_agent` / `get_agent_result`). It was enabled in `settings.toml` while the dynaconf validator default was already `False`.

This PR turns the shipped default off so the feature is opt-in (`enabled = true` or `DYNACONF_AGENT_SPAWN__ENABLED=true`). Also asserts the default in the unit test.

No other tests depend on the setting being enabled: the only suite that covers this feature (`tests/unit/test_agent_spawn.py`) either asserts `enabled is False`, exercises runtime/tools directly, or passes `agents_enabled=True` as an explicit kwarg. No e2e/system tests reference agent spawn.

### Testing
- [x] Unit assertion for `settings.agent_spawn.enabled is False`
- [x] `uv run pytest tests/unit/test_agent_spawn.py` — 42 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58adfb60-7e4c-4c60-b58c-0b5ec06e1741?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58adfb60-7e4c-4c60-b58c-0b5ec06e1741&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Agent spawning is now disabled by default.
  * Agent spawning can be enabled explicitly through configuration or an environment variable.

* **Tests**
  * Added coverage confirming the new default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->