### PR TITLE
fix(supervisor): resolve explicit delegation variables from script frame

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/delegation.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/delegation.py
@@ -36,6 +36,15 @@ def resolve_names_from_caller_frame(variable_names: List[str]) -> Dict[str, Any]
     return resolved
 
 
+def _variables_from_supervisor_vm() -> Dict[str, Any]:
+    """Copy the active supervisor variable manager into a name→value dict."""
+    exec_ctx = resolve_supervisor_execution_context()
+    if exec_ctx is None or exec_ctx.variable_manager is None:
+        return {}
+    vm = exec_ctx.variable_manager
+    return {name: vm.get_variable(name) for name in vm.get_variable_names()}
+
+
 def _record_delegation(
     adapter: Any,
     agent_name: str,
@@ -78,9 +87,10 @@ def create_agent_delegation_func(
         logger.info(f"Delegating to {agent_name}: {task[:100]}...")
 
         if isinstance(agent_or_config, CugaAgent):
-            vars_to_pass = {}
             if variables is not None:
                 vars_to_pass = resolve_names_from_caller_frame(variables)
+            else:
+                vars_to_pass = _variables_from_supervisor_vm()
             result = await agent_or_config.invoke(
                 task,
                 thread_id=f"supervisor_conversational_{agent_name}",

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/delegation.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/delegation.py
@@ -8,32 +8,14 @@ from typing import Any, Callable, Dict, List, Optional
 from loguru import logger
 
 from cuga.backend.cuga_graph.nodes.cuga_supervisor.execution_context import (
+    SUPERVISOR_EXEC_KEY,
     resolve_supervisor_execution_context,
 )
 from cuga.config import settings
 
 
-def resolve_names_from_caller_frame(variable_names: List[str]) -> Dict[str, Any]:
-    """Resolve names from the delegated code's caller frame.
-
-    LocalExecutor injects supervisor context into ``_async_main``'s globals; only
-    using ``f_locals`` missed those bindings, so sub-agents received no variables
-    and tasks showed e.g. ``amount=None``.
-    """
-    resolved: Dict[str, Any] = {}
-    frame = inspect.currentframe()
-    try:
-        caller = frame.f_back if frame is not None else None
-        if caller is None:
-            return resolved
-        for name in variable_names:
-            if name in caller.f_locals:
-                resolved[name] = caller.f_locals[name]
-            elif name in caller.f_globals:
-                resolved[name] = caller.f_globals[name]
-    finally:
-        del frame
-    return resolved
+def _frame_has_supervisor_exec(frame: Any) -> bool:
+    return SUPERVISOR_EXEC_KEY in frame.f_locals or SUPERVISOR_EXEC_KEY in frame.f_globals
 
 
 def _variables_from_supervisor_vm() -> Dict[str, Any]:
@@ -43,6 +25,42 @@ def _variables_from_supervisor_vm() -> Dict[str, Any]:
         return {}
     vm = exec_ctx.variable_manager
     return {name: vm.get_variable(name) for name in vm.get_variable_names()}
+
+
+def resolve_names_from_caller_frame(variable_names: List[str]) -> Dict[str, Any]:
+    """Resolve names from the generated supervisor script frame.
+
+    Walk to the frame holding ``SUPERVISOR_EXEC_KEY`` (``_async_main``), not the
+    immediate ``delegate_to_agent`` wrapper. Fill names missing from that frame
+    from the supervisor VM (prior-turn values are not locals yet).
+    """
+    resolved: Dict[str, Any] = {}
+    frame = inspect.currentframe()
+    try:
+        current = frame.f_back if frame is not None else None
+        first_caller = current
+        exec_frame = None
+        while current is not None:
+            if _frame_has_supervisor_exec(current):
+                exec_frame = current
+                break
+            current = current.f_back
+        target = exec_frame if exec_frame is not None else first_caller
+        if target is None:
+            return resolved
+        for name in variable_names:
+            if name in target.f_locals:
+                resolved[name] = target.f_locals[name]
+            elif name in target.f_globals:
+                resolved[name] = target.f_globals[name]
+        if any(name not in resolved for name in variable_names):
+            vm_vars = _variables_from_supervisor_vm()
+            for name in variable_names:
+                if name not in resolved and name in vm_vars:
+                    resolved[name] = vm_vars[name]
+    finally:
+        del frame
+    return resolved
 
 
 def _record_delegation(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/prompts/supervisor_lite_prompt.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/prompts/supervisor_lite_prompt.jinja2
@@ -79,7 +79,8 @@ Your output MUST be one of these two types. **Do not mix them.**
 3.  **DATA FROM AGENTS ONLY:** NEVER answer from your own knowledge. You MUST execute code that delegates to agents to get real data before providing a final answer.
 4.  **CHECK VARIABLES FIRST:** Before delegating to an agent, check if variables from a previous code execution already contain the data you need.
 5.  **COORDINATE MULTIPLE AGENTS:** You can call multiple agents in sequence across separate execution cycles, using results from one agent to inform the next agent's task.
-6.  **DYNAMIC PARAMETER PASSING:** After each agent execution, you will see the results in the execution output and available variables. You can analyze these results and decide what parameters to pass to the next agent. This allows for dynamic, adaptive workflows where Agent B's task depends on Agent A's results.
+6.  **DYNAMIC PARAMETER PASSING:** After each agent execution, you will see the results in the execution output and available variables. You can analyze these results and decide what parameters to pass to the next agent. This allows for dynamic, adaptive workflows where Agent B's task depends on Agent A's results. Prefer `variables=["name"]` so the next agent receives structured values. If you omit `variables`, known Variables are still forwarded.
+7.  **NEVER ASK THE USER FOR DATA YOU ALREADY HAVE:** If a sub-agent asks for a value that is already in Variables, retry the delegation with `variables=[...]`. Do not return that question to the user.
 
 ### Code Execution Requirements
 5.  **USE `await`:** All agent delegation functions are async. You MUST use `await` (e.g., `result = await delegate_to_crm_agent("Get customer data")`).

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/prompts/supervisor_lite_prompt.jinja2
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/prompts/supervisor_lite_prompt.jinja2
@@ -79,7 +79,7 @@ Your output MUST be one of these two types. **Do not mix them.**
 3.  **DATA FROM AGENTS ONLY:** NEVER answer from your own knowledge. You MUST execute code that delegates to agents to get real data before providing a final answer.
 4.  **CHECK VARIABLES FIRST:** Before delegating to an agent, check if variables from a previous code execution already contain the data you need.
 5.  **COORDINATE MULTIPLE AGENTS:** You can call multiple agents in sequence across separate execution cycles, using results from one agent to inform the next agent's task.
-6.  **DYNAMIC PARAMETER PASSING:** After each agent execution, you will see the results in the execution output and available variables. You can analyze these results and decide what parameters to pass to the next agent. This allows for dynamic, adaptive workflows where Agent B's task depends on Agent A's results. Prefer `variables=["name"]` so the next agent receives structured values. If you omit `variables`, known Variables are still forwarded.
+6.  **DYNAMIC PARAMETER PASSING:** After each agent execution, you will see the results in the execution output and available variables. You can analyze these results and decide what parameters to pass to the next agent. This allows for dynamic, adaptive workflows where Agent B's task depends on Agent A's results. Prefer `variables=["name"]` so the next agent receives structured values. If you omit `variables`, known Variables are still forwarded to internal agents.
 7.  **NEVER ASK THE USER FOR DATA YOU ALREADY HAVE:** If a sub-agent asks for a value that is already in Variables, retry the delegation with `variables=[...]`. Do not return that question to the user.
 
 ### Code Execution Requirements

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_delegation_recording.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_delegation_recording.py
@@ -191,6 +191,40 @@ async def test_delegation_auto_passes_supervisor_variables_when_omitted():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_delegation_forwards_explicit_variables():
+    mock_agent = _fake_agent()
+    with patch("cuga.sdk.CugaAgent", _FakeCugaAgent):
+        await _run_delegate(
+            _empty_delegation_state(),
+            mock_agent,
+            "async def _run():\n    return await delegate('get account value', variables=['user_id'])\n",
+            variable_manager=_FakeVM({"user_id": "user_alice_99"}),
+        )
+
+    assert mock_agent.invoke.await_args.kwargs["variables"] == {"user_id": "user_alice_99"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delegation_forwards_mid_script_explicit_variables():
+    mock_agent = _fake_agent()
+    with patch("cuga.sdk.CugaAgent", _FakeCugaAgent):
+        await _run_delegate(
+            _empty_delegation_state(),
+            mock_agent,
+            (
+                "async def _run():\n"
+                "    user_id = 'from_script'\n"
+                "    return await delegate('get account value', variables=['user_id'])\n"
+            ),
+            variable_manager=_FakeVM({"user_id": "from_vm"}),
+        )
+
+    assert mock_agent.invoke.await_args.kwargs["variables"] == {"user_id": "from_script"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_delegation_empty_variables_list_does_not_auto_pass():
     mock_agent = _fake_agent()
     with patch("cuga.sdk.CugaAgent", _FakeCugaAgent):

--- a/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_delegation_recording.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_delegation_recording.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -111,12 +111,23 @@ def test_record_delegation_updates_state_fields():
     assert state.metrics["last_delegated_agent"] == "crm_agent"
 
 
-@pytest.mark.asyncio
-async def test_delegation_func_records_internal_agent_result():
-    from cuga import CugaAgent
+class _FakeCugaAgent:
+    pass
 
-    adapter = _make_adapter()
-    state = SimpleNamespace(
+
+class _FakeVM:
+    def __init__(self, values):
+        self._values = dict(values)
+
+    def get_variable_names(self):
+        return list(self._values)
+
+    def get_variable(self, name):
+        return self._values.get(name)
+
+
+def _empty_delegation_state():
+    return SimpleNamespace(
         selected_agents=[],
         agent_results={},
         agent_variables={},
@@ -124,24 +135,70 @@ async def test_delegation_func_records_internal_agent_result():
         metrics={},
     )
 
-    mock_agent = CugaAgent(tools=[])
-    mock_result = SimpleNamespace(answer="worker answer", variables={"x": 1}, chat_messages=None)
-    mock_agent.invoke = AsyncMock(return_value=mock_result)
 
-    delegate = create_agent_delegation_func(adapter, "worker", mock_agent)
+def _fake_agent(*, answer="ok", variables=None, chat_messages=None):
+    agent = _FakeCugaAgent()
+    agent.invoke = AsyncMock(
+        return_value=SimpleNamespace(answer=answer, variables=variables, chat_messages=chat_messages)
+    )
+    return agent
 
+
+def _run_delegate(state, mock_agent, source, *, variable_manager=None):
+    delegate = create_agent_delegation_func(_make_adapter(), "worker", mock_agent)
     namespace = {
-        SUPERVISOR_EXEC_KEY: SupervisorExecutionContext(state=state, variable_manager=None),
+        SUPERVISOR_EXEC_KEY: SupervisorExecutionContext(state=state, variable_manager=variable_manager),
         "delegate": delegate,
     }
-    exec(
-        "async def _run():\n    return await delegate('do work')\n",
-        namespace,
-        namespace,
-    )
-    answer = await namespace["_run"]()
+    exec(source, namespace, namespace)
+    return namespace["_run"]()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delegation_func_records_internal_agent_result():
+    state = _empty_delegation_state()
+    mock_agent = _fake_agent(answer="worker answer", variables={"x": 1})
+    with patch("cuga.sdk.CugaAgent", _FakeCugaAgent):
+        answer = await _run_delegate(
+            state,
+            mock_agent,
+            "async def _run():\n    return await delegate('do work')\n",
+        )
 
     assert answer == "worker answer"
     assert state.agent_results["worker"] == "worker answer"
     assert state.agent_variables["worker"] == {"x": 1}
     assert state.selected_agents == ["worker"]
+    mock_agent.invoke.assert_awaited_once()
+    assert mock_agent.invoke.await_args.kwargs.get("variables") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delegation_auto_passes_supervisor_variables_when_omitted():
+    mock_agent = _fake_agent()
+    with patch("cuga.sdk.CugaAgent", _FakeCugaAgent):
+        await _run_delegate(
+            _empty_delegation_state(),
+            mock_agent,
+            "async def _run():\n    return await delegate('get account value')\n",
+            variable_manager=_FakeVM({"user_id": "user_alice_99"}),
+        )
+
+    assert mock_agent.invoke.await_args.kwargs["variables"] == {"user_id": "user_alice_99"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_delegation_empty_variables_list_does_not_auto_pass():
+    mock_agent = _fake_agent()
+    with patch("cuga.sdk.CugaAgent", _FakeCugaAgent):
+        await _run_delegate(
+            _empty_delegation_state(),
+            mock_agent,
+            "async def _run():\n    return await delegate('get account value', variables=[])\n",
+            variable_manager=_FakeVM({"user_id": "user_alice_99"}),
+        )
+
+    assert mock_agent.invoke.await_args.kwargs.get("variables") is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug fix

Fixes #655

Continues #656 (addresses review: explicit `variables=[...]` resolved from the wrong frame).

### Summary

`resolve_names_from_caller_frame` used a single `f_back`, so it landed on `delegate_to_agent` instead of the generated `_async_main` frame. `variables=["user_id"]` therefore resolved to `{}` and the sub-agent was invoked with `variables=None`.

The helper now walks to the frame that holds `SUPERVISOR_EXEC_KEY`, then fills remaining names from the supervisor VM. Mid-script assignments come from that frame; prior-turn values come from the VM. `variables=[]` still opts out.

Omitted-`variables` auto-forward remains internal-agent-only. Rule 6/7 still prefer an explicit list, which now actually forwards values (including on the A2A paths that share the helper).

### Testing
- [x] Verified fix locally; tests pass
- `uv run pytest src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_delegation_recording.py src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_supervisor_graph_adapter.py src/cuga/backend/cuga_graph/nodes/cuga_supervisor/tests/test_execution_context.py` — 31 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e50fe4b-4a85-403e-a93b-e09baf1e507c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e50fe4b-4a85-403e-a93b-e09baf1e507c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

