### PR TITLE
fix(cuga-lite): keep variables addendum out of persisted history (#600)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,10 @@ jobs:
           uv run pytest tests/unit/test_cuga_lite_bind_tools.py \
             tests/unit/test_bind_tools_safe_fallback.py \
             tests/unit/test_tool_use_failed_recovery.py
+          # call_model prompt assembly: the variables addendum must reach the model
+          # but never be persisted into history (#600) — unbounded copies previously
+          # exhausted the context window mid-task.
+          uv run pytest tests/unit/test_variables_addendum_not_persisted.py
           uv run pytest \
             tests/unit/test_toolguard_provider.py \
             tests/unit/test_policy_tool_guide_loading.py \

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -159,12 +159,20 @@ def create_call_model_node(
                     modified = True
                     playbook_fired = True
 
+                # The variables addendum is rebuilt from live state on every turn, so it must
+                # stay OUT of persisted history (#600). Persisting it left every message that
+                # was once `is_last` holding its own copy (capped at
+                # variables_summary_max_length each, but unbounded in count), which grew the
+                # context ~5x faster than the conversation itself and eventually tripped the
+                # provider's context limit mid-task. Unlike `pi` and `playbook_guidance` —
+                # which are guarded to fire once per conversation/task — this one has no
+                # such guard, so it is the only addendum that accumulates.
+                outbound_content = content
                 if variables_summary_text and is_last:
-                    content = content + variables_addendum
-                    modified = True
+                    outbound_content = content + variables_addendum
 
                 modified_messages.append(msg.model_copy(update={"content": content}) if modified else msg)
-                messages_for_model.append({"role": "user", "content": content})
+                messages_for_model.append({"role": "user", "content": outbound_content})
 
             elif is_ai:
                 modified_messages.append(msg)

--- a/tests/unit/test_variables_addendum_not_persisted.py
+++ b/tests/unit/test_variables_addendum_not_persisted.py
@@ -1,0 +1,163 @@
+"""Regression tests for #600 — the "## Available Variables" addendum must be sent
+to the model but never persisted into conversation history.
+
+Persisting it made every message that was once ``is_last`` retain its own copy
+(each capped by ``variables_summary_max_length`` but unbounded in count), inflating
+context growth ~5x and eventually tripping the provider's context limit mid-task.
+
+These tests drive the real ``call_model`` node from
+``cuga_agent_core.graph.shared_nodes`` — they do not re-implement its logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.shared_nodes import create_call_model_node
+
+pytestmark = pytest.mark.unit
+
+ADDENDUM_MARKER = "## Available Variables"
+VAR_SUMMARY = "# Variables Summary\n\n## my_var\nvalue preview"
+
+
+class _State:
+    """Minimal stand-in for the graph state used by call_model."""
+
+    def __init__(self, messages: List[Any]):
+        self.chat_messages = messages
+        self.prepared_prompt = "BASE PROMPT"
+        self.variable_counter_state = None
+        self.variable_creation_order = None
+        self.step_count = 0
+
+
+def _make_settings() -> MagicMock:
+    s = MagicMock()
+    s.policy.enabled = False
+    s.advanced_features.variables_summary_max_length = 12000
+    return s
+
+
+def _make_adapter(captured_outbound: List[List[dict]]) -> MagicMock:
+    a = MagicMock()
+    a.messages_key = "chat_messages"
+    a.metadata_key = "meta"
+    a.execute_node_name = "sandbox"
+    a.sender_name = "unit-test"
+
+    a.prepare_system_content.return_value = "SYSTEM"
+    a.get_few_shot_messages.return_value = []
+    a.get_pi.return_value = None
+    a.get_metadata.return_value = {}
+    a.build_metadata_update.return_value = {}
+    a.get_tools_needing_probing.return_value = []
+    a.get_tracker.return_value = None
+    a.get_variables_storage.return_value = {}
+    a.resolve_max_steps.return_value = 70
+    a.get_messages = lambda state: state.chat_messages
+
+    # No code block in the reply -> call_model takes the terminal path and
+    # returns the persisted message list, which is what we assert on.
+    a.normalize_response.return_value = ("done, no code here", "")
+    a.on_response_processed.return_value = None
+    a.classify_auto_continue = AsyncMock(return_value=False)
+    a.resolve_bind_tools = AsyncMock(return_value=None)
+
+    var_manager = MagicMock()
+    var_manager.get_variable_names.return_value = ["my_var"]
+    var_manager.get_variables_summary.return_value = VAR_SUMMARY
+    a.get_variable_manager.return_value = var_manager
+
+    async def _ainvoke(bound, messages_for_model, invoke_config):
+        captured_outbound.append(messages_for_model)
+        return MagicMock()
+
+    a.ainvoke_model = AsyncMock(side_effect=_ainvoke)
+    return a
+
+
+async def _run_turn(messages: List[Any], captured: List[List[dict]]):
+    """Invoke the real call_model node once; return its persisted message list."""
+    adapter = _make_adapter(captured)
+    node = create_call_model_node(adapter, MagicMock(), _make_settings())
+
+    async def _passthrough(msgs, *args, **kwargs):
+        return msgs
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.shared_nodes.apply_context_summarization",
+        new=AsyncMock(side_effect=_passthrough),
+    ):
+        cmd = await node(_State(messages), {"configurable": {}})
+    return cmd.update[adapter.messages_key]
+
+
+@pytest.mark.asyncio
+async def test_addendum_sent_to_model_but_not_persisted():
+    """One turn: model sees the addendum; stored history does not."""
+    captured: List[List[dict]] = []
+    persisted = await _run_turn([HumanMessage(content="first request")], captured)
+
+    outbound_users = [m for m in captured[0] if m.get("role") == "user"]
+    assert any(ADDENDUM_MARKER in m["content"] for m in outbound_users), (
+        "the addendum must still reach the model"
+    )
+
+    stored = [m for m in persisted if isinstance(m, HumanMessage)]
+    assert stored, "expected the human message to be persisted"
+    assert not any(ADDENDUM_MARKER in (m.content or "") for m in stored), (
+        "the addendum must NOT be written back into history (#600)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_addendum_does_not_accumulate_across_turns():
+    """Multi-turn: exactly one copy goes out per turn, zero accumulate in history."""
+    captured: List[List[dict]] = []
+    messages: List[Any] = [HumanMessage(content="turn 1")]
+
+    for turn in range(2, 5):
+        persisted = await _run_turn(messages, captured)
+        # feed history forward the way the graph does, then add the next user turn
+        messages = list(persisted) + [HumanMessage(content=f"turn {turn}")]
+
+    stored_copies = sum(
+        1 for m in messages if isinstance(m, HumanMessage) and ADDENDUM_MARKER in (m.content or "")
+    )
+    assert stored_copies == 0, (
+        f"history accumulated {stored_copies} copies of the variables addendum; "
+        "it must never be persisted (#600)"
+    )
+
+    for turn_idx, outbound in enumerate(captured):
+        copies = sum(1 for m in outbound if m.get("role") == "user" and ADDENDUM_MARKER in m["content"])
+        assert copies == 1, f"turn {turn_idx}: expected exactly 1 addendum, got {copies}"
+
+
+@pytest.mark.asyncio
+async def test_addendum_absent_when_no_variables_exist():
+    """No variables -> no addendum anywhere."""
+    captured: List[List[dict]] = []
+    adapter = _make_adapter(captured)
+    adapter.get_variable_manager.return_value.get_variable_names.return_value = []
+    node = create_call_model_node(adapter, MagicMock(), _make_settings())
+
+    async def _passthrough(msgs, *args, **kwargs):
+        return msgs
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_agent_core.graph.shared_nodes.apply_context_summarization",
+        new=AsyncMock(side_effect=_passthrough),
+    ):
+        cmd = await node(_State([HumanMessage(content="hello")]), {"configurable": {}})
+
+    persisted = cmd.update[adapter.messages_key]
+    assert not any(ADDENDUM_MARKER in m.get("content", "") for m in captured[0])
+    assert not any(
+        ADDENDUM_MARKER in (m.content or "") for m in persisted if isinstance(m, (HumanMessage, AIMessage))
+    )


### PR DESCRIPTION
## Bug fix

Fixes #600

### Summary

The `## Available Variables` addendum was appended to the last user message and then **written back into conversation state** via `model_copy`. Because the `is_last` guard moves each turn, every message that was once last kept its own copy of the block — capped individually by `variables_summary_max_length` (12,000 chars) but **unbounded in count**.

Measured on AppWorld med (`aws/gpt-oss-120b`), task `2ff4dfb_1`:

- **16 stored copies**, totalling **314,992 chars** (~79K tokens — 60% of the 131,072-token window)
- **15 of the 16 byte-identical** (MD5 of trailing 6,000 chars)
- context grew **~6,300 tokens/turn** against ~1,300 warranted by the model's own output — roughly **5× inflation**
- that task made **zero tool calls** while consuming 1,559,914 tokens, so this is not tool-output flooding

Three task-runs died outright with `Input length (131885) exceeds model's maximum context length (131072)` — `2ff4dfb_1`, `6474048_1`, `7574325_1` (the last at `match_rate = 0.8` when it was killed). Without the duplication ~20 turns cost roughly 25K tokens instead of ~126K, so these would not have approached the limit.

**Fix:** the addendum is rebuilt from live state every turn, so it only ever needs to reach the outbound prompt. It now goes into `messages_for_model` while the persisted message is left untouched.

`pi` (User Context) and `playbook_guidance` are deliberately unchanged — both are guarded to fire once per conversation/task (`pi_added`, and `playbook_fired` tracked in metadata), so neither accumulates. The variables addendum was the only one of the three with no such guard.

Note `variables_summary_max_length` does not help here: it bounds the size of each copy, not how many copies accumulate — the guard was on the wrong axis.

### Testing
- [x] Verified fix locally; tests pass

`uv run pytest tests/unit/test_variables_addendum_not_persisted.py -m unit` → **3 passed**

New regression tests drive the real `call_model` node via a mocked adapter (they do not re-implement its loop):

1. `test_addendum_sent_to_model_but_not_persisted` — model receives it, history does not
2. `test_addendum_does_not_accumulate_across_turns` — 4 turns: exactly 1 outbound copy per turn, **0** stored
3. `test_addendum_absent_when_no_variables_exist` — no variables, no addendum anywhere

**Verified the tests actually catch the bug:** with the fix stashed, tests 1 and 2 fail; test 3 passes either way (nothing to persist when there are no variables).

Wider suite: `uv run pytest tests/unit -m unit` → **366 passed, 11 failed**. All 11 failures are in `tests/unit/test_llm_advanced_params.py` and are **pre-existing on `main`** — verified by diffing the sorted failing test IDs on both refs (identical sets). That file does not reference `shared_nodes` / `call_model` / `cuga_agent_core`; the failures occur at a stale `patch("cuga.backend.llm.models.ReasoningChatOpenAI")` target, unrelated to this change. Worth a separate look, since that file is in the CI allowlist added by #549.

`ruff format` + `ruff check` clean on both changed files.

### Not verified

The three tasks that died have **not** been re-run to confirm they now complete — that needs a live eval run. The token arithmetic above is a projection from the trace, not a post-fix measurement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented live variable summaries from being saved in conversation history.
  * Ensured variable information is sent to the model only when needed, without accumulating across turns.
  * Preserved original conversation messages and avoided duplicate variable summaries.

* **Tests**
  * Added coverage confirming variable summaries are sent correctly, excluded from history, included only once per turn, and omitted when no variables are available.
  * Added these checks to the automated unit-test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->