### PR TITLE
fix(cuga-lite): keep block locals when code execution times out

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/local/local_executor.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/local/local_executor.py
@@ -14,6 +14,16 @@ from ..common.benchmark_mode import is_relaxed_execution
 from cuga.backend.cuga_graph.nodes.cuga_lite.tracking.tracker import BlockToolCallCounter
 
 
+class _BlockSystemExit:
+    """Carrier so exit()/SystemExit inside a Task does not escape the event loop."""
+
+    __slots__ = ("exc", "locals")
+
+    def __init__(self, exc: BaseException, locals_: dict[str, Any]):
+        self.exc = exc
+        self.locals = locals_
+
+
 class LocalExecutor(BaseExecutor):
     """Handles local code execution with restricted environment."""
 
@@ -86,42 +96,74 @@ class LocalExecutor(BaseExecutor):
 
                 async_main = exec_locals['_async_main']
                 BlockToolCallCounter.reset()
-                try:
-                    result_locals = await asyncio.wait_for(async_main(), timeout=timeout)
-                except asyncio.TimeoutError:
+
+                # Run as a Task so a timeout can read the still-live frame before
+                # cancelling. ``wait_for`` on a bare coroutine clears that frame,
+                # which is why variables computed before the stall used to vanish.
+                #
+                # SystemExit inside a Task is re-raised into the event loop by
+                # asyncio (it escapes ``except SystemExit`` around ``wait``), so
+                # catch it inside the task and return a carrier instead.
+                async def _run_block():
+                    try:
+                        return await async_main()
+                    except SystemExit as e:
+                        return _BlockSystemExit(e, LocalExecutor._locals_from_frame(e, "_async_main"))
+
+                task = asyncio.create_task(_run_block())
+                done, _pending = await asyncio.wait({task}, timeout=timeout)
+                if not done:
+                    recovered = self._locals_from_coro(task.get_coro(), "_async_main")
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+                    context_locals.update(recovered)
                     # Preserve the evidence instead of discarding it: the agent
                     # otherwise sees a bare timeout, learns nothing, and re-runs
                     # the same loop until the step limit.
                     partial_stdout = stdout_buf.getvalue()
                     calls_made = BlockToolCallCounter.current_count()
+                    kept = sorted(k for k in recovered if not callable(recovered[k]))
+                    if kept:
+                        kept_note = (
+                            f"kept variables from this block: {', '.join(kept)} "
+                            "(available in the next block).\n"
+                        )
+                    else:
+                        kept_note = "no variables from this block were saved.\n"
                     guidance = (
                         f"Error during execution: Execution timed out after {timeout} seconds.\n"
                         f"This code block started {calls_made} tool call(s) before it was killed; "
-                        "ALL variables from this block are LOST (nothing was saved).\n"
+                        f"{kept_note}"
                         "Do NOT rerun the same code — it will time out again. Restructure instead: "
                         "use a bulk/aggregate tool (find_tools), or process a small batch of items "
-                        "per code block and store partial progress in a variable (variables persist "
-                        "across blocks only when the block finishes in time).\n"
+                        "per code block and store partial progress in a variable.\n"
                     )
                     if partial_stdout.strip():
                         guidance += f"Partial stdout before the timeout:\n{partial_stdout}"
                     else:
                         guidance += "(no stdout was printed before the timeout)"
                     return guidance
-                context_locals.update(result_locals)
+                outcome = task.result()
+                if isinstance(outcome, _BlockSystemExit):
+                    # `exit()` is a reasonable thing for generated code to reach —
+                    # "stop this block, there is nothing more to do". Honour that
+                    # intent: end the block early and keep variables computed
+                    # before the exit (#629 / #630).
+                    context_locals.update(outcome.locals)
+                    reason = str(outcome.exc) if str(outcome.exc) and not str(outcome.exc).isdigit() else ""
+                    note = "Block ended early: the code called exit()/quit() or raised SystemExit"
+                    note += f" ({reason}).\n" if reason else ".\n"
+                    note += (
+                        "This ended the block only — variables defined before it were kept and "
+                        "are available in the next block. Nothing after the exit ran.\n"
+                    )
+                    captured = stdout_buf.getvalue()
+                    return f"{note}{captured}" if captured.strip() else f"{note}(no output printed)"
+                context_locals.update(outcome)
         except SystemExit as e:
-            # `exit()` is a reasonable thing for generated code to reach — "stop
-            # this block, there is nothing more to do". The intent is fine; the
-            # blast radius was not. Relaxed execution hands the block the full
-            # builtins, and SystemExit is a BaseException, so it walked past
-            # every `except Exception` above this and killed the host process
-            # mid-run (an evaluation sweep died at task 23 of 40 this way).
-            #
-            # So honour the intent instead of forbidding it: end the block early
-            # and keep everything a normal block would have kept. `return
-            # locals()` never ran, but the frame is still alive on the
-            # traceback, so the variables computed before the exit are readable
-            # from it and persist across blocks as usual.
+            # Safety net for SystemExit raised outside the task (e.g. during
+            # setup). Task-scoped exit()/SystemExit is handled via _BlockSystemExit.
             context_locals.update(self._locals_from_frame(e, "_async_main"))
             reason = str(e) if str(e) and not str(e).isdigit() else ""
             note = "Block ended early: the code called exit()/quit() or raised SystemExit"
