### PR TITLE
fix(tracker): confine external trajectory writes to the tracker directory

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,10 @@ jobs:
             tests/unit/test_tool_guard_generation_route_sync.py \
             tests/unit/test_policy_frontend_dict_guards_enabled.py \
             tests/unit/test_toolguard_reuse_roundtrip.py
+          # Trajectory-write containment (#636) and the recording path it must not break.
+          uv run pytest \
+            tests/unit/test_tracker_external_path_containment.py \
+            tests/unit/test_registry_trajectory_recording.py
           uv run pytest tests/integration/a2a/ tests/unit/test_a2a_simple_runner_hitl.py
         env:
           PYTHONUNBUFFERED: "1"

--- a/src/cuga/backend/activity_tracker/tracker.py
+++ b/src/cuga/backend/activity_tracker/tracker.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 import time
 
@@ -663,6 +664,25 @@ class ActivityTracker(object):
             # TODO: Handle None full_path properly - either use a default path or require callers to provide one
             if not full_path:
                 logger.debug("Skipping external step collection: full_path is None")
+                return
+
+            # Confine the write to the trajectory base directory before any other use.
+            # ``full_path`` may arrive from an untrusted caller (the registry's
+            # ``/functions/call`` trajectory_path query parameter), and every legitimate
+            # value is built under ``_base_dir`` by ``get_current_trajectory_path``.
+            # Anything that resolves outside it is refused, so this cannot become an
+            # arbitrary file write. Resolving first means every path use below operates
+            # on the confined value. Same helper and pattern as the static-route fix.
+            # Imported locally: the helper's package pulls a chain that imports this
+            # module back, so a top-level import would be circular.
+            from cuga.backend.cuga_graph.nodes.cuga_lite.executors.filesystem.paths import (
+                assert_resolved_path_under,
+            )
+
+            try:
+                full_path = str(assert_resolved_path_under(Path(full_path), Path(self._base_dir)))
+            except ValueError:
+                logger.error("Rejected external step path outside the trajectory directory")
                 return
 
             if not os.path.exists(os.path.dirname(full_path)):

--- a/tests/unit/test_registry_trajectory_recording.py
+++ b/tests/unit/test_registry_trajectory_recording.py
@@ -45,6 +45,18 @@ class _StubMcpManager:
     auth_config: dict = {}
 
 
