### PR TITLE
fix(server): contain static file routes to their static directory

### DIFF
--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -48,6 +48,9 @@ from cuga.config import (
     LOGGING_DIR,
     TRACES_DIR,
 )
+from cuga.backend.cuga_graph.nodes.cuga_lite.executors.filesystem.paths import (
+    assert_resolved_path_under,
+)
 from cuga.backend.server import manage_routes
 from cuga.backend.server import secrets_routes
 from cuga.backend.server.workspace_upload import (
@@ -4321,9 +4324,13 @@ async def get_attachment_snapshot(request: Request) -> Optional[List[Dict[str, A
 @app.get("/flows/{full_path:path}")
 async def serve_flows(full_path: str, request: Request):
     """Serves files from the flows directory."""
-    file_path = os.path.join(app_state.STATIC_DIR_FLOWS, full_path)
-    if os.path.exists(file_path) and os.path.isfile(file_path):
-        return FileResponse(file_path)
+    static_root = Path(app_state.STATIC_DIR_FLOWS)
+    try:
+        file_path = assert_resolved_path_under(Path(os.path.join(static_root, full_path)), static_root)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Flow file not found.")
+    if file_path.is_file():
+        return FileResponse(str(file_path))
     raise HTTPException(status_code=404, detail="Flow file not found.")
 
 
@@ -4333,10 +4340,16 @@ async def serve_react(full_path: str, request: Request):
     if not app_state.STATIC_DIR_HTML:
         raise HTTPException(status_code=500, detail="Frontend build directory not found.")
 
+    static_root = Path(app_state.STATIC_DIR_HTML)
     lookup_path = full_path[7:] if full_path.startswith("manage/") else full_path
-    file_path = os.path.join(app_state.STATIC_DIR_HTML, lookup_path)
-    if os.path.exists(file_path) and os.path.isfile(file_path):
-        return FileResponse(file_path)
+    try:
+        file_path = assert_resolved_path_under(Path(os.path.join(static_root, lookup_path)), static_root)
+    except ValueError:
+        # Resolved outside the static directory: refuse rather than falling through to
+        # the index.html SPA route, so the request gets one unambiguous answer.
+        raise HTTPException(status_code=404, detail="Frontend files not found.")
+    if file_path.is_file():
+        return FileResponse(str(file_path))
 
     index_path = os.path.join(app_state.STATIC_DIR_HTML, "index.html")
     if os.path.exists(index_path):

--- a/tests/unit/test_static_route_path_containment.py
+++ b/tests/unit/test_static_route_path_containment.py
@@ -1,0 +1,188 @@
+# tests/unit/test_static_route_path_containment.py
+"""Containment regression tests for the static file routes (GHSA-55pr-c85h-3p9q).
+
+``serve_flows`` and ``serve_react`` join the request path onto a static
+directory. Before the fix they returned the file after only an
+``exists``/``isfile`` check, so a path that walked upward out of the static
+directory was served. Both now resolve the join and refuse anything landing
+outside their static root.
+
+Two layers are covered, because each can hide the bug on its own:
+
+* the handlers called directly, which no HTTP client can normalize away;
+* the same handlers behind a router, reached with a percent-encoded URL so
+  neither httpx nor Starlette collapses the dot-segments before routing.
+
+Every traversal test first asserts that the *unfixed* join would have found a
+real file, so the test cannot pass merely because nothing was there to serve.
+The handlers are registered on a throwaway ``FastAPI()`` rather than the real
+``app`` — the same lightweight ``TestClient`` pattern as
+test_session_settings_routes.py — so routing is exercised without app startup.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+import pytest
+
+import cuga.backend.server.main as _main
+from cuga.backend.server.main import serve_flows, serve_react
+
+pytestmark = pytest.mark.unit
+
+CANARY = "cuga-test-canary-this-must-never-be-served"
+TRAVERSAL = "../../outside/canary.txt"
+
+
+@pytest.fixture
+def static_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A static dir with a canary file two levels above it.
+
+    Both static roots point at the same directory so one fixture serves both
+    handlers. ``index.html`` is present so the SPA fallback is reachable.
+    """
+    root = tmp_path / "static" / "dist"
+    root.mkdir(parents=True)
+    (root / "index.html").write_text("<!doctype html><title>app</title>")
+    (root / "app.js").write_text("console.log('app');")
+
+    outside = tmp_path / "static" / "dist" / ".." / ".." / "outside"
+    outside_resolved = tmp_path / "outside"
+    outside_resolved.mkdir(parents=True, exist_ok=True)
+    assert Path(os.path.normpath(outside)) == outside_resolved
+    (outside_resolved / "canary.txt").write_text(CANARY)
+
+    monkeypatch.setattr(_main.app_state, "STATIC_DIR_FLOWS", str(root), raising=False)
+    monkeypatch.setattr(_main.app_state, "STATIC_DIR_HTML", str(root), raising=False)
+    return root
+
+
+@pytest.fixture
+def client(static_root: Path) -> TestClient:
+    """The real handlers on a bare app — routing without the full app's startup."""
+    app = FastAPI()
+    app.get("/flows/{full_path:path}")(serve_flows)
+    app.get("/{full_path:path}")(serve_react)
+    return TestClient(app)
+
+
+def assert_traversal_would_have_been_served(static_root: Path) -> None:
+    """Guard against a vacuous pass: the pre-fix join must find a real file."""
+    pre_fix_path = os.path.join(str(static_root), TRAVERSAL)
+    assert os.path.exists(pre_fix_path) and os.path.isfile(pre_fix_path), (
+        "test is vacuous: the traversal target does not exist, so the unfixed "
+        "handler would have 404'd for the wrong reason"
+    )
+    assert Path(pre_fix_path).read_text() == CANARY
+
+
+# ---------------------------------------------------------------------------
+# Handlers called directly — no client in the loop
+# ---------------------------------------------------------------------------
+
+
+async def test_serve_flows_rejects_traversal(static_root: Path):
+    assert_traversal_would_have_been_served(static_root)
+
+    with pytest.raises(HTTPException) as exc:
+        await serve_flows(TRAVERSAL, request=None)
+    assert exc.value.status_code in (403, 404)
+
+
+async def test_serve_react_rejects_traversal(static_root: Path):
+    assert_traversal_would_have_been_served(static_root)
+
+    with pytest.raises(HTTPException) as exc:
+        await serve_react(TRAVERSAL, request=None)
+    assert exc.value.status_code in (403, 404)
+
+
+async def test_serve_react_rejects_traversal_behind_manage_prefix(static_root: Path):
+    """The ``manage/`` prefix is stripped before the join; containment still applies."""
+    with pytest.raises(HTTPException) as exc:
+        await serve_react(f"manage/{TRAVERSAL}", request=None)
+    assert exc.value.status_code in (403, 404)
+
+
+async def test_serve_flows_rejects_absolute_path(static_root: Path, tmp_path: Path):
+    """``os.path.join`` discards the static root when the tail is absolute."""
+    absolute = str(tmp_path / "outside" / "canary.txt")
+    assert os.path.isfile(os.path.join(str(static_root), absolute))
+
+    with pytest.raises(HTTPException) as exc:
+        await serve_flows(absolute, request=None)
+    assert exc.value.status_code in (403, 404)
+
+
+# ---------------------------------------------------------------------------
+# Through the router, with the dot-segments percent-encoded
+# ---------------------------------------------------------------------------
+
+
+def test_flows_route_rejects_encoded_traversal(client: TestClient, static_root: Path):
+    assert_traversal_would_have_been_served(static_root)
+
+    resp = client.get("/flows/..%2f..%2foutside%2fcanary.txt")
+    assert resp.status_code in (403, 404)
+    assert CANARY not in resp.text
+
+
+def test_react_route_rejects_encoded_traversal(client: TestClient, static_root: Path):
+    assert_traversal_would_have_been_served(static_root)
+
+    resp = client.get("/..%2f..%2foutside%2fcanary.txt")
+    assert resp.status_code in (403, 404)
+    assert CANARY not in resp.text
+
+
+def test_encoded_traversal_reaches_the_handler_undecoded(client: TestClient):
+    """The encoded URL must survive httpx and Starlette as a real traversal.
+
+    Without this, the two tests above could pass because the request never
+    carried dot-segments by the time it reached the route.
+    """
+    seen: list[str] = []
+
+    app = FastAPI()
+
+    @app.get("/flows/{full_path:path}")
+    async def _capture(full_path: str):
+        seen.append(full_path)
+        return {"ok": True}
+
+    TestClient(app).get("/flows/..%2f..%2foutside%2fcanary.txt")
+    assert seen == ["../../outside/canary.txt"]
+
+
+# ---------------------------------------------------------------------------
+# Legitimate requests are unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_flows_route_still_serves_a_real_file(client: TestClient):
+    resp = client.get("/flows/app.js")
+    assert resp.status_code == 200
+    assert "console.log" in resp.text
+
+
+def test_react_route_still_serves_a_real_asset(client: TestClient):
+    resp = client.get("/app.js")
+    assert resp.status_code == 200
+    assert "console.log" in resp.text
+
+
+def test_react_route_still_falls_back_to_index_for_deep_links(client: TestClient):
+    """An unknown path with no traversal keeps the SPA fallback."""
+    resp = client.get("/some/client/side/route")
+    assert resp.status_code == 200
+    assert "<title>app</title>" in resp.text
+
+
+def test_react_route_still_strips_the_manage_prefix(client: TestClient):
+    resp = client.get("/manage/app.js")
+    assert resp.status_code == 200
+    assert "console.log" in resp.text

--- a/tests/unit/test_static_route_path_containment.py
+++ b/tests/unit/test_static_route_path_containment.py
@@ -90,7 +90,7 @@ async def test_serve_flows_rejects_traversal(static_root: Path):
 
     with pytest.raises(HTTPException) as exc:
         await serve_flows(TRAVERSAL, request=None)
-    assert exc.value.status_code in (403, 404)
+    assert exc.value.status_code == 404
 
 
 async def test_serve_react_rejects_traversal(static_root: Path):
@@ -98,14 +98,14 @@ async def test_serve_react_rejects_traversal(static_root: Path):
 
     with pytest.raises(HTTPException) as exc:
         await serve_react(TRAVERSAL, request=None)
-    assert exc.value.status_code in (403, 404)
+    assert exc.value.status_code == 404
 
 
 async def test_serve_react_rejects_traversal_behind_manage_prefix(static_root: Path):
     """The ``manage/`` prefix is stripped before the join; containment still applies."""
     with pytest.raises(HTTPException) as exc:
         await serve_react(f"manage/{TRAVERSAL}", request=None)
-    assert exc.value.status_code in (403, 404)
+    assert exc.value.status_code == 404
 
 
 async def test_serve_flows_rejects_absolute_path(static_root: Path, tmp_path: Path):
@@ -115,7 +115,7 @@ async def test_serve_flows_rejects_absolute_path(static_root: Path, tmp_path: Pa
 
     with pytest.raises(HTTPException) as exc:
         await serve_flows(absolute, request=None)
-    assert exc.value.status_code in (403, 404)
+    assert exc.value.status_code == 404
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +127,7 @@ def test_flows_route_rejects_encoded_traversal(client: TestClient, static_root: 
     assert_traversal_would_have_been_served(static_root)
 
     resp = client.get("/flows/..%2f..%2foutside%2fcanary.txt")
-    assert resp.status_code in (403, 404)
+    assert resp.status_code == 404
     assert CANARY not in resp.text
 
 
@@ -135,7 +135,7 @@ def test_react_route_rejects_encoded_traversal(client: TestClient, static_root: 
     assert_traversal_would_have_been_served(static_root)
 
     resp = client.get("/..%2f..%2foutside%2fcanary.txt")
-    assert resp.status_code in (403, 404)
+    assert resp.status_code == 404
     assert CANARY not in resp.text
 
 


### PR DESCRIPTION
## Bug fix

Fixes #631

### Summary

`serve_flows` and `serve_react` in `src/cuga/backend/server/main.py` build a path by joining
the request path onto a static directory and serve whatever is there. Neither checks the
result is still inside that directory, so a request can resolve to a file outside it.

Both now resolve the path with `assert_resolved_path_under` — the helper the workspace upload
and download paths already use — and return 404 if it lands outside.

Closes code-scanning alerts **#4 to #9** (`py/path-injection`), open on these routes since
September 2025.

One deliberate change: on a failed check `serve_react` returns 404 rather than falling through
to the `index.html` SPA fallback. Ordinary assets, client-side routes, the `manage/` prefix and
the SPA fallback are unaffected.

### Testing

`tests/unit/test_static_route_path_containment.py` — 11 tests across both routes; all 6 refusal
cases were confirmed to fail against the old handlers. HTTP clients normalise paths before
sending, so the tests call the handlers directly and also send percent-encoded paths through a
router, with a further test asserting the encoding survives to the handler — otherwise the
coverage could quietly become vacuous. Every refusal case first asserts the unchecked version
would have found a real file.

`pytest tests/unit`: 1252 passed, with the same 17 failures already on `origin/main` in
unrelated modules. `ruff check` and `ruff format --check` clean. Also verified against the real
frontend build.

Merge #634 first, so CodeQL analysis here comes back clean.

- [x] Verified fix locally; tests pass