@@ -163,6 +205,27 @@ class LocalExecutor(BaseExecutor):
         if frame is None:
             return {}
         return {k: v for k, v in frame.f_locals.items() if not k.startswith("__")}
+
+    @staticmethod
+    def _locals_from_coro(coro: Any, func_name: str) -> dict[str, Any]:
+        """Read locals from a still-suspended coroutine frame.
+
+        Used on the timeout path: the Task is stalled at an ``await``, so its
+        frame is live until we cancel. Must be called before cancellation —
+        afterwards the frame is cleared and recovery returns nothing. Walks
+        ``cr_await`` so a thin wrapper around ``_async_main`` still works.
+        """
+        seen: set[int] = set()
+        while coro is not None and id(coro) not in seen:
+            seen.add(id(coro))
+            frame = getattr(coro, "cr_frame", None)
+            while frame is not None:
+                if frame.f_code.co_name == func_name:
+                    return {k: v for k, v in frame.f_locals.items() if not k.startswith("__")}
+                frame = frame.f_back
+            nxt = getattr(coro, "cr_await", None)
+            coro = nxt if asyncio.iscoroutine(nxt) else None
+        return {}
 
     def format_error(
         self,

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_timeout_evidence.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_timeout_evidence.py
@@ -86,6 +86,38 @@ await asyncio.sleep(5)"""
 
 
 @pytest.mark.asyncio
+async def test_timeout_keeps_variables_computed_before_stall():
+    """Locals assigned before the stalling await survive the timeout.
+
+    ``asyncio.wait_for`` on a bare coroutine cancels and clears the frame
+    before it can be read, so the block's namespace used to be discarded even
+    though the frame was still live at the timeout instant. Variables assigned
+    after the stalling line must stay absent — recovered state is real
+    progress, not a partial write.
+    """
+    executor = LocalExecutor()
+    ctx: dict = {}
+    code = _wrap(
+        """cart_total = 299.0
+denise_email = "deniseburch@gmail.com"
+print(f"cart_total={cart_total}")
+await asyncio.sleep(5)
+after_timeout = True"""
+    )
+
+    result = await executor.execute(wrapped_code=code, context_locals=ctx, timeout=0.3)
+
+    assert "timed out after 0.3 seconds" in result
+    assert ctx.get("cart_total") == 299.0
+    assert ctx.get("denise_email") == "deniseburch@gmail.com"
+    assert "after_timeout" not in ctx
+    assert "cart_total" in result
+    assert "denise_email" in result
+    assert "LOST" not in result
+    assert "after_timeout" not in result
+
+
+@pytest.mark.asyncio
 async def test_successful_block_unaffected():
     """Blocks that finish in time keep the existing output contract."""
     executor = LocalExecutor()


### PR DESCRIPTION
## Bug fix

Fixes #642

### Summary

When a sandbox code block hits the execution timeout, variables computed before the stalling `await` were discarded even though the coroutine frame was still live. `asyncio.wait_for` on a bare coroutine cancels and clears that frame before it can be read, and the guidance text told the agent that **all** variables were lost — so it rediscovered work that had already succeeded (measured cost on AppWorld `2e9b91e_1` and 28 timeout blocks in one `test_easy` sweep).

**Root cause:** timeout used `wait_for(async_main())`, which destroys the frame; `context_locals` was never updated on that path.

**Solution:**
- Run the block as a `Task` and use `asyncio.wait(..., timeout=...)` so the frame can be read **before** cancel
- Merge recovered locals into `context_locals` (same idea as `_locals_from_frame` for `SystemExit` in #630)
- Catch `SystemExit` inside the task via a carrier — Task-scoped `SystemExit` otherwise escapes into the event loop and breaks the #630 `exit()` path
- Update timeout guidance to list kept variables instead of claiming total loss

### Testing
- [x] Verified bug locally: timed-out block printed `cart_total`/`denise_email` then left `context_locals` empty with "ALL variables ... LOST"
- [x] Verified fix locally; tests pass — `test_timeout_evidence.py` + `test_code_executor.py` (35 passed)
- [x] Added regression `test_timeout_keeps_variables_computed_before_stall` (pre-stall vars kept; post-stall vars absent; guidance lists kept names)
- [x] Confirmed `test_generated_exit_ends_the_block_not_the_runtime` still passes
- [x] `ruff check` / `ruff format` clean on changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved variables and partial output when task execution times out.
  * Ensured `exit()` and `SystemExit` end only the current block without losing earlier results.
  * Improved handling of suspended asynchronous tasks so retained state is reported accurately.

* **Tests**
  * Added coverage confirming variables created before a timeout remain available, while later assignments do not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->