### PR TITLE
fix(trajectory): record code not content for Assistant_code step

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -179,7 +179,7 @@ class AgentGraphAdapter(CoreGraphAdapter):
         try:
             self._tracker.collect_step(step=Step(name="Raw_Assistant_Response", data=content))
             if code:
-                self._tracker.collect_step(step=Step(name="Assistant_code", data=content))
+                self._tracker.collect_step(step=Step(name="Assistant_code", data=code))
             else:
                 self._tracker.collect_step(step=Step(name="Assistant_nl", data=content))
         except Exception as exc:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
@@ -182,7 +182,8 @@ def test_normalize_response_extracts_reasoning():
 # ── 6. on_response_processed hook ────────────────────────────────────────
 
 
-def test_on_response_processed_calls_tracker_for_code():
+@pytest.mark.unit
+def test_on_response_processed_code_branch_records_code_not_content():
     AgentGraphAdapter = _get_adapter_class()
     tracker = _make_tracker()
     adapter = AgentGraphAdapter(
@@ -193,11 +194,20 @@ def test_on_response_processed_calls_tracker_for_code():
         base_tool_provider=None,
     )
     state = SimpleNamespace()
-    adapter.on_response_processed(state, code="print(1)", content="```python\nprint(1)\n```")
-    tracker.collect_step.assert_called()
+    content = "Here is the solution:\n```python\nprint(1)\n```"
+    code = "print(1)"
+    adapter.on_response_processed(state, code=code, content=content)
+
+    calls = tracker.collect_step.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["step"].name == "Raw_Assistant_Response"
+    assert calls[0].kwargs["step"].data == content
+    assert calls[1].kwargs["step"].name == "Assistant_code"
+    assert calls[1].kwargs["step"].data == code  # must be code, not content
 
 
-def test_on_response_processed_calls_tracker_for_nl():
+@pytest.mark.unit
+def test_on_response_processed_nl_branch_records_content():
     AgentGraphAdapter = _get_adapter_class()
     tracker = _make_tracker()
     adapter = AgentGraphAdapter(
@@ -208,8 +218,15 @@ def test_on_response_processed_calls_tracker_for_nl():
         base_tool_provider=None,
     )
     state = SimpleNamespace()
-    adapter.on_response_processed(state, code=None, content="The answer is 42.")
-    tracker.collect_step.assert_called()
+    content = "The answer is 42."
+    adapter.on_response_processed(state, code=None, content=content)
+
+    calls = tracker.collect_step.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs["step"].name == "Raw_Assistant_Response"
+    assert calls[0].kwargs["step"].data == content
+    assert calls[1].kwargs["step"].name == "Assistant_nl"
+    assert calls[1].kwargs["step"].data == content
 
 
 # ── 7. build_metadata_update hook ────────────────────────────────────────


### PR DESCRIPTION
## Bug fix

Fixes #586

### Summary

`AgentGraphAdapter.on_response_processed` was passing `content` (the full normalized model response) as the payload for the `Assistant_code` trajectory step instead of `code` (the extracted Python body). This meant downstream trajectory consumers always saw the same value in both `Raw_Assistant_Response` and `Assistant_code` when a response contained prose plus a code block.

**Root cause:** A one-word typo on line 182 of `adapter/graph_adapter.py` — `data=content` instead of `data=code`.

**Fix:** Change `data=content` → `data=code` for the `Assistant_code` step. No other production changes.

The two existing adapter unit tests for `on_response_processed` only called `assert_called()` (no data assertions), so the bug was invisible to them. They have been replaced with tests that:
- Use distinct `content` (prose + fenced block) vs `code` (Python body) values
- Assert exact ordered `call_args_list` with correct data on each step
- Carry the `@pytest.mark.unit` marker

### Testing
- [x] Verified fix locally; tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response tracking so code responses record only the extracted code, rather than the full response text.
  - Natural-language responses continue to record their complete content.
  - Raw assistant responses remain available for tracking and review.

- **Tests**
  - Added coverage to verify tracking behavior for both code and natural-language responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->