### PR TITLE
docs(security): add a security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -98,7 +98,9 @@ out-of-scope report than miss a real one.
 3. We develop the fix in the advisory's temporary private fork, so it is not public before the
    advisory is ready.
 4. We release a version containing the fix.
-5. We publish the advisory and request a CVE.
+5. We publish the advisory and request a CVE. CVEs for this repository are issued by GitHub,
+   which acts as the CVE Numbering Authority for advisories filed by maintainers of a hosted
+   open-source project.
 
 We ask that you keep the report confidential until the advisory is published. We aim to publish
 within 90 days of the report; if a fix is taking longer, we will tell you why rather than let the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,110 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Report privately. Do not open a public issue, pull request, or discussion for an undisclosed
+vulnerability.**
+
+Use GitHub's private vulnerability reporting, which is enabled on this repository:
+
+**https://github.com/cuga-project/cuga-agent/security/advisories/new**
+
+The report is visible only to you and the maintainers. If you cannot use that form, open a public
+issue that says only that you have a security report and asks for a private channel — no details.
+
+### What to include
+
+The more of this you can provide, the faster we can confirm and fix:
+
+- The version affected (`cuga` release, or the commit if you are running from source).
+- How CUGA was deployed — which services were running, what was reachable from where, and whether
+  the registry or main server was bound to a non-loopback address.
+- A reproduction: a request, script, or test that demonstrates the issue. A self-contained
+  reproduction that needs no model provider key is ideal, but not required.
+- What the reproduction proves — the file read, the credential used, the boundary crossed.
+- Any impact you think we will underestimate.
+
+### What to expect
+
+- **Acknowledgement within 5 business days**, confirming we received the report.
+- **An initial assessment within 10 business days**, telling you whether we consider it a
+  vulnerability, our severity view, and roughly when a fix will land.
+- Progress updates as the fix moves, and notice before the advisory is published.
+
+If you have not heard from us within those windows, please follow up on the report thread — a
+missed notification is more likely than a decision not to respond.
+
+## Supported versions
+
+CUGA is pre-1.0 and moves quickly. Security fixes land in the next release cut from `main`; we do
+not backport to earlier minor versions.
+
+| Version | Supported |
+| --- | --- |
+| Latest `0.3.x` release | Yes |
+| Any earlier release | No — upgrade to the latest |
+
+If you are pinned to an older version and cannot upgrade, say so in your report and we will tell
+you which change to apply, though we will not be publishing a patched build for it.
+
+## Scope
+
+CUGA is an agent harness that runs model-generated code, calls third-party APIs with stored
+credentials, and serves a local web UI. That shape makes the boundary worth stating explicitly.
+
+### In scope
+
+- Authentication or authorization bypass in the main server, the tool registry, or the secrets API.
+- Path traversal, SSRF, injection, or any request-reachable flaw that reads or writes data outside
+  its intended directory or host.
+- Disclosure of stored credentials or secrets — through API responses, logs, traces, the activity
+  tracker, or exported trajectories.
+- Escape from the code-execution sandbox to the host beyond the level of access the sandbox is
+  documented to allow.
+- Prompt injection **that crosses a security boundary** — for example, causing exfiltration of a
+  stored credential, or reaching a host or file the operator never granted.
+
+### Out of scope
+
+- **Model behaviour on its own.** The agent producing a wrong, unhelpful, or undesirable answer is
+  a bug, not a vulnerability. Report it as a normal issue. Prompt injection is in scope only where
+  it crosses a boundary, as above.
+- **Attacks that assume an already-compromised host**, a malicious operator, or an attacker who
+  already holds the credentials in question.
+- **`docs/examples`.** These are standalone illustrations, not shipped code.
+- **Dependency advisories with no demonstrated reachable path** in CUGA. Dependabot already tracks
+  our dependencies; a report is useful when you can show the vulnerable path is actually reached.
+- **Best-practice observations with no demonstrated impact** — a missing header, a scanner finding
+  with no exploit behind it.
+
+### Deployment choices you should know about
+
+Some defaults are chosen for local development and are not safe on an untrusted network. These are
+documented posture, not undisclosed flaws, but reports that demonstrate concrete impact in a
+realistic deployment are still welcome:
+
+- Services may bind to all interfaces rather than loopback. Verify your own exposure rather than
+  assuming CUGA is unreachable.
+- The code-execution sandbox is a containment boundary, not a hostile-multi-tenant boundary. Do not
+  run untrusted third-party tasks on infrastructure you care about without your own isolation.
+
+If you are unsure whether something is in scope, report it. We would rather triage an
+out-of-scope report than miss a real one.
+
+## How we handle a report
+
+1. We confirm the report privately and open a draft security advisory.
+2. We assess impact and assign a CVSS score and CWE.
+3. We develop the fix in the advisory's temporary private fork, so it is not public before the
+   advisory is ready.
+4. We release a version containing the fix.
+5. We publish the advisory and request a CVE.
+
+We ask that you keep the report confidential until the advisory is published. We aim to publish
+within 90 days of the report; if a fix is taking longer, we will tell you why rather than let the
+date pass in silence.
+
+## Credit
+
+Reporters are credited by name on the published advisory unless you ask us not to be. Tell us how
+you would like to be identified.