+_MISSING = object()
+
+
+def _restore(module, name: str, value) -> None:
+    """Put a module global back, including back to not existing at all."""
+    if value is _MISSING:
+        if hasattr(module, name):
+            delattr(module, name)
+    else:
+        setattr(module, name, value)
+
+
 @pytest.fixture
 def registry_client(tmp_path: Path):
     """The real app with MCP startup skipped, and every global it touches restored.
@@ -57,9 +69,14 @@ def registry_client(tmp_path: Path):
     original_enabled = settings.advanced_features.tracker_enabled
     original_steps = list(tracker.steps)
     original_prompts = list(tracker.prompts)
-    # registry/mcp_manager are only bound by the lifespan, so they may not exist yet.
-    original_registry = getattr(srv, "registry", None)
-    original_manager = getattr(srv, "mcp_manager", None)
+    # experiment_folder and task_id are what get_current_trajectory_path builds from,
+    # so leaving them set would hand a later test this test's trajectory path.
+    original_experiment_folder = tracker.experiment_folder
+    original_task_id = tracker.task_id
+    # registry/mcp_manager are only bound by the lifespan, so they may not exist yet;
+    # _MISSING marks that so teardown removes them again rather than binding None.
+    original_registry = getattr(srv, "registry", _MISSING)
+    original_manager = getattr(srv, "mcp_manager", _MISSING)
     original_db_mode = srv.database_mode
     original_lifespan = srv.app.router.lifespan_context
 
@@ -81,10 +98,12 @@ def registry_client(tmp_path: Path):
             yield client, tracker
     finally:
         srv.app.router.lifespan_context = original_lifespan
-        srv.registry = original_registry
-        srv.mcp_manager = original_manager
+        _restore(srv, "registry", original_registry)
+        _restore(srv, "mcp_manager", original_manager)
         srv.database_mode = original_db_mode
         tracker.set_base_dir(original_base_dir)
+        tracker.experiment_folder = original_experiment_folder
+        tracker.task_id = original_task_id
         tracker.steps = original_steps
         tracker.prompts = original_prompts
         settings.update({"ADVANCED_FEATURES": {"TRACKER_ENABLED": original_enabled}}, merge=True)

--- a/tests/unit/test_registry_trajectory_recording.py
+++ b/tests/unit/test_registry_trajectory_recording.py
@@ -1,0 +1,110 @@
+# tests/unit/test_registry_trajectory_recording.py
+"""Normal trajectory recording still works through the registry endpoint.
+
+``collect_step_external`` now refuses paths outside the tracker's base directory.
+The refusal is covered by test_tracker_external_path_containment.py; this covers
+the other half, on the real caller: a legitimate ``trajectory_path`` still
+records the call.
+
+The path is built by ``get_current_trajectory_path`` and URL-quoted, exactly as
+``sandbox.py`` builds the ``/functions/call`` URL, and the request goes through
+the real route so the query parameter is decoded the way it is in production.
+Only the MCP tool behind the endpoint is stubbed.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cuga.backend.activity_tracker.tracker import ActivityTracker
+from cuga.backend.tools_env.registry.registry import api_registry_server as srv
+from cuga.config import settings
+
+pytestmark = pytest.mark.unit
+
+
+class _StubResult:
+    text = '{"contacts": ["ada"]}'
+
+
+class _StubRegistry:
+    async def show_apis_for_app(self, app_name):
+        return {"list_contacts": {"secure": False, "path": "/contacts"}}
+
+    async def call_function(self, **kwargs):
+        return [_StubResult()]
+
+
+class _StubMcpManager:
+    auth_config: dict = {}
+
+
+@pytest.fixture
+def registry_client(tmp_path: Path):
+    """The real app with MCP startup skipped, and every global it touches restored.
+
+    ActivityTracker is a singleton and TRACKER_ENABLED is a process-global setting,
+    so both are saved and restored, as are the module globals and the app lifespan.
+    """
+    tracker = ActivityTracker()
+    original_base_dir = tracker.get_base_dir()
+    original_enabled = settings.advanced_features.tracker_enabled
+    original_steps = list(tracker.steps)
+    original_prompts = list(tracker.prompts)
+    # registry/mcp_manager are only bound by the lifespan, so they may not exist yet.
+    original_registry = getattr(srv, "registry", None)
+    original_manager = getattr(srv, "mcp_manager", None)
+    original_db_mode = srv.database_mode
+    original_lifespan = srv.app.router.lifespan_context
+
+    @contextlib.asynccontextmanager
+    async def _skip_mcp_startup(app):
+        srv.registry = _StubRegistry()
+        srv.mcp_manager = _StubMcpManager()
+        srv.database_mode = False
+        yield
+
+    srv.app.router.lifespan_context = _skip_mcp_startup
+    tracker.set_base_dir(str(tmp_path))
+    tracker.experiment_folder = "experiment"
+    tracker.task_id = "task-1"
+    (tmp_path / "experiment").mkdir()
+
+    try:
+        with TestClient(srv.app) as client:
+            yield client, tracker
+    finally:
+        srv.app.router.lifespan_context = original_lifespan
+        srv.registry = original_registry
+        srv.mcp_manager = original_manager
+        srv.database_mode = original_db_mode
+        tracker.set_base_dir(original_base_dir)
+        tracker.steps = original_steps
+        tracker.prompts = original_prompts
+        settings.update({"ADVANCED_FEATURES": {"TRACKER_ENABLED": original_enabled}}, merge=True)
+
+
+def test_registry_call_records_trajectory_for_a_legitimate_path(registry_client):
+    client, tracker = registry_client
+
+    trajectory_path = tracker.get_current_trajectory_path()
+    assert trajectory_path, "the tracker must produce a path to record to"
+
+    response = client.post(
+        f"/functions/call?trajectory_path={quote(trajectory_path)}",
+        json={"app_name": "crm", "function_name": "list_contacts", "args": {}},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"contacts": ["ada"]}
+
+    recorded = json.loads(Path(trajectory_path).read_text())
+    assert [step["name"] for step in recorded["steps"]] == ["api_call", "api_response"], (
+        "a trajectory_path inside the tracker's base directory must still be recorded"
+    )

