### PR TITLE
fix: propagate assistant reasoning and record fenced code in CugaLite trajectories

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
@@ -157,6 +157,7 @@ class CoreGraphAdapter(ABC):
         ``reasoning`` is the normalized model reasoning returned alongside
         ``content``. Default: no-op. Lite uses this to record tracker steps.
         """
+        pass
 
     def build_metadata_update(self, state: Any, *, playbook_fired: bool) -> dict:
         """Return the *value* (not the full key/value pair) for the metadata

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/graph_nodes.py
@@ -145,9 +145,18 @@ class CoreGraphAdapter(ABC):
         Default: empty (Supervisor and any adapter that hasn't opted in)."""
         return frozenset()
 
-    def on_response_processed(self, state: Any, code: Optional[str], content: str) -> None:
-        """Side-effect hook called after code extraction.  Default: no-op.
-        Lite uses this to record tracker steps."""
+    def on_response_processed(
+        self,
+        state: Any,
+        code: Optional[str],
+        content: str,
+        reasoning: Optional[str] = None,
+    ) -> None:
+        """Side-effect hook called after code extraction.
+
+        ``reasoning`` is the normalized model reasoning returned alongside
+        ``content``. Default: no-op. Lite uses this to record tracker steps.
+        """
 
     def build_metadata_update(self, state: Any, *, playbook_fired: bool) -> dict:
         """Return the *value* (not the full key/value pair) for the metadata

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/graph/shared_nodes.py
@@ -198,7 +198,7 @@ def create_call_model_node(
             content, reasoning, tools_needing_probing=adapter.get_tools_needing_probing()
         )
 
-        adapter.on_response_processed(state, code, content)
+        adapter.on_response_processed(state, code, content, reasoning)
 
         # ── Build final message list + step count ──────────────────────────
         final_messages: list = modified_messages + [AIMessage(content=content)]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_agent_core/tests/graph/test_graph_adapter_hooks.py
@@ -103,12 +103,18 @@ def test_default_get_invoke_config_returns_empty_dict():
     assert adapter.get_invoke_config({}) == {}
 
 
+@pytest.mark.unit
 def test_default_on_response_processed_is_noop():
     adapter = _MinimalAdapter()
     state = SimpleNamespace()
     # Must not raise
-    adapter.on_response_processed(state, code=None, content="hi")
-    adapter.on_response_processed(state, code="print(1)", content="```python\nprint(1)\n```")
+    adapter.on_response_processed(state, code=None, content="hi", reasoning=None)
+    adapter.on_response_processed(
+        state,
+        code="print(1)",
+        content="```python\nprint(1)\n```",
+        reasoning="Need to print one",
+    )
 
 
 def test_default_build_metadata_update_returns_existing_meta_when_no_playbook():
@@ -218,6 +224,7 @@ async def test_overridden_resolve_bind_tools():
 # ── 3. Hook signatures are stable under keyword call ──────────────────────
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_all_hooks_callable_with_keyword_args():
     adapter = _MinimalAdapter()
@@ -231,7 +238,7 @@ async def test_all_hooks_callable_with_keyword_args():
     adapter.prepare_system_content(state, {}, "prompt")
     adapter.normalize_response(response)
     adapter.get_invoke_config({})
-    adapter.on_response_processed(state, code=None, content="hi")
+    adapter.on_response_processed(state, code=None, content="hi", reasoning="thought")
     adapter.build_metadata_update(state, playbook_fired=False)
     adapter.get_variables_storage(state)
     adapter.get_tracker()

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -175,13 +175,22 @@ class AgentGraphAdapter(CoreGraphAdapter):
         )
         return content, reasoning
 
-    def on_response_processed(self, state: Any, code: Optional[str], content: str) -> None:
+    def on_response_processed(
+        self,
+        state: Any,
+        code: Optional[str],
+        content: str,
+        reasoning: Optional[str] = None,
+    ) -> None:
         try:
             self._tracker.collect_step(step=Step(name="Raw_Assistant_Response", data=content))
             if code:
-                self._tracker.collect_step(step=Step(name="Assistant_code", data=code))
+                fenced_code = f"```python\n{code}\n```"
+                self._tracker.collect_step(step=Step(name="Assistant_code", data=fenced_code))
             else:
                 self._tracker.collect_step(step=Step(name="Assistant_nl", data=content))
+            if reasoning:
+                self._tracker.collect_step(step=Step(name="Assistant_reasoning", data=reasoning))
         except Exception as exc:
             logger.debug(f"AgentGraphAdapter.on_response_processed tracker error: {exc}")
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
@@ -183,7 +183,7 @@ def test_normalize_response_extracts_reasoning():
 
 
 @pytest.mark.unit
-def test_on_response_processed_code_branch_records_code_not_content():
+def test_on_response_processed_code_branch_records_fenced_code_not_content():
     AgentGraphAdapter = _get_adapter_class()
     tracker = _make_tracker()
     adapter = AgentGraphAdapter(
@@ -196,14 +196,45 @@ def test_on_response_processed_code_branch_records_code_not_content():
     state = SimpleNamespace()
     content = "Here is the solution:\n```python\nprint(1)\n```"
     code = "print(1)"
-    adapter.on_response_processed(state, code=code, content=content)
+    adapter.on_response_processed(state, code=code, content=content, reasoning=None)
 
     calls = tracker.collect_step.call_args_list
     assert len(calls) == 2
     assert calls[0].kwargs["step"].name == "Raw_Assistant_Response"
     assert calls[0].kwargs["step"].data == content
     assert calls[1].kwargs["step"].name == "Assistant_code"
-    assert calls[1].kwargs["step"].data == code  # must be code, not content
+    assert calls[1].kwargs["step"].data == "```python\nprint(1)\n```"
+
+
+@pytest.mark.unit
+def test_on_response_processed_records_reasoning_after_assistant_step():
+    AgentGraphAdapter = _get_adapter_class()
+    tracker = _make_tracker()
+    adapter = AgentGraphAdapter(
+        tracker=tracker,
+        base_callbacks=[],
+        task_todos_ref=[],
+        tools_context_ref={},
+        base_tool_provider=None,
+    )
+    state = SimpleNamespace()
+    content = "The answer is 42."
+    reasoning = "I computed six times seven."
+
+    adapter.on_response_processed(
+        state,
+        code=None,
+        content=content,
+        reasoning=reasoning,
+    )
+
+    calls = tracker.collect_step.call_args_list
+    assert [call.kwargs["step"].name for call in calls] == [
+        "Raw_Assistant_Response",
+        "Assistant_nl",
+        "Assistant_reasoning",
+    ]
+    assert calls[2].kwargs["step"].data == reasoning
 
 
 @pytest.mark.unit
@@ -219,7 +250,7 @@ def test_on_response_processed_nl_branch_records_content():
     )
     state = SimpleNamespace()
     content = "The answer is 42."
-    adapter.on_response_processed(state, code=None, content=content)
+    adapter.on_response_processed(state, code=None, content=content, reasoning="")
 
     calls = tracker.collect_step.call_args_list
     assert len(calls) == 2


### PR DESCRIPTION
## Bug fix

Fixes #598

### Summary

Assistant trajectory steps were missing two behaviours:
- `Assistant_code` steps stored the raw LLM content string instead of a properly-fenced Python code block.
- Normalized model reasoning was never surfaced as a trajectory step, even when the model returned it.

**Root cause:** The shared `call_model` node did not thread the reasoning value returned by `normalize_response` into the post-response hook, and the CugaLite adapter's `on_response_processed` override neither applied a Python fence to extracted code nor accepted or recorded a reasoning argument.

**Solution (3 commits):**
- `fix: propagate assistant reasoning to response hook` — extend the base `CoreGraphAdapter.on_response_processed` hook to accept `reasoning: Optional[str] = None` and update the shared call-model node to pass the already-normalized value through.
- `fix: record fenced code and assistant reasoning` — update `AgentGraphAdapter.on_response_processed` to wrap extracted code in a ````python\n{code}\n`````` fence as `Assistant_code`, and append `Assistant_reasoning` (after the code/NL step) only when reasoning is truthy.
- `fix(graph-nodes): add explicit pass to on_response_processed no-op base hook` — cosmetic consistency fix (docstring-only body → explicit `pass`).

**Step ordering guaranteed:** `Raw_Assistant_Response` → `Assistant_code` or `Assistant_nl` → `Assistant_reasoning` (only when non-empty).

### Testing
- [x] Verified fix locally; tests pass
- [x] TDD: wrote failing tests first, then implemented (55 tests pass across both affected test files)
- [x] New/changed tests carry `@pytest.mark.unit`
- [x] `ruff check` passes on all modified files
- [x] No new imports; lazy-import patterns preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant reasoning is now captured alongside responses when available.
  * Generated code is consistently recorded as formatted Python code.
* **Bug Fixes**
  * Improved response tracking to preserve code, reasoning, and natural-language outputs in the correct sequence.
* **Tests**
  * Expanded coverage for response hooks, reasoning capture, code formatting, and signature compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->