### PR DESCRIPTION
## Documentation

Closes #650

### Summary

The repository had no `SECURITY.md`. Private vulnerability reporting is already enabled, so
reports can be filed, but nothing told a researcher the channel existed, what was in scope, or
what response to expect. GitHub also showed the security policy as missing.

This adds the policy at `.github/SECURITY.md`, matching [docling-project/docling](https://github.com/docling-project/docling/blob/main/.github/SECURITY.md).
GitHub reads the policy from the root, `.github/` or `docs/` identically, so the Security tab and
the "Report a vulnerability" affordance work the same either way. No code changes.

Worth doing now: nine draft advisories are open against this repo and the fixes for #631 and #636
are merged. Publishing advisories raises visibility with researchers, and the first thing an
external reporter looks for is a policy. Without one, the likely outcome is a vulnerability
disclosed in a public issue before a fix exists.

### What it covers

- **Reporting** — the private advisory form, and an explicit request not to use public issues for
  undisclosed vulnerabilities. Includes what to put in a report.
- **Supported versions** — fixes land in the next release cut from `main`; no backports to earlier
  minors. Stated plainly rather than implying every past release on PyPI is patched.
- **Scope** — written around what CUGA actually is, rather than boilerplate. The distinction that
  matters for an agent harness: model output being wrong is a bug, not a vulnerability, while
  prompt injection *is* in scope where it crosses a boundary such as exfiltrating a stored
  credential.
- **Known deployment posture** — the non-loopback bind and the sandbox's containment level are
  recorded as documented choices rather than undisclosed flaws, so reports about them get triaged
  against a stated position instead of re-litigated each time. Deliberately not phrased as "out of
  scope", since GHSA-g82r covers a live issue in that area.
- **Handling process** — the sequence already followed for #631, #633 and #636: fix in the
  advisory's private fork, release, publish, request CVE. The policy names GitHub as the CNA that
  issues our CVEs. Verified against the sibling IBM-affiliated project: six of docling's CVEs were
  assigned by `GitHub_M` through the advisory flow and none by IBM's CNA, whose published scope is
  IBM-branded products only.
- **Credit** — reporters are credited unless they decline.

### Two things for reviewers to decide

1. **Response targets.** I put in acknowledgement within 5 business days and an initial assessment
   within 10, plus a 90-day publication aim. These are conservative placeholders chosen to be
   achievable, not measured against anything. Change them to whatever the team will actually
   commit to — a target we miss is worse than a slower one we meet.
2. **The supported-versions table** says the latest `0.3.x` only. If anyone is expected to be
   supported on an older pin, that needs to change.

### Type of Changes

- [x] Documentation

### Testing

Not code, so no tests. Verified:

- `https://github.com/cuga-project/cuga-agent/security/policy` returns 200, and private
  vulnerability reporting is confirmed enabled via the API, so the reporting link is live.
- `docs/examples`, referenced in the out-of-scope section, exists.
- Latest release confirmed as `v0.3.1`, matching the supported-versions table.
- `typos SECURITY.md` clean. Ruff skipped — no Python files changed.

### Checklist

- [x] Documentation only; no code or behaviour changes
- [x] Links and version references verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive security policy.
  * Documented vulnerability reporting procedures, supported versions, scope, response timelines, confidentiality, deployment considerations, and reporter recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
