### PR TITLE
fix(runtime-tools): normalize execution callables to always be awaitable

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/tools/test_runtime_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/tools/test_runtime_tools.py
@@ -20,8 +20,6 @@ from types import SimpleNamespace
 
 import pytest
 
-pytestmark = pytest.mark.unit
-
 from cuga.backend.cuga_graph.nodes.cuga_agent_core.tools.runtime_tools import (
     RuntimeBackends,
     ToolBundle,
@@ -29,6 +27,8 @@ from cuga.backend.cuga_graph.nodes.cuga_agent_core.tools.runtime_tools import (
     prompt_tool_dicts,
     resolve_runtime_backends,
 )
+
+pytestmark = pytest.mark.unit
 
 
 # ─── prompt_tool_dicts (Phase 5: expose runtime tools in Supervisor prompt) ──

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/tools/test_runtime_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/tools/test_runtime_tools.py
@@ -14,9 +14,13 @@ Two concerns, kept separate:
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 from types import SimpleNamespace
 
 import pytest
+
+pytestmark = pytest.mark.unit
 
 from cuga.backend.cuga_graph.nodes.cuga_agent_core.tools.runtime_tools import (
     RuntimeBackends,
@@ -183,10 +187,10 @@ def patch_packages(monkeypatch):
             created["shell_thread_id"] = thread_id
             created["shell_label"] = self.label
 
-            async def _rc():
+            def _rc():
                 return "ran"
 
-            return [_FakeTool("run_command", coroutine=_rc)]
+            return [_FakeTool("run_command", func=_rc)]
 
     from cuga.backend.cuga_graph.nodes.cuga_lite.executors import CodeExecutor
 
@@ -241,6 +245,15 @@ def test_callable_is_coroutine_or_func_and_skips_empty(patch_packages):
     # write_file had only .func, read_file had .coroutine — both captured
     assert callable(bundle.execution_callables["read_file"])
     assert callable(bundle.execution_callables["write_file"])
+
+
+def test_execution_callables_are_always_awaitable(patch_packages):
+    bundle = build_runtime_tools(thread_id="t1", backends=RuntimeBackends("host", "native"))
+    assert set(bundle.execution_callables) == {"read_file", "write_file", "run_command"}
+    assert all(inspect.iscoroutinefunction(fn) for fn in bundle.execution_callables.values())
+    assert asyncio.run(bundle.execution_callables["read_file"]()) == "x"
+    assert asyncio.run(bundle.execution_callables["write_file"]()) is None
+    assert asyncio.run(bundle.execution_callables["run_command"]()) == "ran"
 
 
 # ─── Skills parity: prompt_tool_dicts on real StructuredTool (Supervisor) ────

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tools/runtime_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tools/runtime_tools.py
@@ -105,6 +105,8 @@ def build_runtime_tools(*, thread_id: Optional[str], backends: RuntimeBackends) 
     Mirrors the original ``cuga_lite_graph`` injection (same backend
     selection, same ``coroutine or func`` extraction, same log lines).
     """
+    from cuga.backend.cuga_graph.nodes.cuga_agent_core.execution.code_extraction import make_tool_awaitable
+
     bundle = ToolBundle()
 
     if backends.filesystem != "none":
@@ -120,7 +122,7 @@ def build_runtime_tools(*, thread_id: Optional[str], backends: RuntimeBackends) 
         for ft in fs_tools:
             fn = ft.coroutine or ft.func
             if fn:
-                bundle.execution_callables[ft.name] = fn
+                bundle.execution_callables[ft.name] = make_tool_awaitable(fn)
         bundle.prompt_tools.extend(fs_tools)
         bundle.app_definitions.append(
             AppDefinition(
@@ -148,7 +150,7 @@ def build_runtime_tools(*, thread_id: Optional[str], backends: RuntimeBackends) 
         for st in run_cmd_tools:
             fn = st.coroutine or st.func
             if fn:
-                bundle.execution_callables[st.name] = fn
+                bundle.execution_callables[st.name] = make_tool_awaitable(fn)
         bundle.prompt_tools.extend(run_cmd_tools)
         logger.info(f"[{sandbox_label}] Injected run_command (thread_id={thread_id!r})")
 


### PR DESCRIPTION
## Bug fix

Fixes #583

### Summary

Every filesystem and shell callable stored in `ToolBundle.execution_callables` by `build_runtime_tools()` is now guaranteed to be awaitable, regardless of whether the underlying LangChain `StructuredTool` exposes a synchronous `func` or asynchronous `coroutine`.

**Root cause:** `build_runtime_tools()` stored callables via `fn = ft.coroutine or ft.func` with no normalization. When a tool only had a sync `func` (e.g. `write_file`, `run_command`), the stored callable was a plain synchronous function — callers using `await tool()` semantics would fail at runtime.

**Solution:** Added a function-local import of the existing `make_tool_awaitable()` helper (from `code_extraction.py`) inside `build_runtime_tools()`, and wrapped both the filesystem and shell callable insertions with it. The import is kept inside the function body to preserve lazy startup behaviour (project constraint). No consumer sites (`prepare_node.py`, `prepare_agents_and_prompt.py`) were modified — the fix is applied at the shared bundle-construction boundary.

**Changes:**
- `runtime_tools.py`: function-local `make_tool_awaitable` import + wrap both `bundle.execution_callables` insertions
- `test_runtime_tools.py`: `pytestmark = pytest.mark.unit` marker, sync fake shell callable, and a new regression test `test_execution_callables_are_always_awaitable` that asserts every callable in the bundle satisfies `inspect.iscoroutinefunction` and executes correctly under `asyncio.run()`

### Testing
- [x] Verified fix locally; tests pass
- 52 unit tests pass (`test_runtime_tools.py`, `test_code_extraction.py`, `test_sync_async_tools.py`)
- `ruff check` and `ruff format --check` clean on both changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime tool execution consistency by ensuring filesystem and shell operations can be safely awaited.
  * Added validation covering expected results from runtime execution tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->