--- a/tests/unit/test_tracker_external_path_containment.py
+++ b/tests/unit/test_tracker_external_path_containment.py
@@ -35,8 +35,25 @@ pytestmark = pytest.mark.unit
 @pytest.fixture(autouse=True)
 def _enable_tracker():
     """Mirror api_registry_server.py:331, which force-enables the tracker whenever a
-    trajectory_path is supplied, so the tracker_enabled guard is not the thing under test."""
+    trajectory_path is supplied, so the tracker_enabled guard is not the thing under test.
+
+    ActivityTracker is a singleton and the enabled flag is a process-global setting, so
+    both are saved and restored around each test to keep leaked state out of the rest of
+    the suite."""
+    tracker = ActivityTracker()
+    original_base_dir = tracker.get_base_dir()
+    original_enabled = settings.advanced_features.tracker_enabled
+    original_steps = list(tracker.steps)
+    original_prompts = list(tracker.prompts)
+
     settings.update({"ADVANCED_FEATURES": {"TRACKER_ENABLED": True}}, merge=True)
+    try:
+        yield
+    finally:
+        tracker.set_base_dir(original_base_dir)
+        tracker.steps = original_steps
+        tracker.prompts = original_prompts
+        settings.update({"ADVANCED_FEATURES": {"TRACKER_ENABLED": original_enabled}}, merge=True)
 
 
 def _tracker_with_base(base: Path) -> ActivityTracker:

--- a/tests/unit/test_tracker_external_path_containment.py
+++ b/tests/unit/test_tracker_external_path_containment.py
@@ -1,0 +1,93 @@
+# tests/unit/test_tracker_external_path_containment.py
+"""Containment regression for the external-trajectory tracker write.
+
+``ActivityTracker.collect_step_external`` writes ``full_path`` after only
+checking that its parent directory exists. On the registry server, ``full_path``
+is the ``trajectory_path`` query parameter of ``POST /functions/call``
+(api_registry_server.py:305, :332), which carries no authentication, so a
+request could name any writable path and have the tracker overwrite it with
+trajectory JSON that embeds the request body.
+
+This corresponds to code-scanning alerts #11, #12, #13, #30, dismissed as
+"false positive" on 2026-02-26 with no recorded reason. Reproduced end to end
+before the fix: a single unauthenticated request overwrote a file outside any
+trajectory directory.
+
+The fix confines the write to the tracker's ``_base_dir``, where every
+legitimate path is built by ``get_current_trajectory_path``. These tests assert
+both halves: a path outside the base directory is refused and leaves the target
+untouched, and a path inside it is still written.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cuga.backend.activity_tracker.tracker import ActivityTracker, Step
+from cuga.config import settings
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _enable_tracker():
+    """Mirror api_registry_server.py:331, which force-enables the tracker whenever a
+    trajectory_path is supplied, so the tracker_enabled guard is not the thing under test."""
+    settings.update({"ADVANCED_FEATURES": {"TRACKER_ENABLED": True}}, merge=True)
+
+
+def _tracker_with_base(base: Path) -> ActivityTracker:
+    tracker = ActivityTracker()
+    tracker.set_base_dir(str(base))
+    return tracker
+
+
+def test_external_step_refuses_path_outside_base_dir(tmp_path: Path):
+    base = tmp_path / "trajectories"
+    base.mkdir()
+
+    victim = tmp_path / "victim.json"
+    victim.write_text('{"do_not":"overwrite"}')
+    assert victim.parent.exists()  # the only guard the old code applied
+
+    tracker = _tracker_with_base(base)
+    tracker.collect_step_external(
+        Step(name="api_call", data="attacker-controlled"),
+        full_path=str(victim),
+    )
+
+    assert victim.read_text() == '{"do_not":"overwrite"}', (
+        "tracker overwrote a file outside its base directory — arbitrary write "
+        "via the trajectory_path parameter is unmitigated"
+    )
+
+
+def test_external_step_refuses_traversal_out_of_base_dir(tmp_path: Path):
+    base = tmp_path / "trajectories"
+    base.mkdir()
+    victim = tmp_path / "victim.json"
+    victim.write_text('{"do_not":"overwrite"}')
+
+    traversal = os.path.join(str(base), "..", "victim.json")
+    assert os.path.exists(traversal)  # non-vacuous: the join does resolve to the victim
+
+    tracker = _tracker_with_base(base)
+    tracker.collect_step_external(Step(name="api_call", data="x"), full_path=traversal)
+
+    assert victim.read_text() == '{"do_not":"overwrite"}'
+
+
+def test_external_step_still_writes_inside_base_dir(tmp_path: Path):
+    base = tmp_path / "trajectories"
+    base.mkdir()
+    legit = base / "experiment" / "task-1.json"
+    legit.parent.mkdir(parents=True)
+
+    tracker = _tracker_with_base(base)
+    tracker.collect_step_external(Step(name="api_call", data="ok"), full_path=str(legit))
+
+    assert legit.exists(), "a path inside the base directory must still be written"
+    assert "steps" in legit.read_text()


