### PR TITLE
fix(cuga-lite): emit Assistant_reasoning before code/nl trajectory step

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/adapter/graph_adapter.py
@@ -184,13 +184,13 @@ class AgentGraphAdapter(CoreGraphAdapter):
     ) -> None:
         try:
             self._tracker.collect_step(step=Step(name="Raw_Assistant_Response", data=content))
+            if reasoning:
+                self._tracker.collect_step(step=Step(name="Assistant_reasoning", data=reasoning))
             if code:
                 fenced_code = f"```python\n{code}\n```"
                 self._tracker.collect_step(step=Step(name="Assistant_code", data=fenced_code))
             else:
                 self._tracker.collect_step(step=Step(name="Assistant_nl", data=content))
-            if reasoning:
-                self._tracker.collect_step(step=Step(name="Assistant_reasoning", data=reasoning))
         except Exception as exc:
             logger.debug(f"AgentGraphAdapter.on_response_processed tracker error: {exc}")
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_agent_graph_adapter.py
@@ -207,7 +207,7 @@ def test_on_response_processed_code_branch_records_fenced_code_not_content():
 
 
 @pytest.mark.unit
-def test_on_response_processed_records_reasoning_after_assistant_step():
+def test_on_response_processed_records_reasoning_before_assistant_step():
     AgentGraphAdapter = _get_adapter_class()
     tracker = _make_tracker()
     adapter = AgentGraphAdapter(
@@ -231,10 +231,10 @@ def test_on_response_processed_records_reasoning_after_assistant_step():
     calls = tracker.collect_step.call_args_list
     assert [call.kwargs["step"].name for call in calls] == [
         "Raw_Assistant_Response",
-        "Assistant_nl",
         "Assistant_reasoning",
+        "Assistant_nl",
     ]
-    assert calls[2].kwargs["step"].data == reasoning
+    assert calls[1].kwargs["step"].data == reasoning
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Bug fix

### Summary

`Assistant_reasoning` was being recorded after `Assistant_code`/`Assistant_nl` in the CugaLite trajectory. Reasoning should appear before the code or natural-language step so the model's thinking is visible prior to its output.

**Root cause:** The `on_response_processed` override collected the reasoning step last, after the code/NL step.

**Solution:** Reorder the tracker calls so the step sequence is:
`Raw_Assistant_Response` → `Assistant_reasoning` (when present) → `Assistant_code` or `Assistant_nl`

### Testing
- [x] Verified fix locally; tests pass
- [x] Updated test `test_on_response_processed_records_reasoning_before_assistant_step` to assert new step order
- [x] 3/3 unit-marked trajectory tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assistant reasoning is now recorded before the generated response, ensuring activity history appears in the correct sequence.

* **Tests**
  * Updated validation to confirm the corrected ordering of reasoning and assistant output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->