### PR TITLE
feat(config): reasoning-effort model profiles for OpenAI-compatible endpoints

### DIFF
--- a/src/cuga/configurations/models/settings.openai.reasoning-high-32k.toml
+++ b/src/cuga/configurations/models/settings.openai.reasoning-high-32k.toml
@@ -1,0 +1,80 @@
+# OpenAI-platform profile: reasoning_effort=high AND enlarged completion budgets
+# (32000; action agent 8000).
+#
+# Use this over settings.openai.reasoning-high.toml when reasoning tokens crowd out
+# visible output at the stock budgets: reasoning is billed against the same max_tokens
+# (max_completion_tokens) budget, so a long think can consume all of it and return
+# empty content. The stock action-agent budget of 400 in particular is not survivable
+# for a reasoning model — the budget is exhausted before any content is emitted.
+# For clean A/B attribution against a default-effort run, prefer the stock-budget
+# profile: this one changes effort and budgets together.
+#
+# Use with:  AGENT_SETTING_CONFIG="settings.openai.reasoning-high-32k.toml"
+#
+# Works with any model served over an OpenAI-compatible endpoint (including LiteLLM
+# gateways via OPENAI_BASE_URL). For gpt-5*/o-series models, _is_reasoning_model()
+# suppresses the temperature line below; for other models it is sent and honored.
+# reasoning_effort reaches the provider either way via extra_params. Whether the
+# endpoint HONORS it is provider-specific — check output_token_details.reasoning
+# in usage after a run.
+# See cuga-agent#622 for making both knobs first-class instead of extra_params.
+
+[agent.task_decomposition.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.planner.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.chat.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.shortlister.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.plan_controller.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.final_answer.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.code.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.code_planner.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.qa.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 32000
+extra_params = { reasoning_effort = "high" }
+
+[agent.action.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 8000
+extra_params = { reasoning_effort = "high" }

--- a/src/cuga/configurations/models/settings.openai.reasoning-high.toml
+++ b/src/cuga/configurations/models/settings.openai.reasoning-high.toml
@@ -1,0 +1,86 @@
+# OpenAI-platform profile: stock budgets + reasoning_effort=high.
+#
+# Differs from settings.openai.toml by exactly ONE thing: extra_params.reasoning_effort.
+# Budgets are left at the stock 16000 / 400 so an A/B against a default-effort run has a
+# single independent variable. If reasoning tokens crowd out visible output on your
+# workload (empty-content completions), use settings.openai.reasoning-high-32k.toml,
+# which pairs high effort with enlarged budgets.
+#
+# Use with:  AGENT_SETTING_CONFIG="settings.openai.reasoning-high.toml"
+#
+# Works with any model served over an OpenAI-compatible endpoint (including LiteLLM
+# gateways via OPENAI_BASE_URL). What differs by model is how models.py reads it:
+# for gpt-5*/o-series, _is_reasoning_model() drops the temperature line below; for
+# gpt-oss and other unmatched models it is sent and honored. reasoning_effort reaches
+# the provider on either path — both branches merge extra_params into client kwargs.
+# Whether the endpoint HONORS it is provider-specific: after a run, check
+# output_token_details.reasoning (usage) — if it stays near zero on hard tasks, the
+# endpoint is swallowing the parameter.
+#
+# Verified end-to-end with gpt-oss-120b behind an OpenAI-compatible LiteLLM gateway:
+# mean reasoning tokens/call rose ~5x vs the default-effort profile on the same tasks.
+#
+# Budget note: reasoning tokens are billed against the same max_tokens
+# (max_completion_tokens) budget. A long enough think can consume the whole budget and
+# return empty content; if that appears, it is a budget artifact, not a model result.
+# See cuga-agent#622 for making both knobs first-class instead of extra_params.
+
+[agent.task_decomposition.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.planner.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.chat.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.shortlister.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.plan_controller.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.final_answer.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.code.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.code_planner.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.qa.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 16000
+extra_params = { reasoning_effort = "high" }
+
+[agent.action.model]
+platform = "openai"
+temperature = 0.1
+max_tokens = 400
+extra_params = { reasoning_effort = "high" }


### PR DESCRIPTION
## Feature

Part of #622 — a deliberately small, config-only step. It does **not** close #622: first-class `reasoning_effort` on `LLMConfig`, per-platform wire-format translation, and the model capability table remain open there.

### Summary

Adds two ready-made model settings profiles so anyone can run reasoning models (gpt-5*/o-series, gpt-oss, or anything behind a LiteLLM gateway) at high reasoning effort by switching one env var — no code changes:

- **`settings.openai.reasoning-high.toml`** — `settings.openai.toml` + `extra_params = { reasoning_effort = "high" }` on every agent section, budgets untouched (16000 / 400). Exactly one delta vs the default profile, so it A/Bs cleanly against existing default-effort runs.
- **`settings.openai.reasoning-high-32k.toml`** — same, with `max_tokens` raised to 32000 (action agent 400 → 8000), for workloads where reasoning tokens crowd out visible output. Reasoning is billed against the same `max_completion_tokens` budget; at stock budgets we observed calls where a long think consumed the entire budget and returned empty content, and the 400-token action budget is exhausted before any content is emitted.

Usage: `AGENT_SETTING_CONFIG="settings.openai.reasoning-high.toml"`.

No code change is needed because both the reasoning and non-reasoning paths of the `openai` and `litellm` platform branches already merge `extra_params` into client kwargs (`_merge_optional_sampling`), and `reasoning_effort` is a first-class `ChatOpenAI` field — it goes out as a top-level payload key. Whether the *endpoint* honors it is provider-specific; the file headers document how to verify (`output_token_details.reasoning` in usage).

### Testing
- [x] Tested locally; tests pass
- Verified end-to-end with `gpt-oss-120b` behind an OpenAI-compatible LiteLLM gateway: constructing via `LLMManager._create_llm_instance` puts `reasoning_effort=high` in the request payload, and mean reasoning tokens/call rose ~5× vs the default profile on the same AppWorld task set (means of 226 → 1,228 tokens/call across 43-task runs).
- Also exercised with a `gpt-5*`-class Azure deployment through the same gateway: temperature correctly suppressed by `_is_reasoning_model()`, `reasoning_effort` accepted.
- Config-only change; no Python touched, so no new unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high-reasoning configuration profiles for OpenAI-compatible models.
  * Added options for standard and extended token budgets, including specialized action-agent limits.
  * Configured models to use consistent low-temperature settings for more focused responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->