### PR DESCRIPTION
## Bug fix

Fixes #636

### Summary

`ActivityTracker.collect_step_external` in `src/cuga/backend/activity_tracker/tracker.py` wrote
the file path it was given after checking only that the parent directory existed, not that the
path stayed inside the directory the tracker writes to. On the registry server that path is the
`trajectory_path` value from the `/functions/call` request, so the file written was chosen by the
caller rather than the server.

The write is now confined to `_base_dir` with `assert_resolved_path_under`, the same helper as
#632. Normal trajectory recording is unchanged, since those paths are already inside `_base_dir`;
a path outside it is refused and logged.

The helper is imported inside the function rather than at module top, because its package imports
the tracker back and a top-level import would be circular. Same as `backends.py`.

### Testing

`tests/unit/test_tracker_external_path_containment.py` — three tests: an outside path is refused
and the target file untouched; a traversal path is refused, having first asserted the join really
does resolve to the target so it cannot pass for the wrong reason; an inside path still writes.
Both refusal tests were confirmed to fail against the old code.

`pytest tests/unit`: only the 17 failures already on `main`, none in the tracker. `ruff check` and
`ruff format --check` clean. The end-to-end request that overwrote a file before the change leaves
it untouched after it.

### Code scanning

This reopens alerts **#11, #12, #13 and #30**, which report exactly this and were dismissed as
false positives in February with no recorded reason. The CodeQL check here passes — it introduces
no new alerts, because the lines it changes already carry alerts on `main`.

They close only once #634 is also on `main`. Measured locally with CodeQL 2.26.2, `tracker.py`
goes from 4 `py/path-injection` findings with this PR alone to 0 with #634 as well. This PR
supplies the containment check; #634 makes CodeQL able to recognise it. Neither alone closes them.

Merge #634 first.

- [x] Verified fix locally; tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented trajectory files from being written outside the designated tracking directory.
  - Valid paths within the tracking directory continue to be supported.
  - Improved protection against directory traversal attempts.

- **Tests**
  - Added coverage for valid, invalid, and traversal-based paths.
  - Added verification that registry-recorded API activity is correctly saved.
  - Included these checks in the automated test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->