### PR TITLE
feat(cuga-lite): pluggable shortlister with cosine and hybrid strategies (#624)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,9 @@ jobs:
           uv run pytest tests/unit/test_cuga_lite_bind_tools.py \
             tests/unit/test_bind_tools_safe_fallback.py \
             tests/unit/test_tool_use_failed_recovery.py
+          # Pluggable shortlister (#624): every config surface must stay wired —
+          # a key reachable from settings but not the SDK reads as "config does nothing".
+          uv run pytest tests/unit/test_shortlister_config_surfaces.py
           # call_model prompt assembly: the variables addendum must reach the model
           # but never be persisted into history (#600) — unbounded copies previously
           # exhausted the context window mid-task.

--- a/README.md
+++ b/README.md
@@ -940,6 +940,64 @@ mode = 'api'  # 'api', 'web', or 'hybrid'
 </details>
 
 <details>
+<summary>🔍 Tool Shortlisting</summary>
+
+## What it is
+
+When an app exposes many tools, CUGA shrinks the set before the model sees it. This happens in two places: `find_tools` (the agent asking "what tools exist for X?") and the `bind_tools` provider cap. Both are pluggable.
+
+## Strategies
+
+| Strategy | How it ranks | Cost |
+|---|---|---|
+| `llm` (default) | asks the model | one LLM call per shortlist |
+| `embedding` | local cosine similarity | no LLM call, ~65ms warm |
+| `hybrid` | cosine cuts to `top_k`, then the LLM picks | one LLM call, much smaller prompt |
+
+`embedding` compares one vector built from your question against one vector per tool (name + description + parameter names + return field names). It is strong at **recall** but weak at separating near-identical tools such as `get_contacts` (list) and `get_contact` (by id) — so `hybrid` is usually the better choice for discovery, and `embedding` for the provider cap where only "don't drop the needed tool" matters.
+
+Embeddings are local by default (`all-MiniLM-L6-v2` via fastembed, ~90MB, cached under `~/.cache/cuga/fastembed`): no network call, no API cost. The first call while the model is still downloading is served by the LLM strategy, so **a query never waits on a download**.
+
+## Configuration
+
+```toml
+[shortlister]
+strategy = "hybrid"   # llm | embedding | hybrid | "my.pkg.MyShortlister"
+threshold = 128       # engage the cosine stage only above this many candidates
+top_k = 128           # how many candidates the cosine stage keeps
+max_results = 10      # find_tools only: max tools shown to the agent
+```
+
+Equivalent via env: `DYNACONF_SHORTLISTER__STRATEGY=hybrid`. Or from the SDK, per agent or per call:
+
+```python
+from cuga import CugaAgent, Shortlister
+
+agent = CugaAgent(tools=[...], shortlister=Shortlister(strategy="hybrid"))
+await agent.invoke("...", shortlister=Shortlister(top_k=32))   # per-call override
+```
+
+**At or below `threshold` candidates nothing changes** — the cosine stage does not run and shortlisting behaves exactly as it always has. Set `threshold = 0` to always engage the configured strategy.
+
+> Note: `[shortlister] threshold` (128) is *not* `advanced_features.shortlisting_tool_threshold` (35). The latter decides when tools are hidden behind `find_tools` in the prompt; the former decides when the cosine stage engages inside the shortlister.
+
+## Custom strategies
+
+Point `strategy` at a dotted class path, or pass an instance:
+
+```python
+class MyShortlister:
+    name = "mine"
+    async def shortlist(self, request) -> "list[ShortlistCandidate]": ...
+
+agent = CugaAgent(tools=[...], shortlister=Shortlister(instance=MyShortlister()))
+```
+
+See `docs/design/pluggable-shortlister.md` for the full design.
+
+</details>
+
+<details>
 <summary>📝 Special Instructions Configuration</summary>
 
 ## How It Works

--- a/docs/design/pluggable-shortlister.md
+++ b/docs/design/pluggable-shortlister.md
@@ -1,0 +1,1028 @@
+# Pluggable Shortlister for CUGA Lite — Spec & Design
+
+Status: implemented (#624), with deliberate reductions — see "What shipped" below
+Scope: `src/cuga/backend/cuga_graph/nodes/cuga_lite/`, `src/cuga/sdk.py`, `src/cuga/config.py`
+
+## What shipped vs. what this document designed
+
+The implementation deliberately dropped several designed pieces to keep the diff
+against `main` minimal. Each is easy to add later if a need appears:
+
+| Designed | Shipped | Why |
+|---|---|---|
+| `ShortlistResult` with a `notes` list | strategies return `List[ShortlistCandidate]` | `notes` had no producer once name-validation was dropped; a bare list is the simplest thing that works |
+| Name-validation + bounded retries in `LLMShortlister` | not implemented | that is PR #549's unmerged work; duplicating it would have conflicted and changed behavior beyond this feature's scope. `main` silently drops unknown names, and so does this |
+| `prewarm` config + `prepare_node` hook | not implemented | the lazy-load + fallback path already guarantees no query blocks on a download, so prewarm was a pure optimization — and it was the only reason `prepare_node.py` appeared in the diff |
+| `[shortlister] model` (agent-settings key for the LLM leg) | not implemented | unrequested scope; the LLM leg keeps `settings.agent.code.model`, exactly as before |
+| `prompt_preselect` | not implemented | was already marked "later, measure first"; shipping a dead config key is worse than shipping none |
+| Batch/asymmetric helpers added to `storage/embedding/embedding_service.py` | implemented inside `shortlister/embedding.py` | keeps the change self-contained and leaves the knowledge engine untouched |
+| Server/demo-UI override wiring | not implemented | tracked as follow-up; settings, env, `configurable` and the SDK all work |
+
+**Related work:** no existing issue or PR proposes a pluggable/non-LLM shortlister — this is new.
+Two open PRs touch the same functions and must be sequenced against; see [§8](#8-related-issues-and-prs).
+
+---
+
+## Context
+
+CUGA Lite reduces a large tool catalogue down to a workable candidate set before the model
+sees it. Today that reduction is **always LLM-based**, at two independent call sites, and it
+is not configurable beyond an on/off threshold.
+
+**Why change it:**
+
+1. **Cost & latency.** Every `find_tools` call is a full LLM round-trip whose prompt contains
+   the serialized schema of every tool in the app. On a 300-tool catalogue that is a large
+   prompt, paid for on every discovery call. The bind-time cap adds *another* round-trip per
+   `call_model` (`helpers/bind_tools.py:205-221` documents this cost explicitly).
+2. **Model coupling.** The bind-time shortlister runs on *the same model being bound*, so a
+   model without native structured output cannot shortlist at all — the reason
+   `BindToolsUnsupportedError` exists (`bind_tools/cap.py:35-43`). A non-LLM shortlister
+   removes that coupling entirely.
+3. **No extension point.** `PromptUtils.shortlist_tool_names` and `PromptUtils.find_tools` are
+   `@staticmethod`s called by name from two modules. There is no seam to swap the ranker.
+
+**Intended outcome:** a `ShortlisterStrategy` seam with three built-ins (`llm` — today's
+behavior and the default, `embedding` — cosine similarity, `hybrid` — cosine prefilter then
+LLM rerank), selectable by config name or dotted class path, plus a `CugaAgent(shortlister=…)`
+SDK argument. Default behavior is byte-for-byte unchanged.
+
+---
+
+## 1. Current state — exactly where shortlisting happens
+
+CUGA Lite's graph is three nodes (`cuga_agent_core/graph/shared_graph.py:50-61`):
+
+```
+START → prepare → call_model ⇄ sandbox → END
+```
+
+Tool reduction happens in **four layers**; only layers 3 and 4 are LLM-based, and those are
+the two seams this spec makes pluggable.
+
+| # | Layer | Location | Trigger | LLM? |
+|---|---|---|---|---|
+| 1 | App-level filtering | `adapter/prepare_node.py:169-224` | `sub_task_app` / `api_intent_relevant_apps` / `force_lite_mode_apps` | no |
+| 2 | Prompt collapse to `find_tools` | `adapter/prepare_node.py:225-263` | `total_tool_count > shortlisting_tool_threshold` (35) | no |
+| **3** | **Runtime discovery — `find_tools`** | `helpers/find_tools.py:54-137` → `prompt_utils.py:297-458` | agent calls it | **yes — seam A** |
+| **4** | **Bind-time provider cap** | `bind_tools/cap.py:275-383` → `prompt_utils.py:461-541` | candidates > `cuga_lite_bind_tools_max_count` (128) | **yes — seam B** |
+
+### Seam A — `PromptUtils.find_tools(query, all_tools, all_apps, llm, run_config) -> str`
+
+When layer 2 fires, the prompt shows **only** `find_tools`; the real callables stay in the
+sandbox namespace (`adapter/prepare_node.py:249-258`). The agent then calls
+`await find_tools(query, app_name)` in generated code. That runs an LLM chain against
+`prompts/shortlister/system.jinja2` with schema `ShortListerOutputLite`, then enriches each
+ranked name into params/response docs and returns **markdown**.
+
+Two behaviors to preserve: no fixed result count, and failures are **swallowed into an error
+string** for the agent rather than raised (`helpers/find_tools.py:112-131`).
+
+### Seam B — `PromptUtils.shortlist_tool_names(query, all_tools, all_apps, llm, top_k, instructions, run_config) -> List[str]`
+
+Same chain, but injects a `Return the {top_k} most relevant tools…` instruction and returns
+ranked names. Guards already in place: `top_k <= 0` or empty tools → `[]`; whitespace-only
+query → `[]`; hallucinated names filtered against `valid_names`; clamped to `top_k`.
+
+Failures here are **deliberately loud** — `RuntimeError` for a genuine failure or an empty
+ranking, re-raised through `adapter/graph_adapter.py:159-161` because silent truncation would
+corrupt native-vs-text benchmark comparisons.
+
+### The shared payload builder
+
+Both seams serialize candidates through `PromptUtils._build_shortlister_payload`
+(`prompt_utils.py:254-295`), whose docstring states it exists specifically to stop the two
+callers drifting. The new design keeps that single-source property by routing both through one
+strategy interface.
+
+---
+
+## 2. What already exists and must be reused
+
+| Need | Existing utility | Path |
+|---|---|---|
+| Async embed function (OpenAI / fastembed local / auto) | `create_embedding_function()` → `(embed_fn, dim)` | `backend/storage/embedding/embedding_service.py:58-96` |
+| Embedding config shape to copy (**not** inherit — see §3.4) | `get_embedding_config()`, `[storage.embedding]` | `embedding_service.py:22-39`, `settings.toml:136-141` |
+| Default model already registered at 384 dims | `LOCAL_MODEL_DIMS["sentence-transformers/all-MiniLM-L6-v2"]` | `embedding_service.py:13-19` |
+| Model cache (already warm on most installs) | `FASTEMBED_CACHE_DIR` → `~/.cache/cuga/fastembed` | `config.py:47-50` |
+| Cosine precedent | `np.dot` of normalized vectors vs a threshold | `cuga_graph/policy/agent.py:282-321` |
+| Param/response doc text for a tool | `PromptUtils.get_tool_docs(tool)` → `(params_doc, response_doc)` | `cuga_lite/prompt_utils.py` |
+| Dotted-path class loading | `get_class(path)` (used by `page_understanding.transformer_path`) | `config.py:363-367` |
+| Router → typed plan pattern | `ExecutionRouter.resolve()` → `ExecutionPlan` | `cuga_agent_core/policy/execution_policy.py:62-141` |
+| Config precedence pattern | `resolve_bind_tools_fields` (configurable > model profile > settings) | `cuga_lite/model_runtime_profile.py:75-116` |
+| Non-blocking model load contract | background load + `is_ready`/`ensure_loading`/`prewarm` | `backend/knowledge/reranker.py:1-20` |
+
+**No new dependencies.** `fastembed>=0.4.0` is already a core dep (`pyproject.toml:44`).
+
+---
+
+## 3. Design
+
+### 3.1 Core protocol
+
+New package `src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/`, `base.py`:
+
+```python
+@dataclass
+class ShortlistCandidate:
+    name: str                 # must match a StructuredTool.name in the request
+    score: float              # higher = more relevant; scale is strategy-defined
+    reasoning: str = ""       # "" for non-LLM strategies
+
+
+@dataclass
+class ShortlistRequest:
+    query: str                       # the step query (seam A) / first user message (seam B)
+    tools: List[StructuredTool]
+    apps: List[AppDefinition]
+    task_context: Optional[str] = None   # initial user message, kept separate — see §3A.3
+    top_k: Optional[int] = None      # None = strategy decides count (seam A semantics)
+    llm: Optional[BaseChatModel] = None
+    run_config: Any = None
+    instructions: Optional[str] = None
+
+
+@dataclass
+class ShortlistResult:
+    candidates: List[ShortlistCandidate]
+    notes: List[str] = field(default_factory=list)   # e.g. PR #549's filtered-names footer
+
+
+class ShortlisterStrategy(Protocol):
+    name: ClassVar[str]
+
+    async def shortlist(self, request: ShortlistRequest) -> ShortlistResult: ...
+    async def prewarm(self, tools: List[StructuredTool]) -> None: ...   # default no-op
+
+
+class ShortlisterUnavailableError(RuntimeError):
+    """Strategy cannot run (missing model/deps). Caller degrades to fallback_strategy."""
+```
+
+`ShortlistRequest`/`ShortlistResult` are dataclasses rather than bare kwargs and a bare list so
+third-party strategies do not break when a field is added later. Matches `EmbeddingSchemaConfig`
+and `RerankedCandidate`. `ShortlistResult.notes` is what carries strategy-produced annotations
+(hallucination filtering, degradation warnings) through to the rendered markdown without
+widening the return type again later.
+
+### 3.2 The critical refactor: split rank from render
+
+`PromptUtils.find_tools` currently fuses ranking (L324-357) and markdown rendering (L359-458).
+Extract the rendering half verbatim into `shortlister/render.py`:
+
+```python
+def render_tools_markdown(
+    candidates: List[ShortlistCandidate],
+    tools: List[StructuredTool],
+    notes: Optional[List[str]] = None,   # appended after the tool list; see PR #549
+) -> str
+```
+
+This is a pure move — same `Tool` model, same `get_tool_docs`, same `# Found N Matching Tool(s)`
+header, same `"No matching tools found for your query."` empty case. It is what lets a cosine
+strategy produce identical output shape with `reasoning` supplied differently.
+
+The `notes` parameter exists so PR #549's "Filtered out N unrecognized tool names" footer
+survives the extraction — it is a strategy-produced annotation, not a rendering concern. Both
+the empty-result branch and the normal branch must append it, matching #549's behavior.
+
+### 3.3 Built-in strategies
+
+**`llm` (default — behavior-preserving).** Wraps the existing chain. Maps
+`APIDetails.relevance_score → score`, `APIDetails.reasoning → reasoning`. When `top_k` is set
+it generates today's `Return the {top_k} most relevant tools…` instruction; when `None` it
+passes `instructions=""`. Identical prompts, identical schema, identical model resolution.
+
+**Name-validation and retry belong here, not in `PromptUtils`.** Hallucinating a tool name is
+an LLM failure mode; an embedding ranker draws names from the candidate list and structurally
+cannot invent one. So PR #549's helpers — `_partition_shortlist_details`,
+`_shortlist_retry_instructions`, `_format_filtered_tool_names_note`, and
+`_ainvoke_shortlister_with_name_validation` — move into `llm.py` as private methods of
+`LLMShortlister`, and the filtered-names note is returned as a `ShortlistResult.notes` entry.
+`EmbeddingShortlister` implements neither, and pays no retry cost.
+
+**`embedding` (cosine).**
+
+- *Document text* per tool, built once via `doc.py::tool_document(tool, app_name)`:
+
+  ```
+  {app_name} / {tool.name}
+  {tool.description}
+  Parameters:
+  {params_doc}       # from PromptUtils.get_tool_docs — no new schema walking
+  Returns:
+  {response_doc}
+  ```
+
+- *Embedding* via `create_embedding_function()`, inheriting `[storage.embedding]` unless
+  `[shortlister] embedding_provider` / `embedding_model` override it.
+- *Cache*: module-level `Dict[str, np.ndarray]` keyed by `sha256(model_name + tool_document)`
+  — a content fingerprint, so a changed tool description re-embeds automatically. Vectors are
+  **stored L2-normalized**, so scoring is one matmul: `scores = doc_matrix @ query_vec` →
+  O(N·d) in numpy, not a Python loop.
+- *Selection*: `top_k` when given. When `None` (seam A): every candidate with
+  `score >= min_score`, capped at `[shortlister] top_k`.
+- **Never-empty rule**: if nothing clears `min_score`, return the best `min(3, N)` anyway.
+  Non-negotiable — `cap.py` raises `RuntimeError` on an empty ranking, and an empty
+  `find_tools` result is a dead end for the agent.
+- `reasoning` = `f"Cosine similarity {score:.3f} to the query."` so the rendered markdown
+  keeps its shape.
+- Raises `ShortlisterUnavailableError` if no embed fn can be built (offline, missing model).
+
+**`hybrid`.** `embedding` prefilters to `[shortlister] top_k` (default 128), then
+`llm` ranks that reduced pool and its ordering wins. Cuts the LLM prompt from N tools to 50
+while keeping reasoning quality. If the embedding leg is unavailable it degrades to pure `llm`
+(logged once). The LLM leg's exceptions propagate unchanged — preserving each seam's existing
+failure contract.
+
+### 3.4 Selection: `[shortlister]` config section + router
+
+A dedicated section, mirroring `[execution]`/`ExecutionRouter` — the repo's cleanest and most
+recent extension pattern — rather than seven more flat `advanced_features` keys.
+
+```toml
+[shortlister]
+strategy = "llm"          # llm | embedding | hybrid | "my.pkg.MyShortlister"
+threshold = 128           # engage the cosine stage only when candidates EXCEED this
+top_k = 128               # how many candidates the cosine stage keeps
+max_results = 10          # seam A only: max tools actually rendered to the agent
+min_score = 0.15          # cosine floor — deliberately LOW; this is a recall filter (§3A.5)
+fallback_strategy = "llm" # used when `strategy` raises ShortlisterUnavailableError
+query_weight = 0.7        # step query vs task context blend (§3A.3)
+# Embeddings are self-contained by default: always local, never a network call, never billed.
+# Deliberately does NOT inherit [storage.embedding] — that section may be set to "openai".
+embedding_provider = "local"
+embedding_model = "sentence-transformers/all-MiniLM-L6-v2"   # 384-dim, ~90MB, in LOCAL_MODEL_DIMS
+model = ""                # "" = keep today's settings.agent.code.model for the llm leg
+prewarm = false           # embed the catalogue in `prepare` instead of on first find_tools
+prompt_preselect = false  # layer-2 preselection (§3A.1 point 3) — later step, measure first
+
+# Optional per-seam overrides. Unset = inherit the values above.
+[shortlister.discovery]   # seam A — PromptUtils.find_tools
+# strategy = "hybrid"
+[shortlister.bind_cap]    # seam B — PromptUtils.shortlist_tool_names
+# strategy = "embedding"
+```
+
+`ShortlisterRouter.resolve(settings, *, seam, configurable=None, override=None)` takes a
+`seam: Literal["discovery", "bind_cap"]` and layers `[shortlister.<seam>]` over `[shortlister]`
+before applying `configurable` and `override`. Per-seam keys are unset by default, so a user who
+only sets `strategy = "embedding"` gets it everywhere — the simple case stays simple.
+
+### 3.4.1 Why `threshold = top_k = 128`
+
+128 is not an arbitrary number: it is already `cuga_lite_bind_tools_max_count`, the provider cap
+that seam B exists to enforce. Reusing it makes one number mean one thing across both seams —
+*"more than 128 candidates is too many; cut to 128."*
+
+The property that makes this safe:
+
+> **At or below 128 candidates, nothing changes.** The cosine stage does not run, and both seams
+> behave exactly as they do today. Cosine engages only on genuinely large catalogues — precisely
+> the case where the LLM shortlister's prompt is most expensive and least accurate.
+
+So the blast radius of enabling cosine is confined to catalogues where today's behavior is
+already the weakest. Small/medium apps are bit-for-bit unaffected regardless of `strategy`.
+
+**`threshold` is a different number from the existing `shortlisting_tool_threshold = 35`.** They
+are easy to confuse and must stay distinct:
+
+| Setting | Layer | Meaning |
+|---|---|---|
+| `advanced_features.shortlisting_tool_threshold` = **35** | 2 | when to *hide* tools behind `find_tools` in the prompt |
+| `shortlister.threshold` = **128** | 3 & 4 | when the *cosine stage* engages inside the shortlister |
+
+### 3.4.2 Why `top_k = 128` must not reach the agent at seam A
+
+`top_k = 128` is correct for seam B — 128 *is* the bind cap — and correct as the hybrid prefilter
+width. It is **wrong as seam A's final output**, and this is a hard constraint, not a preference:
+
+`find_tools` renders every returned tool as markdown with description, reasoning, parameter docs,
+response docs, and both input and output JSON schemas — realistically 400–1500 characters each.
+128 tools is roughly 50K–190K characters. That output is a sandbox execution result, and
+`code_executor.py:52` truncates it at `advanced_features.execution_output_max_length`
+(70 000 chars; the `config.py:159` validator default is 35 000). So a 128-tool result would be
+**silently cut mid-render**, dropping tools with no error — and whatever survived would flood the
+agent's context.
+
+Hence `max_results` (default **10**), which caps what seam A renders:
+
+| Path at seam A | Flow | What the agent sees |
+|---|---|---|
+| `strategy = "hybrid"` | 300 → cosine `top_k` 128 → LLM ranks → LLM's own count | a handful, as today |
+| `strategy = "embedding"` | 300 → cosine `top_k` 128 → `min_score` → `max_results` | ≤ 10 |
+
+`max_results` is ignored at seam B, where `top_k` is the operative cap.
+
+`plan.py`:
+
+```python
+BuiltinStrategy = Literal["llm", "embedding", "hybrid"]
+
+
+class ShortlisterPlan(BaseModel):
+    strategy: str              # builtin name or dotted path
+    fallback_strategy: str = "llm"
+    top_k: int = 10
+    min_score: float = 0.30
+    max_results: int = 10
+    embedding_provider: Optional[str] = None
+    embedding_model: Optional[str] = None
+    model: Optional[str] = None
+    prewarm: bool = False
+    notes: List[str] = Field(default_factory=list)   # like ExecutionPlan.fallbacks
+
+
+class ShortlisterRouter:
+    @staticmethod
+    def resolve(settings, *, configurable=None, override=None) -> ShortlisterPlan
+```
+
+**Precedence** (mirrors `resolve_bind_tools_fields`):
+
+1. `override` — a `ShortlisterStrategy` instance injected via SDK, or `configurable["shortlister"]`
+2. `configurable["shortlister_strategy"]` and the other `shortlister_*` configurable keys
+3. `settings.shortlister.*`
+4. built-in defaults above
+
+`factory.py`:
+
+```python
+_BUILTINS = {
+    "llm": LLMShortlister,
+    "embedding": EmbeddingShortlister,
+    "hybrid": HybridShortlister,
+}
+_INSTANCES: Dict[str, ShortlisterStrategy] = {}   # keyed by resolved plan signature
+
+
+def resolve_shortlister(plan: ShortlisterPlan) -> ShortlisterStrategy
+```
+
+A `strategy` value containing a `.` is treated as a dotted path and loaded with
+`cuga.config.get_class` — exactly how `page_understanding.transformer_path` works today.
+Unknown bare names raise `ValueError` listing the built-ins. Instances are cached by plan
+signature so the embedding model loads once per process.
+
+### 3.5 Call sites — signatures unchanged
+
+**This is the load-bearing property of the design.** Both `PromptUtils` functions keep their
+exact signature and return type; only their bodies change:
+
+```python
+# prompt_utils.py — same signature, same return type
+async def find_tools(query, all_tools, all_apps, llm=None, run_config=None) -> str:
+    plan = ShortlisterRouter.resolve(settings, configurable=_configurable_of(run_config))
+    strategy = resolve_shortlister(plan)
+    result = await strategy.shortlist(
+        ShortlistRequest(
+            query=query, tools=all_tools, apps=all_apps,
+            top_k=None, llm=llm, run_config=run_config,
+        )
+    )
+    return render_tools_markdown(result.candidates, all_tools, notes=result.notes)
+
+
+async def shortlist_tool_names(query, all_tools, all_apps, llm=None, top_k=4,
+                               instructions=None, run_config=None) -> List[str]:
+    # all existing guards kept verbatim: top_k<=0 / empty tools / whitespace query -> []
+    ...
+    result = await strategy.shortlist(ShortlistRequest(..., top_k=top_k, ...))
+    # existing hallucination filter against valid_names + dedupe + top_k clamp, unchanged
+    # (redundant for embedding, but kept as defense-in-depth for custom strategies)
+```
+
+Consequence: **`cap.py`, `helpers/find_tools.py`, `adapter/graph_adapter.py`, and all six
+existing test files need zero changes.** `_build_shortlister_payload` moves under the `llm`
+strategy (its only consumer) but keeps its name and shared-by-both-legs role.
+
+`run_config` is already threaded into both functions, so `configurable` reaches the router
+with no new plumbing.
+
+**One addition in `prepare_node.py`**: when `plan.prewarm and enable_find_tools`, kick a
+background embed of the catalogue. This honors the reranker's stated contract that *a user
+query must never block on a model download*. Default `false` — opt-in.
+
+**SDK** (`sdk.py`): mirror the `ToolCalling` pattern that open PR #472 establishes for native
+function calling — a typed config object plus an `_apply_*` merge helper — rather than poking a
+raw key into `configurable`:
+
+```python
+# shortlister/config.py  (public, re-exported from cuga.__init__)
+@dataclass
+class Shortlister:
+    strategy: Optional[str] = None          # builtin name or dotted path
+    instance: Optional[ShortlisterStrategy] = None   # pre-built object wins over `strategy`
+    top_k: Optional[int] = None
+    min_score: Optional[float] = None
+    threshold: Optional[int] = None
+    max_results: Optional[int] = None
+    query_weight: Optional[float] = None
+    embedding_model: Optional[str] = None
+    embedding_provider: Optional[str] = None
+    fallback_strategy: Optional[str] = None
+    prewarm: Optional[bool] = None
+
+
+def shortlister_to_configurable(s: Optional[Shortlister]) -> Dict[str, Any]:
+    """Serialize to `shortlister_*` configurable keys. Returns {} when off (no-op)."""
+```
+
+`CugaAgent.__init__` gains `shortlister: Optional[Shortlister] = None`; `invoke()` and
+`stream()` gain the same as a per-invoke override; and `_apply_shortlister(run_config,
+shortlister)` merges with `configurable.setdefault(...)` so an explicit raw key set by the
+caller is never clobbered — exactly as `_apply_tool_calling` does in #472. Follow its
+`try/except → log and disable` guard so a malformed config degrades to the default `llm`
+strategy rather than failing the run.
+
+### 3.5.1 Every entry point that must be wired
+
+"Configurable everywhere" is a checklist, not a principle — a key wired in only some of these is
+the usual reason a setting appears not to work. All seven are in scope:
+
+| # | Surface | What to add | Mirror this existing code |
+|---|---|---|---|
+| 1 | `settings.toml` | the `[shortlister]` section above | `[execution]` |
+| 2 | Env vars | `DYNACONF_SHORTLISTER__STRATEGY`, `…__THRESHOLD`, `…__TOP_K`, … (free once the section exists) | any nested Dynaconf key |
+| 3 | `config.py` validators | one `Validator` **per key**, so a missing section can never `AttributeError` | `config.py:217-218` |
+| 4 | `configurable` (per-invoke) | `shortlister_strategy`, `shortlister_threshold`, `shortlister_top_k`, `shortlister_max_results`, `shortlister_min_score`, plus `shortlister` for a live instance | `prepare_node.py:114-118` |
+| 5 | SDK | `Shortlister` dataclass, `CugaAgent(shortlister=…)`, `invoke/stream(shortlister=…)`, `_apply_shortlister` | `ToolCalling` in PR #472 |
+| 6 | Public export | `Shortlister` (and `ShortlisterStrategy` for custom impls) in `cuga/__init__.py` `__all__` + `_import_map` | the existing lazy-loader entries |
+| 7 | Server / demo UI | `extract_agent_feature_overrides` (`manage_routes/helpers.py:33`), the feature-flag defaults block (`helpers.py:147-154`), `draft_ops.py:20-21`, and the `agent_loop` → `graph` → `configurable` chain (`agent_loop.py:320/337/546-547`, `graph.py:74/109`) | how `shortlisting_tool_threshold` is threaded today |
+
+Surface 7 is the one most likely to be skipped. `shortlisting_tool_threshold` is already plumbed
+through all of it, so it is a working template to copy rather than new design.
+
+**Ease-of-use check** — the three ways a user should be able to turn this on, all equivalent:
+
+```toml
+# 1. settings.toml — deployment-wide
+[shortlister]
+strategy = "hybrid"
+```
+
+```bash
+# 2. env — one-off / container
+DYNACONF_SHORTLISTER__STRATEGY=hybrid
+```
+
+```python
+# 3. SDK — per agent, or per call
+from cuga import CugaAgent, Shortlister
+
+agent = CugaAgent(tools=[...], shortlister=Shortlister(strategy="hybrid"))
+await agent.invoke("...", shortlister=Shortlister(strategy="embedding"))
+```
+
+Defaults are chosen so that `Shortlister(strategy="hybrid")` alone is a complete, sensible
+configuration — `threshold`, `top_k`, `max_results`, `min_score` and `query_weight` all have
+working defaults and none need to be set for the common case.
+
+### 3.5.2 K is configurable at every level
+
+There are **two** K values, and both must be settable from every surface — a K that can only be
+changed in `settings.toml` is not configurable in practice:
+
+| Knob | Meaning | Default | Applies to |
+|---|---|---|---|
+| `top_k` | how many candidates the cosine stage keeps | 128 | both seams (seam B's hard cap; seam A's prefilter width) |
+| `max_results` | how many tools seam A actually renders to the agent | 10 | seam A only |
+
+Both are reachable from all four control planes, with the **later row winning**:
+
+```toml
+# settings.toml — deployment-wide
+[shortlister]
+top_k = 64
+max_results = 15
+[shortlister.bind_cap]
+top_k = 128          # per-seam: keep the full cap for bind, tighter K for discovery
+```
+
+```bash
+DYNACONF_SHORTLISTER__TOP_K=64
+DYNACONF_SHORTLISTER__MAX_RESULTS=15
+```
+
+```python
+# SDK — per agent
+agent = CugaAgent(tools=[...], shortlister=Shortlister(strategy="hybrid", top_k=64, max_results=15))
+
+# SDK — per call, overrides the agent default
+await agent.invoke("…", shortlister=Shortlister(top_k=32))
+
+# raw configurable — for callers driving the graph directly
+config = {"configurable": {"shortlister_top_k": 32, "shortlister_max_results": 5}}
+```
+
+Two guards on K, both tested:
+
+- **Seam B clamps to the provider cap regardless.** If `top_k` is configured above
+  `cuga_lite_bind_tools_max_count`, the effective K is the cap — `cap.py`'s existing
+  `_materialize_shortlist` defense-in-depth clamp already enforces this and must keep working.
+  A user-set K can lower the bound list, never raise it past what the provider accepts.
+- **`top_k <= 0` disables the cosine stage** rather than returning nothing, matching
+  `shortlist_tool_names`'s existing `top_k <= 0 → []` guard being a *skip*, not an error.
+
+### 3.6 Failure semantics — preserved per seam
+
+| Situation | Seam A (`find_tools`) | Seam B (`cap.py`) |
+|---|---|---|
+| Strategy unavailable (no embed model) | fall back to `fallback_strategy`, log once | same |
+| Strategy raises otherwise | caught → error string to agent (existing) | `RuntimeError` (existing) |
+| Model lacks structured output | n/a | `NotImplementedError` → `BindToolsUnsupportedError` → degrade to unbound |
+| Empty ranking | `"No matching tools found…"` | `RuntimeError` (existing) — hence the never-empty rule |
+
+Side benefit worth documenting: with `strategy = "embedding"`, seam B can no longer hit
+`BindToolsUnsupportedError`, because the ranker no longer runs on the model being bound.
+
+---
+
+## 3A. The cosine strategy in detail
+
+### 3A.1 Where exactly it plugs in
+
+Three candidate insertion points. **Two are in scope; the third is opt-in and deliberately not
+the default.**
+
+**Point 1 — inside `PromptUtils.find_tools` (seam A).** The ranking pool is *already app-filtered*
+before the strategy sees it: `find_tools_func(query, app_name)` resolves
+`filtered_tools = app_to_tools_map[app_name]` and passes only those
+(`helpers/find_tools.py:83-91`). So the strategy ranks within one app, typically tens of tools,
+not the whole catalogue. The embedding cache is global per tool; only the *scoring* is per-app.
+
+**Point 2 — inside `PromptUtils.shortlist_tool_names` (seam B).** The pool is `ranking_pool`
+from `cap.py:_build_ranking_pool` — the bound tool list minus the `find_tools` overlay slot.
+Cross-app, up to hundreds of tools. `top_k = max_count - reserve`.
+
+**Point 3 (opt-in, `prompt_preselect`) — layer 2 in `prepare_node.py:225`.** Today when the
+catalogue exceeds the threshold, the prompt collapses to *only* `find_tools`, and the agent
+must spend a round-trip discovering anything. Because cosine is free, we can additionally embed
+the initial user message at `prepare` time and inject the top-N tools **directly into the
+prompt**, alongside `find_tools`:
+
+```
+enable_find_tools = total_tool_count > shortlisting_threshold      # unchanged
+tools_for_prompt  = [find_tool] + cosine_top_n(initial_user_message)   # when prompt_preselect
+```
+
+This can remove the first `find_tools` round-trip entirely for single-step tasks. It is **not**
+the default because at `prepare` time only the initial user message exists — a multi-step task
+("find the account, then list its contacts, then email them") needs different tools at different
+steps, and the step-2 query does not exist yet. Preselection is therefore *additive*: it never
+removes `find_tools`, it only front-loads likely-needed tools. Ship it in a later step, behind
+`[shortlister] prompt_preselect = false`, and measure.
+
+### 3A.2 What it compares
+
+**One sentence:** cosine compares **one vector built from the user's question** against **one
+vector per tool, built from that tool's name + description + parameter names + return field
+names** — and nothing else.
+
+```
+        QUERY SIDE                              TOOL SIDE  (one per tool)
+ ┌──────────────────────────────┐      ┌────────────────────────────────────────┐
+ │ step query   (weight 0.7)    │      │ app name + tool name, split to words   │
+ │ task context (weight 0.3)    │      │ description (often weak or empty)      │
+ │  → blended, normalized       │      │ parameter names + their descriptions   │
+ └──────────────────────────────┘      │ return field NAMES (not schemas)       │
+              │                        └────────────────────────────────────────┘
+              │                                          │
+              └────────►  cosine similarity  ◄───────────┘
+                          = dot product of the two normalized vectors
+```
+
+**Explicitly NOT compared:** the JSON `args_schema`, full response schemas, `_param_constraints`,
+example values, or auth metadata. Those are what make the *LLM* prompt expensive, and in a
+fixed-size vector they dilute the signal rather than add to it. They still reach the agent —
+`render_tools_markdown` includes them in the output — they are simply not part of the *ranking*.
+
+Each tool's vector is computed once and cached by content hash, so a run over 300 tools embeds
+300 short strings the first time and zero thereafter. Only the query is embedded per call.
+
+#### Why this specific set
+
+**This is where the design lives or dies, because tool text in this repo is much weaker than it
+looks.** Sampling the CRM demo app:
+
+- Endpoints carry **no docstrings and no `summary=`/`description=`**
+  (`demo_tools/crm/crm_api/contacts.py`). The parser takes
+  `description = op_obj.get('description', op_obj.get('summary',''))`
+  (`openapi_parser_v0.py:498`), so description degrades to FastAPI's auto-summary — `"Get Contacts"` —
+  or empty for MCP tools without one.
+- Names are machine-generated. `determine_operation_name_strategy` uses a path segment only if
+  segments are **unique**; CRM's `/contacts/` and `/contacts/{contact_id}` collide, so it falls
+  back to the FastAPI operationId. After `sanitize_tool_name` the real names are
+  `crm_get_contacts_contacts_get`, `crm_get_contact_contacts_contact_id_get`,
+  `crm_create_contact_contacts_post`.
+
+So: **descriptions cannot be relied on, and the tool name is the dominant signal** — but only
+after it is split back into words.
+
+Document text per tool (`doc.py::tool_document`):
+
+```
+{app_name} {split_identifier(tool.name)}
+{tool.description}                      # often just "Get Contacts", sometimes ""
+Parameters: {param_name}: {param_description}; ...
+Returns: {top-level response field names}
+```
+
+Concretely, for `crm_get_contacts_contacts_get`:
+
+```
+crm get contacts contacts get
+Get Contacts
+Parameters: skip; limit; email: filter by email address
+Returns: items, total, skip, limit
+```
+
+Rules that matter:
+
+1. **Split identifiers into words.** `split_identifier` handles snake_case, camelCase and the
+   duplicated verb/entity that operationIds produce. Embedding `crm_get_contacts_contacts_get`
+   raw tokenizes badly; `crm get contacts contacts get` matches "list all contacts" well.
+2. **Include parameter names and descriptions.** With descriptions empty, parameters are often
+   the only real natural language available (`email: filter by email address`).
+3. **Include only response field *names*, not schemas.** Reuse `PromptUtils.get_tool_docs`, then
+   keep the names. Full JSON Schema is noise that dilutes the vector.
+4. **Do not embed `args_schema` JSON.** It is what makes the *LLM* prompt expensive and it
+   actively hurts a fixed-size embedding.
+5. **Symmetric vs asymmetric embedding is model-dependent — do not hardcode either.**
+   The default `sentence-transformers/all-MiniLM-L6-v2` is a *symmetric* model: it is trained
+   for sentence-to-sentence similarity with no query-side instruction, so both query and tool
+   document are embedded identically with plain `model.embed()`. `BAAI/bge-*` models are the
+   opposite — trained with a query-side instruction prefix, and fastembed exposes
+   `query_embed()` / `passage_embed()` for exactly that. Applying bge's prefix to MiniLM
+   *degrades* results, and omitting it for bge leaves accuracy on the table.
+
+   So the embedding helper resolves the mode from the model name: bge → asymmetric
+   (`query_embed`/`passage_embed`), everything else → symmetric (`embed`). One small lookup,
+   defaulting to symmetric, so an unrecognized model behaves correctly rather than oddly.
+   (The knowledge engine embeds bge symmetrically today and has the same latent gap; out of
+   scope here, worth its own issue.)
+
+Query text, per seam:
+
+| Seam | Query the strategy receives |
+|---|---|
+| A | `_compose_find_tools_shortlister_query(query, initial_user_message)` → `"Query: {q}\nTask context (initial user message): {init}"` — already task-aware |
+| B | first user message (`_first_user_message_text`), via `graph_adapter.resolve_bind_tools` |
+
+Seam B has nothing to merge — it only ever sees the first user message. Merging is a seam-A
+concern.
+
+### 3A.3 Query construction — merging the step query with the task context
+
+**Merging is required, and it already happens** (`helpers/find_tools.py:33-38`). But the string
+that is right for an LLM is wrong for cosine, for two reasons:
+
+1. **Scaffolding pollutes the vector.** `"Query: "` and `"Task context (initial user message): "`
+   are ~10 tokens of boilerplate that get mean-pooled into every query embedding. They carry no
+   task signal and, being identical for every query, push every query vector in the same
+   direction — measurably reducing discrimination. An LLM reads them as helpful structure; an
+   embedding model just averages them in.
+2. **Length imbalance silently destroys per-step discovery.** If the first user message is a
+   150-word task description and the step query is `"list contacts for account X"`, mean pooling
+   makes the task context dominate. Every step of a multi-step task then produces nearly the
+   *same* query vector — so step 2 retrieves what step 1 retrieved. This is the failure mode that
+   would make cosine look broken on exactly the multi-step AppWorld tasks in #150.
+
+**Fix: merge at the vector level, not the string level.**
+
+```python
+v_query   = normalize(await embed_query(step_query))
+v_context = normalize(await embed_query(task_context))     # cached per thread — see below
+v = normalize(alpha * v_query + (1.0 - alpha) * v_context)
+scores = doc_matrix @ v
+```
+
+- `alpha` (`[shortlister] query_weight`, default **0.7**) makes the step query dominate while the
+  task context still disambiguates. Explicit and tunable, unlike string concatenation where the
+  weighting is an accident of relative length.
+- **The context vector is constant for the session** — the first user message never changes — so
+  cache it per `thread_id`. Steady-state cost is one embedding call per `find_tools`, same as
+  plain concatenation.
+- Both sides are embedded as *queries* (`query_embed`), tool documents as *passages*
+  (§3A.2 rule 5).
+- When there is no task context, `v = v_query`, matching the existing early-return.
+
+**Plumbing.** `helpers/find_tools.py` currently pre-composes the two into one string before
+calling `PromptUtils.find_tools`, so the strategy cannot see them separately. Add an *optional*
+parameter — backward compatible, existing callers and test patches unaffected:
+
+```python
+async def find_tools(query, all_tools, all_apps, llm=None, run_config=None,
+                     task_context: Optional[str] = None) -> str
+```
+
+`ShortlistRequest` gains `task_context: Optional[str] = None`. **`LLMShortlister` recomposes the
+two with `_compose_find_tools_shortlister_query` and produces the byte-identical prompt it sends
+today** — no behavior change on the default path. `EmbeddingShortlister` blends vectors instead.
+When `task_context` is not supplied, the strategy falls back to treating `query` as already
+composed, so nothing breaks.
+
+### 3A.4 Cold start — a query must never wait on a model download
+
+`all-MiniLM-L6-v2` is ~90MB. On a cold cache the first `find_tools` call would otherwise stall
+for seconds to minutes. That is unacceptable, and the repo already has a stated contract for it
+(`knowledge/reranker.py:1-20`): *a user query MUST NEVER block on a model download.*
+
+`EmbeddingShortlister` follows the same shape:
+
+```python
+if not is_ready(model_name):
+    ensure_loading(model_name)          # background thread, at most one per model
+    raise ShortlisterUnavailableError(...)   # caller degrades to fallback_strategy = "llm"
+```
+
+- **Call 1 (cold):** model not ready → background load starts → this call is served by the `llm`
+  strategy and returns at normal speed.
+- **Call 2+ (warm):** cosine, as configured.
+- A failed load (offline, airgapped) backs off for a cooldown before any retry, so a broken setup
+  does not hammer the network or spam logs — copy `_RETRY_COOLDOWN_S` from the reranker.
+- Log the substitution **once** at WARNING. Silent strategy swapping is how "my config does
+  nothing" bugs happen.
+- `prewarm = true` opts into loading during `prepare` instead, for deployments that prefer a
+  slower startup over a first-call substitution.
+
+Because `hybrid`'s prefilter is the embedding leg, the same rule makes `hybrid` degrade to plain
+`llm` on call 1 — which is exactly today's behavior, so the degraded path is already well tested.
+
+### 3A.5 The limitation that shapes the whole design
+
+Cosine cannot reliably separate near-duplicate CRUD siblings. `get_contacts` (list) and
+`get_contact` (by id) differ by one character and one parameter; `create_contact` and
+`update_contact` are semantically adjacent. Their embeddings are nearly identical.
+
+That is **exactly the failure class issue #150 documented** — "cart CRUD tools instead of just
+showing cart", "order-creation instead of order-lookup". So:
+
+> **Cosine is a recall device, not a precision device.** Used alone for final selection it would
+> likely reproduce or worsen #150's errors.
+
+The design consequence, and the recommended defaults:
+
+| Seam | Recommended strategy | Why |
+|---|---|---|
+| **A** (discovery — precision matters, the agent acts on the result) | `hybrid` | cosine cuts 300 → 50 with high recall; the LLM makes the precision call with full schemas |
+| **B** (provider cap — only needs "don't drop the needed tool") | `embedding` | recall is the whole job; exact ordering within the cap is irrelevant, and it removes the LLM round-trip *per `call_model`* plus the `BindToolsUnsupportedError` coupling |
+
+This is why per-seam configuration (§3.4) is not over-engineering — the two seams genuinely want
+different strategies, and `min_score` must be **low** (recall-biased), not tuned for precision.
+
+---
+
+## 4. Files
+
+**New** — `src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/`
+(each file well under the <1000-line rule in `cuga_graph/nodes/AGENTS.md`):
+
+| File | Contents |
+|---|---|
+| `base.py` | `ShortlistCandidate`, `ShortlistRequest`, `ShortlisterStrategy`, `ShortlisterUnavailableError` |
+| `plan.py` | `ShortlisterPlan`, `ShortlisterRouter.resolve` |
+| `factory.py` | `_BUILTINS`, dotted-path via `get_class`, instance cache |
+| `llm.py` | `LLMShortlister` + the migrated `_build_shortlister_payload` |
+| `embedding.py` | `EmbeddingShortlister`, vector cache, numpy cosine |
+| `hybrid.py` | `HybridShortlister` |
+| `render.py` | `render_tools_markdown` (moved from `find_tools` L359-458) |
+| `doc.py` | `tool_document`, `split_identifier`, `tool_fingerprint` (§3A.2) |
+
+**Modified**
+
+| File | Change |
+|---|---|
+| `cuga_lite/prompt_utils.py` | Both functions delegate to a strategy; signatures preserved, `find_tools` gains an optional `task_context` kwarg (§3A.3) |
+| `cuga_lite/helpers/find_tools.py` | Stop pre-composing query + task context into one string; pass both through so the strategy can weight them (§3A.3). Error-swallowing behavior unchanged |
+| `storage/embedding/embedding_service.py` | Add `create_embedding_batch_function()` exposing fastembed's native `model.embed(list)` and OpenAI's `aembed_documents` (falls back to `asyncio.gather` over the single-text fn), **plus model-conditional symmetric/asymmetric embedding** — plain `embed` for MiniLM-class models, `query_embed`/`passage_embed` for `bge-*` (§3A.2 rule 5) |
+| `cuga_lite/adapter/prepare_node.py` | Optional prewarm hook; log the resolved plan |
+| `src/cuga/sdk.py` | `shortlister=` ctor arg + configurable injection |
+| `src/cuga/settings.toml` | New `[shortlister]` section |
+| `src/cuga/config.py` | Validators for every `shortlister.*` key — **and add the missing `advanced_features.shortlisting_tool_threshold` validator** (see §7) |
+| `src/cuga/__init__.py` | Export `Shortlister`, `ShortlisterStrategy` via `__all__` + `_import_map` (§3.5.1 surface 6) |
+| `server/manage_routes/helpers.py`, `draft_ops.py`, `utils/agent_loop.py`, `cuga_graph/graph.py` | Thread the `shortlister_*` overrides the same way `shortlisting_tool_threshold` is threaded today (§3.5.1 surface 7) |
+
+**Unchanged (deliberately):** `bind_tools/cap.py`, `helpers/bind_tools.py`,
+`adapter/graph_adapter.py`, `prompts/shortlister/system.jinja2`.
+
+Note `helpers/find_tools.py` *was* on this list before §3A.3 introduced weighted query blending.
+Passing the step query and task context separately requires touching it — a small change (stop
+calling `_compose_find_tools_shortlister_query`, forward both values), and `LLMShortlister`
+recomposes them so the prompt it sends stays byte-identical.
+
+---
+
+## 5. Rollout — four independently shippable PRs
+
+1. **Seam + LLM strategy.** Protocol, plan/router, factory, `render.py` extraction,
+   `LLMShortlister`, `[shortlister]` section, validators. Pure refactor — *acceptance
+   criterion: all six existing shortlister test files pass untouched.*
+   **Blocked on PR #549 landing first** — see [§8](#8-related-issues-and-prs).
+2. **Embedding strategy.** `doc.py`, `embedding.py`, batch + asymmetric embedding helpers, cache.
+   Ships with the CRUD-sibling recall/precision harness (§6) — the numbers decide step 3's
+   defaults, so this step must not also change any default.
+3. **Hybrid strategy.** `hybrid.py` + per-seam overrides. Flip the recommended
+   defaults (`discovery = "hybrid"`, `bind_cap = "embedding"`) **only if step 2's numbers support
+   it**; otherwise leave `llm` as the global default and document the measurement.
+4. **SDK arg + docs.** `CugaAgent(shortlister=…)`, README section, this document.
+5. *(later, optional)* **Layer-2 preselection.** `prompt_preselect` (§3A.1 point 3), measured
+   against the round-trips it removes versus the tools it front-loads wrongly.
+
+---
+
+## 6. Verification
+
+**Unit** — new files in `src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/`, following the
+mock-adapter shape of `test_prepare_node_weak_schema_tools.py`:
+
+- `test_shortlister_factory.py` — builtin resolution; dotted path via `get_class`; precedence
+  (instance > configurable > settings > default); per-seam override layering; unknown name
+  raises; instance cache reuse.
+- `test_shortlister_defaults.py` — the `threshold = 128` contract (§3.4.1): with 128 candidates
+  the cosine stage does **not** run and output is identical to `strategy="llm"`; with 129 it
+  does. Plus `max_results` caps seam A at 10 while seam B is capped by `top_k`, and
+  `shortlister.threshold` is not confused with `advanced_features.shortlisting_tool_threshold`.
+- `test_shortlister_config_surfaces.py` — one assertion per surface in §3.5.1: env var, validator
+  default with the section absent, `configurable` override beating settings, SDK ctor arg,
+  per-invoke arg beating ctor, `from cuga import Shortlister`, and the server
+  `extract_agent_feature_overrides` round-trip. This is the test that catches a half-wired key.
+- `test_shortlister_embedding.py` — deterministic fake embed fn (hash-derived unit vectors)
+  asserting rank order, `min_score` floor, the never-empty rule, and cache-hit counts.
+- `test_shortlister_hybrid.py` — assert the LLM leg receives exactly `top_k`
+  candidates and that its ordering wins.
+- `test_shortlister_render.py` — `render_tools_markdown` output matches the pre-refactor
+  `find_tools` markdown for a fixed candidate list (golden test guarding the extraction).
+- `test_shortlister_doc.py` — `split_identifier` on the real name shapes:
+  `crm_get_contacts_contacts_get` → `crm get contacts contacts get`, camelCase, and the
+  `__`-collapsed operationId forms. Guards §3A.2 rule 1, the single highest-leverage detail.
+
+**The evaluation that decides `embedding` vs `hybrid`** (§3A.5) — a CRUD-sibling recall/precision
+harness over the CRM app, using real embeddings rather than a fake fn:
+
+- **Recall@`top_k`** for `embedding` — does the needed tool survive the cosine cut? This is the
+  only number that justifies the default `top_k`, and the only one that matters for seam B.
+  Report it at K = 32 / 64 / 128 so the default is a measured choice, not an assumed one.
+- **Precision@1** for `embedding` on sibling pairs — `get_contacts` (list) vs `get_contact`
+  (by id), `create_contact` vs `update_contact`. Expected to be **poor**; the test asserts the
+  documented limitation rather than a passing score, so a future contributor cannot quietly
+  promote `embedding` to seam A's default without re-measuring.
+- Mark `@pytest.mark.stability` (needs a model download) and reuse #150's task phrasings as
+  fixtures so the numbers are comparable to the failure cases that motivated this work.
+
+**Regression (the real gate)** — these must pass with no edits:
+
+```bash
+uv run pytest tests/unit/test_cuga_lite_bind_tools.py \
+              tests/unit/test_bind_tools_safe_fallback.py \
+              tests/unit/test_find_tools_exception.py \
+              src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/ -m unit
+```
+
+**Added to `tests/unit/test_cuga_lite_bind_tools.py`** — over-cap path with
+`strategy="embedding"` binds `top_k` tools with **zero** LLM invocations (assert the patched
+shortlister chain is never called).
+
+**E2E** — a `strategy = "embedding"` variant of
+`src/system_tests/e2e/crm_contacts_email_test_find_tools.py`, `@pytest.mark.stability`.
+
+**Manual smoke** — a registry with >35 tools so layer 2 fires:
+
+```bash
+DYNACONF_SHORTLISTER__STRATEGY=embedding uv run cuga start demo
+```
+
+Expect a log line naming the resolved strategy, no shortlister LLM span in Langfuse, and
+`find_tools` returning the same markdown shape as before.
+
+**CI** — new `tests/unit/` files must be registered in the matching group in
+`.github/workflows/tests.yml:68-119` or they will not run.
+
+---
+
+## 7. Adjacent findings (surfaced, not silently fixed)
+
+Found while tracing; each is a deliberate call, not an oversight:
+
+1. **`advanced_features.shortlisting_tool_threshold` has no dynaconf Validator**, unlike every
+   other cap in this area. A missing settings.toml key `AttributeError`s at
+   `adapter/prepare_node.py:117`. → **Fix in PR 1** (one line, same file we're already editing).
+2. **Both Lite shortlister paths default to `settings.agent.code.model`, not
+   `settings.agent.shortlister.model`** (`prompt_utils.py:347` and `:518`) — only the classic
+   graph node uses the dedicated model. → Exposed as `[shortlister] model`, defaulting to `""`
+   = today's behavior. **Not** changed by default.
+3. **Dead assets**: `cuga_lite/prompts/shortlister/user.jinja2` is referenced by no Python
+   (both callers inline their human messages);
+   `configurations/instructions/default/shortlister.md` is 0 bytes, so `{{ instructions }}` in
+   the classic prompt is always empty. → Noted; **out of scope**.
+4. **Shortlisting is undocumented** outside `settings.toml` inline comments — nothing in
+   README/AGENTS/docs describes `find_tools`, `shortlisting_tool_threshold`, or
+   `cuga_lite_bind_tools_*`. → PR 4 closes this gap for the whole subsystem.
+5. **Version drift**: `src/cuga/__init__.py:28` says `0.2.20`, `pyproject.toml:3` says `0.3.1`.
+   → Pre-existing, unrelated, **out of scope**.
+
+---
+
+## 8. Related issues and PRs
+
+Surveyed `cuga-project/cuga-agent` as of 2026-08-11. **No issue or PR proposes a pluggable or
+non-LLM shortlister** — this design is new and needs its own tracking issue.
+
+### Issues
+
+| # | State | Relationship |
+|---|---|---|
+| [#546](https://github.com/cuga-project/cuga-agent/issues/546) — Validate shortlister/`find_tools` output against real tool names with retry | OPEN | **Complementary.** Hallucination validation, not ranker choice. Composes cleanly: retry lives in `LLMShortlister`; `embedding` cannot hallucinate, so it satisfies #546 by construction. |
+| [#150](https://github.com/cuga-project/cuga-agent/issues/150) — Shortlister enhancement | CLOSED (2026-04) | **Motivation.** AppWorld trace analysis rated shortlister mis-selection a *high*-severity top cause of first divergence — generic search over wishlist retrieval, omitted `place order` / add-to-cart endpoints. Closed with "review the prompt", i.e. the accuracy problem was addressed prompt-only. Strengthens the case for `hybrid`. |
+| [#312](https://github.com/cuga-project/cuga-agent/issues/312) — CodeAgent invokes undefined tools | OPEN | Downstream symptom of the same hallucination class as #546. |
+| [#353](https://github.com/cuga-project/cuga-agent/issues/353) — Epic: Tool Gateway & Secure Execution Runtime | OPEN | Parent epic of #546; the natural home for a shortlister issue. |
+
+### Pull requests
+
+| # | State | Relationship |
+|---|---|---|
+| [#549](https://github.com/cuga-project/cuga-agent/pull/549) — validate shortlister tool names with retry (#546) | **OPEN, CONFLICTING, Unit Tests failing**, last updated 2026-08-05 | **Direct collision.** +147/−25 in `prompt_utils.py`, rewriting the bodies of *both* `find_tools` and `shortlist_tool_names` — the exact regions PR 1 extracts. See sequencing below. |
+| [#472](https://github.com/cuga-project/cuga-agent/pull/472) — native function calling, opt-in (#471) | OPEN | **Overlapping files, no logic conflict**: `prompt_utils.py` (+14/−1), `helpers/bind_tools.py`, `adapter/prepare_node.py`, `sdk.py`, `config.py`, `settings.toml`. Establishes the `ToolCalling` + `tool_calling_to_configurable` + `_apply_tool_calling` pattern this spec now copies for `Shortlister` (§3.5). |
+| [#203](https://github.com/cuga-project/cuga-agent/pull/203) — cap `bind_tools` count and shortlist over the limit | MERGED | Created seam B and its loud-failure contract. Its review notes are the source of the "single payload builder prevents drift" and "no silent truncation" constraints. |
+| [#67](https://github.com/cuga-project/cuga-agent/pull/67) — handle exception in `find_tools` when shortlister LLM fails | MERGED | Source of seam A's swallow-into-error-string contract. |
+| [#524](https://github.com/cuga-project/cuga-agent/pull/524) — graceful `bind_tools` fallback | MERGED | Source of `BindToolsUnsupportedError` degradation. |
+
+### Sequencing
+
+**Land #549 first, then rebase PR 1 on top.** Rationale:
+
+- #549 is a bug fix with a tracked issue; this spec is an enhancement. The bug fix should not
+  wait on a refactor.
+- Rebasing #549 onto a merged PR 1 would be *harder*, not easier — its helpers would have to be
+  re-homed into `llm.py` by an author who did not write that file.
+- Done in this order, PR 1's extraction is mechanical: move #549's four private helpers into
+  `LLMShortlister` unchanged and route their filtered-names note through `ShortlistResult.notes`.
+- #549 is currently red (conflicting + failing unit tests), so this is not a short wait. If it
+  stalls, the fallback is to land PR 1 first and open a follow-up that ports #549's logic into
+  `llm.py` — coordinate with its author (`sami-marreed`) before choosing that path.
+
+**#472 needs no sequencing** — its `prompt_utils.py` change is small and elsewhere in the file,
+and its SDK/settings work is a pattern to follow rather than a conflict. Whichever lands second
+takes a trivial rebase.
+
+**Tracking issue:** #624, filed under epic #612 (Vakra evaluation), cross-linked to #546.
+
+---
+
+## 9. Contribution process — read before opening any PR
+
+Read `CONTRIBUTING.md` in full before the first PR. The rules below are the ones this work will
+actually trip over; the file is authoritative if it has changed.
+
+### 9.1 Authorship — everything under Segev's name
+
+- **Commit identity:** `Segev Shlomov <105229001+segevshlomovIBM@users.noreply.github.com>`.
+  This is the GitHub identity that matches prior upstream commits. The local git config holds
+  the IBM address (`segev.shlomov1@ibm.com`), which is **not** the GitHub identity — set the
+  author/committer per commit via `GIT_AUTHOR_*` / `GIT_COMMITTER_*` env vars rather than
+  changing repo config.
+- **DCO is required on every commit** — `git commit -s`. The `Signed-off-by` line must match the
+  author exactly, or CI fails. To fix after the fact:
+  `git commit --amend --no-edit --signoff` (one commit) or
+  `git rebase --signoff HEAD~<n>` (several), then force-push.
+- **No co-authors and no tool attribution** in commits, PR bodies, or the issue. Sole author.
+- Assign the issue and every PR to `segevshlomovIBM`.
+
+### 9.2 PR mechanics
+
+- **Branches:** `feature/<lowercase-hyphenated>` off `main` — e.g.
+  `feature/624-pluggable-shortlister`. No underscores, no uppercase, no trailing hyphen.
+- **Conventional Commits** for both commit messages and the **PR title** — the repo squash-merges,
+  so the PR title becomes the permanent commit message. Suggested titles per step:
+  `refactor(cuga-lite): extract shortlister strategy seam (#624)`,
+  `feat(cuga-lite): cosine shortlister strategy (#624)`,
+  `feat(cuga-lite): hybrid shortlister strategy (#624)`,
+  `feat(sdk): configure shortlister from CugaAgent (#624)`.
+- **PR template:** use `.github/PULL_REQUEST_TEMPLATE/feature.md` (append `?template=feature.md`
+  to the PR URL) — `## Feature`, `Closes #624`, `### Summary`, `### Testing` checklist.
+- **Size limit — this constrains the plan.** CONTRIBUTING asks for **< ~300 changed lines** and
+  one topic per PR. Step 1 (seam + `llm` strategy + config + validators + tests) will exceed that
+  if done as one PR. Split it: **1a** protocol + factory + router + `render.py`/`doc.py`
+  extraction (mechanical, no behavior change), **1b** config surfaces + validators + wiring.
+  Steps 2–4 are each comfortably under the limit on their own.
+
+### 9.3 Pre-PR checklist
+
+```bash
+uv sync --dev
+uv run ruff format
+uv run ruff check --fix
+uv run pytest -m "not stability and not slow and not pgvector and not manual and not e2e and not load"
+```
+
+Also required by CONTRIBUTING:
+
+- Secret scan before committing:
+  `detect-secrets scan --update .secrets.baseline` then `detect-secrets audit .secrets.baseline`.
+  Note the baseline is known-stale locally — diff against `main`'s baseline rather than
+  wholesale-regenerating it, or the PR carries unrelated churn.
+- `uv.lock` is **not** touched — this feature adds no dependencies, so a lockfile diff in the PR
+  means something went wrong.
+- New `tests/unit/` files must be registered in the matching group in
+  `.github/workflows/tests.yml` or CI silently skips them.
+- No generated files, no `.env`, no local config.

--- a/src/cuga/__init__.py
+++ b/src/cuga/__init__.py
@@ -35,6 +35,9 @@ __all__ = [
     "KnowledgeClient",
     "KnowledgeEngine",
     "KnowledgeConfig",
+    # Tool shortlisting: how a large tool set is shrunk before the model sees it.
+    "Shortlister",
+    "ShortlisterStrategy",
     # Client-adaptation SDK surface — operators can build / validate / hash
     # adaptation text without going through the HTTP layer.
     "CLIENT_ADAPTATION_MAX_CHARS",
@@ -49,6 +52,10 @@ __all__ = [
 if TYPE_CHECKING:
     from cuga.sdk import CugaAgent, CugaSupervisor, run_agent, InvokeResult
     from cuga.backend.cuga_graph.nodes.cuga_lite.tracking.tracker import tracked_tool
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+        Shortlister,
+        ShortlisterStrategy,
+    )
     from cuga.backend.knowledge import KnowledgeClient, KnowledgeEngine
     from cuga.backend.knowledge.config import (
         CLIENT_ADAPTATION_MAX_CHARS,
@@ -74,6 +81,14 @@ _import_map: dict = {
     "KnowledgeClient": ("cuga.backend.knowledge", "KnowledgeClient"),
     "KnowledgeEngine": ("cuga.backend.knowledge", "KnowledgeEngine"),
     "KnowledgeConfig": ("cuga.backend.knowledge.config", "KnowledgeConfig"),
+    "Shortlister": (
+        "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister",
+        "Shortlister",
+    ),
+    "ShortlisterStrategy": (
+        "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister",
+        "ShortlisterStrategy",
+    ),
     "CLIENT_ADAPTATION_MAX_CHARS": (
         "cuga.backend.knowledge.config",
         "CLIENT_ADAPTATION_MAX_CHARS",

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
@@ -97,17 +97,22 @@ async def create_find_tools_tool(
                 f"App '{app_name}' not found in available apps. Available apps: {[app.name if hasattr(app, 'name') else str(app) for app in all_apps]}"
             )
 
+        # Kept for the log/except paths below, which report on the full text.
         shortlister_query = _compose_find_tools_shortlister_query(query, initial_user_message)
 
         from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
 
         try:
+            # Query and task context travel separately so a non-LLM strategy can
+            # weight them; the LLM strategy re-joins them into the same string
+            # `_compose_find_tools_shortlister_query` produces above.
             return await PromptUtils.find_tools(
-                query=shortlister_query,
+                query=query,
                 all_tools=filtered_tools,
                 all_apps=filtered_apps,
                 llm=llm,
                 run_config=nested_langgraph_invoke_config(),
+                task_context=initial_user_message,
             )
         except OutputParserException as e:
             logger.bind(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -12,8 +12,6 @@ from loguru import logger
 from pydantic import BaseModel, Field
 from langchain_core.tools import StructuredTool
 from cuga.backend.cuga_graph.nodes.cuga_lite.providers.base import AppDefinition
-from cuga.backend.llm.utils.helpers import create_chat_prompt_from_templates
-from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
 from cuga.backend.cuga_graph.nodes.cuga_lite.model_runtime_profile import runtime_defaults_for_model
 from cuga.backend.tools_env.registry.utils.schema_utils import json_schema_type
 
@@ -63,6 +61,25 @@ def resolve_cuga_lite_few_shots_enabled(
     if "cuga_lite_enable_few_shots" in prof:
         return _coerce_bool_setting(prof["cuga_lite_enable_few_shots"])
     return few_shots_enabled_from_settings()
+
+
+def _configurable_of(run_config: Optional[Any]) -> Dict[str, Any]:
+    """Pull ``configurable`` out of a RunnableConfig, tolerating any shape.
+
+    ``run_config`` reaches shortlisting from several call sites and is sometimes
+    a plain dict, sometimes absent. Shortlister settings are never important
+    enough to fail a run over, so anything unexpected reads as "no overrides".
+    """
+    if not run_config:
+        return {}
+    try:
+        if isinstance(run_config, dict):
+            configurable = run_config.get("configurable")
+        else:
+            configurable = getattr(run_config, "configurable", None)
+        return configurable if isinstance(configurable, dict) else {}
+    except Exception:
+        return {}
 
 
 class Tool(BaseModel):
@@ -301,18 +318,23 @@ class PromptUtils:
         all_apps: List[AppDefinition],
         llm: Optional[Any] = None,
         run_config: Optional[Any] = None,
+        task_context: Optional[str] = None,
     ) -> str:
         """
         Search tools from given applications and return the relevant matching tools with reasoning.
 
-        This method uses an LLM to analyze available tools from all loaded applications and
-        select the ones needed for the query (including chaining). No fixed result count.
-        Each returned tool includes reasoning plus parameter and response documentation.
+        Ranking is delegated to the configured shortlister strategy (``[shortlister]
+        strategy``, default ``"llm"`` — the original behavior). See
+        ``docs/design/pluggable-shortlister.md``.
 
         Args:
             query: A natural language query describing what tools are needed.
             all_tools: List of all available tools
             all_apps: List of all available app definitions
+            task_context: The initial user message, kept separate from ``query`` so a
+                non-LLM strategy can weight the two (the LLM strategy re-joins them into
+                the string it has always sent). When omitted, ``query`` is assumed to be
+                already composed.
 
         Returns:
             str: A markdown-formatted string of matching tools, each with:
@@ -321,141 +343,41 @@ class PromptUtils:
                  - parameters: Formatted parameter documentation
                  - response schema: Response/return value schema
         """
-        prompt = create_chat_prompt_from_templates(
-            system_path='./prompts/shortlister/system.jinja2',
-            message_templates=[
-                (
-                    'human',
-                    """
-                Current Apps: {all_apps}
-                Current Available Tools: {all_tools}
-                """,
-                ),
-                ('ai', 'Sure, now give me the intent'),
-                ('human', '{input}'),
-            ],
+        from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+            ShortlistRequest,
+            ShortlisterRouter,
+            render_tools_markdown,
+            run_shortlister,
         )
-        tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(all_tools, all_apps)
-        from cuga.backend.llm.models import LLMManager
-        from cuga.backend.cuga_graph.nodes.api.shortlister_agent.prompts.load_prompt import (
-            ShortListerOutputLite,
+        from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import compose_query
+
+        plan = ShortlisterRouter.resolve(
+            settings, seam="discovery", configurable=_configurable_of(run_config)
         )
-        from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
+        # Below the threshold the cosine stage would add cost without cutting
+        # anything, so the LLM ranks the full set exactly as it does today.
+        # Uniform on purpose: "at or below threshold, shortlisting behaves as it
+        # always did" is easier to reason about than per-strategy exceptions.
+        # Set ``threshold = 0`` to always engage the configured strategy.
+        engage_cosine = len(all_tools) > plan.threshold
+        if not engage_cosine:
+            plan = plan.model_copy(update={"strategy": "llm", "instance": None})
 
-        llm_manager = LLMManager()
-        model = llm or llm_manager.get_model(settings.agent.code.model)
-        chain = BaseAgent.get_chain(prompt, model, ShortListerOutputLite)
-        response = await chain.ainvoke(
-            {
-                "input": query,
-                "all_apps": apps_as_dict,
-                "all_tools": tools_as_dict,
-                "instructions": "",
-            },
-            config=nested_langgraph_invoke_config(run_config),
+        candidates = await run_shortlister(
+            plan,
+            ShortlistRequest(
+                query=query,
+                tools=all_tools,
+                apps=all_apps,
+                task_context=task_context,
+                top_k=plan.top_k if engage_cosine else None,
+                max_results=plan.max_results if engage_cosine else None,
+                llm=llm,
+                run_config=run_config,
+            ),
         )
-
-        enriched_tools = []
-        for api_detail in response.result:
-            # Find the actual tool to get input schema and output schema
-            actual_tool = None
-            for t in all_tools:
-                if t.name == api_detail.name:
-                    actual_tool = t
-                    break
-
-            if not actual_tool:
-                continue
-
-            params_doc, response_doc = PromptUtils.get_tool_docs(actual_tool)
-
-            # Get input schema from the actual tool
-            input_schema = {}
-            if hasattr(actual_tool, 'args_schema') and actual_tool.args_schema:
-                try:
-                    input_schema = actual_tool.args_schema.schema()
-                except Exception:
-                    input_schema = {}
-
-            # Get output schema from response_schemas if available
-            output_schema = {}
-            if hasattr(actual_tool, 'func') and hasattr(actual_tool.func, '_response_schemas'):
-                response_schemas = actual_tool.func._response_schemas
-                if response_schemas and isinstance(response_schemas, dict) and 'success' in response_schemas:
-                    raw_output_schema = response_schemas['success']
-                    # Ensure output_schema is always a dict
-                    if isinstance(raw_output_schema, list):
-                        # If it's a list, wrap it in a proper JSON schema format
-                        if len(raw_output_schema) > 0 and isinstance(raw_output_schema[0], dict):
-                            # List of objects - create array schema with items
-                            output_schema = {"type": "array", "items": raw_output_schema[0]}
-                        else:
-                            # List of primitives - create array schema
-                            output_schema = {
-                                "type": "array",
-                                "items": raw_output_schema[0] if raw_output_schema else {},
-                            }
-                    elif isinstance(raw_output_schema, dict):
-                        output_schema = raw_output_schema
-                    else:
-                        # Fallback for other types
-                        output_schema = {"value": raw_output_schema} if raw_output_schema is not None else {}
-
-            enriched_tool = Tool(
-                name=api_detail.name,
-                input=VariableUtils.sanitize_value(input_schema),
-                reasoning=api_detail.reasoning,
-                output_schema=VariableUtils.sanitize_value(output_schema),
-                params_doc=params_doc,
-                response_doc=response_doc,
-            )
-            enriched_tools.append(enriched_tool)
-
-        if not enriched_tools:
-            return "No matching tools found for your query."
-
-        tool_descriptions = {
-            tool.name: getattr(tool, 'description', None)
-            for tool in all_tools
-            if hasattr(tool, 'description')
-        }
-
-        markdown_lines = [
-            f"# Found {len(enriched_tools)} Matching Tool(s)\n",
-            f"**Query:** {query}\n",
-        ]
-
-        for idx, tool in enumerate(enriched_tools, 1):
-            markdown_lines.append(f"## {idx}. `{tool.name}`\n")
-
-            tool_description = tool_descriptions.get(tool.name)
-            if tool_description:
-                markdown_lines.append(f"**Description:** {tool_description}\n")
-
-            markdown_lines.append(f"**Reasoning:** {tool.reasoning}\n")
-
-            if tool.params_doc:
-                markdown_lines.append("**Parameters:**\n")
-                markdown_lines.append(f"{tool.params_doc}\n")
-            else:
-                markdown_lines.append("**Parameters:** No parameters required\n")
-
-            if tool.response_doc:
-                markdown_lines.append("**Response Schema:**\n")
-                markdown_lines.append(f"{tool.response_doc}\n")
-
-            if tool.input_ and tool.input_ != {}:
-                markdown_lines.append("**Input Schema:**\n")
-                markdown_lines.append(f"```json\n{json.dumps(tool.input_, indent=2)}\n```\n")
-
-            if tool.output_schema and tool.output_schema != {}:
-                markdown_lines.append("**Output Schema:**\n")
-                markdown_lines.append(f"```json\n{json.dumps(tool.output_schema, indent=2)}\n```\n")
-
-            markdown_lines.append("---\n")
-
-        return "\n".join(markdown_lines)
+        display_query = compose_query(query, task_context) if task_context else query
+        return render_tools_markdown(candidates, all_tools, display_query)
 
     @staticmethod
     async def shortlist_tool_names(
@@ -481,62 +403,42 @@ class PromptUtils:
         if not query or not query.strip():
             return []
 
-        from cuga.backend.llm.models import LLMManager
-        from cuga.backend.cuga_graph.nodes.api.shortlister_agent.prompts.load_prompt import (
-            ShortListerOutputLite,
-        )
-        from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
-
-        effective_instructions = (
-            instructions
-            if instructions is not None
-            else (
-                f"Return the {top_k} most relevant tools (or fewer if not enough are relevant), "
-                "ordered best-first by relevance. Do not exceed this count."
-            )
+        from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+            ShortlistRequest,
+            ShortlisterRouter,
+            run_shortlister,
         )
 
-        prompt = create_chat_prompt_from_templates(
-            system_path='./prompts/shortlister/system.jinja2',
-            message_templates=[
-                (
-                    'human',
-                    """
-                Current Apps: {all_apps}
-                Current Available Tools: {all_tools}
-                """,
-                ),
-                ('ai', 'Sure, now give me the intent'),
-                ('human', '{input}'),
-            ],
-        )
-        tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(all_tools, all_apps)
+        plan = ShortlisterRouter.resolve(settings, seam="bind_cap", configurable=_configurable_of(run_config))
+        # ``top_k`` here is the provider cap the caller computed; it is a hard
+        # ceiling, so never let a configured value raise it.
+        effective_top_k = min(top_k, plan.top_k) if plan.top_k else top_k
+        if len(all_tools) <= plan.threshold:
+            plan = plan.model_copy(update={"strategy": "llm", "instance": None})
 
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
-
-        llm_manager = LLMManager()
-        model = llm or llm_manager.get_model(settings.agent.code.model)
-        chain = BaseAgent.get_chain(prompt, model, ShortListerOutputLite)
-        response = await chain.ainvoke(
-            {
-                "input": query,
-                "all_apps": apps_as_dict,
-                "all_tools": tools_as_dict,
-                "instructions": effective_instructions,
-            },
-            config=nested_langgraph_invoke_config(run_config),
+        candidates = await run_shortlister(
+            plan,
+            ShortlistRequest(
+                query=query,
+                tools=all_tools,
+                apps=all_apps,
+                top_k=effective_top_k,
+                llm=llm,
+                run_config=run_config,
+                instructions=instructions,
+            ),
         )
 
         valid_names = {t.name for t in all_tools}
         ranked: List[str] = []
         seen: set = set()
-        for api_detail in getattr(response, "result", None) or []:
-            name = getattr(api_detail, "name", None)
+        for candidate in candidates:
+            name = getattr(candidate, "name", None)
             if not name or name in seen or name not in valid_names:
                 continue
             seen.add(name)
             ranked.append(name)
-            if len(ranked) >= top_k:
+            if len(ranked) >= effective_top_k:
                 break
         return ranked
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/__init__.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/__init__.py
@@ -1,0 +1,43 @@
+"""Pluggable tool shortlisting for CugaLite.
+
+See ``docs/design/pluggable-shortlister.md``. Default (``strategy = "llm"``)
+reproduces the pre-existing behavior exactly.
+"""
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterStrategy,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.config import (
+    Shortlister,
+    shortlister_to_configurable,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.factory import (
+    clear_instance_cache,
+    resolve_shortlister,
+    run_shortlister,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import (
+    BUILTIN_STRATEGIES,
+    ShortlisterPlan,
+    ShortlisterRouter,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.render import render_tools_markdown
+
+__all__ = [
+    "BUILTIN_STRATEGIES",
+    "Shortlister",
+    "ShortlistCandidate",
+    "ShortlistRequest",
+    "ShortlisterPlan",
+    "ShortlisterRouter",
+    "ShortlisterStrategy",
+    "ShortlisterUnavailableError",
+    "clear_instance_cache",
+    "render_tools_markdown",
+    "resolve_shortlister",
+    "run_shortlister",
+    "shortlister_to_configurable",
+]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/base.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/base.py
@@ -1,0 +1,78 @@
+"""Core types for pluggable tool shortlisting.
+
+A *shortlister* reduces a candidate tool set down to the ones worth showing the
+model. CugaLite does this at two call sites — runtime discovery (``find_tools``)
+and the bind-time provider cap — and both route through
+:class:`ShortlisterStrategy` so the ranker can be swapped by configuration.
+
+See ``docs/design/pluggable-shortlister.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar, List, Optional, Protocol
+
+from langchain_core.tools import StructuredTool
+
+
+@dataclass
+class ShortlistCandidate:
+    """One ranked tool.
+
+    ``score`` is strategy-defined (LLM relevance, cosine similarity, …) and is
+    used only for ordering — never compared across strategies.
+    """
+
+    name: str
+    score: float = 0.0
+    reasoning: str = ""
+
+
+@dataclass
+class ShortlistRequest:
+    """Everything a strategy needs to rank ``tools`` against ``query``.
+
+    ``query`` and ``task_context`` are kept **separate** rather than pre-joined:
+    the LLM strategy re-composes them into the exact prompt string it has always
+    sent, while the embedding strategy weights them independently (a long task
+    context would otherwise dominate a short per-step query and make every step
+    of a task retrieve the same tools).
+
+    ``top_k=None`` means "strategy decides how many" — the ``find_tools``
+    semantic, where the result count varies with the query.
+    """
+
+    query: str
+    tools: List[StructuredTool]
+    apps: List[Any]
+    task_context: Optional[str] = None
+    top_k: Optional[int] = None
+    max_results: Optional[int] = None
+    llm: Optional[Any] = None
+    run_config: Any = None
+    instructions: Optional[str] = None
+
+
+class ShortlisterUnavailableError(RuntimeError):
+    """Strategy cannot run right now (model not loaded, dependency missing).
+
+    Deliberately distinct from a genuine ranking failure: the factory catches
+    this and degrades to ``fallback_strategy`` instead of failing the run. A
+    strategy that is merely *bad* at ranking must not raise this.
+    """
+
+
+class ShortlisterStrategy(Protocol):
+    """Swap-in ranker. Implement this to provide a custom shortlister.
+
+    Register it via ``[shortlister] strategy = "my.pkg.MyShortlister"`` or
+    ``CugaAgent(shortlister=Shortlister(instance=MyShortlister()))``.
+
+    Returns candidates best-first. Names that match no tool in the request are
+    dropped by the caller, so a strategy need not filter them itself.
+    """
+
+    name: ClassVar[str]
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]: ...

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/config.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/config.py
@@ -1,0 +1,67 @@
+"""Public SDK config object for shortlisting.
+
+Mirrors the ``ToolCalling`` shape: a dataclass the caller builds, serialized
+into ``run_config["configurable"]`` by the SDK. Every field defaults to ``None``
+meaning "inherit" — so ``Shortlister(strategy="hybrid")`` is a complete,
+sensible configuration and the remaining knobs keep their settings values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import (
+    CONFIGURABLE_PREFIX,
+    ALL_FIELDS,
+)
+
+
+@dataclass
+class Shortlister:
+    """How CugaLite should shrink a large tool set.
+
+    Example:
+        ```python
+        from cuga import CugaAgent, Shortlister
+
+        agent = CugaAgent(tools=[...], shortlister=Shortlister(strategy="hybrid"))
+        await agent.invoke("...", shortlister=Shortlister(top_k=32))
+        ```
+    """
+
+    #: ``"llm"`` (default), ``"embedding"``, ``"hybrid"``, or a dotted class path.
+    strategy: Optional[str] = None
+    #: A pre-built strategy object; wins over ``strategy``.
+    instance: Optional[Any] = None
+    #: Engage the cosine stage only above this many candidates.
+    threshold: Optional[int] = None
+    #: How many candidates the cosine stage keeps.
+    top_k: Optional[int] = None
+    #: Max tools rendered to the agent by ``find_tools``.
+    max_results: Optional[int] = None
+    #: Cosine floor. Low by design — this is a recall filter.
+    min_score: Optional[float] = None
+    #: Step-query vs task-context blend, 0..1.
+    query_weight: Optional[float] = None
+    fallback_strategy: Optional[str] = None
+    embedding_model: Optional[str] = None
+    embedding_provider: Optional[str] = None
+
+
+def shortlister_to_configurable(shortlister: Optional[Shortlister]) -> Dict[str, Any]:
+    """Serialize to ``shortlister_*`` configurable keys.
+
+    Returns ``{}`` when there is nothing to say, so callers can treat an absent
+    or empty config as a no-op.
+    """
+    if shortlister is None:
+        return {}
+    out: Dict[str, Any] = {}
+    for field_name in ALL_FIELDS:
+        value = getattr(shortlister, field_name, None)
+        if value is not None:
+            out[f"{CONFIGURABLE_PREFIX}{field_name}"] = value
+    if shortlister.instance is not None:
+        out["shortlister_instance"] = shortlister.instance
+    return out

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/doc.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/doc.py
@@ -1,0 +1,153 @@
+"""Turn a tool into the short text that gets embedded.
+
+Tool text in practice is much weaker than it looks. Sampling the bundled CRM
+demo: endpoints carry no docstring and no ``summary=``/``description=``, so the
+OpenAPI parser falls back to FastAPI's auto-summary (``"Get Contacts"``) or
+nothing. Names are machine-generated — ``determine_operation_name_strategy``
+only uses a path segment when segments are unique, and ``/contacts/`` collides
+with ``/contacts/{contact_id}``, so names fall back to operationIds:
+``crm_get_contacts_contacts_get``.
+
+So the **name carries most of the signal**, but only once split back into words:
+``crm_get_contacts_contacts_get`` tokenizes badly, ``crm get contacts contacts
+get`` matches "list all contacts" well.
+
+Deliberately excluded from the embedded text: ``args_schema`` JSON, full
+response schemas, param constraints. They are what makes the *LLM* prompt
+expensive, and in a fixed-size vector they dilute signal rather than add it.
+They still reach the agent via the rendered markdown — they are simply not part
+of the ranking.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, List, Optional
+
+from langchain_core.tools import StructuredTool
+
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+_NON_WORD = re.compile(r"[^0-9a-zA-Z]+")
+_WS = re.compile(r"\s+")
+
+#: Trailing HTTP-verb noise that operationId-derived names accumulate.
+_NOISE_SUFFIXES = {"get", "post", "put", "patch", "delete"}
+
+
+def split_identifier(name: str) -> str:
+    """Split a tool identifier into space-separated lowercase words.
+
+    ``crm_get_contacts_contacts__get``  -> ``crm get contacts contacts get``
+    ``getAccountContacts``              -> ``get account contacts``
+    ``crm-get.contacts``                -> ``crm get contacts``
+
+    Duplicate words are kept: repetition in an operationId is genuine emphasis
+    on the entity ("contacts" twice) and helps rather than hurts the match.
+    """
+    if not name:
+        return ""
+    spaced = _CAMEL_BOUNDARY.sub(" ", str(name))
+    spaced = _NON_WORD.sub(" ", spaced)
+    return _WS.sub(" ", spaced).strip().lower()
+
+
+def _response_field_names(response_doc: str, limit: int = 24) -> List[str]:
+    """Pull bare field names out of a rendered response doc.
+
+    We want ``items, total, skip`` — not the JSON Schema they came from. Parsing
+    the already-rendered doc keeps this in step with whatever
+    ``PromptUtils.get_tool_docs`` produces instead of re-walking schemas here.
+    """
+    names: List[str] = []
+    for raw_line in (response_doc or "").splitlines():
+        line = raw_line.strip().lstrip("-*• ").strip()
+        if not line:
+            continue
+        match = re.match(r"^`?([A-Za-z_][A-Za-z0-9_]*)`?\s*[:(]", line)
+        if match:
+            candidate = match.group(1)
+            if candidate not in names:
+                names.append(candidate)
+        if len(names) >= limit:
+            break
+    return names
+
+
+def _param_lines(tool: StructuredTool, limit: int = 24) -> List[str]:
+    """``name: description`` for each parameter, description optional.
+
+    With tool descriptions frequently empty, parameter text is often the only
+    real natural language available for a tool.
+    """
+    schema: Dict[str, Any] = {}
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is not None:
+        try:
+            if hasattr(args_schema, "model_json_schema"):
+                schema = args_schema.model_json_schema()
+            elif hasattr(args_schema, "schema"):
+                schema = args_schema.schema()
+        except (AttributeError, TypeError, ValueError):
+            schema = {}
+    properties = (schema or {}).get("properties") or {}
+    lines: List[str] = []
+    for param_name, spec in list(properties.items())[:limit]:
+        description = ""
+        if isinstance(spec, dict):
+            description = str(spec.get("description") or "").strip()
+        words = split_identifier(param_name)
+        lines.append(f"{words}: {description}" if description else words)
+    return lines
+
+
+def tool_document(
+    tool: StructuredTool,
+    app_name: str = "",
+    response_doc: str = "",
+) -> str:
+    """Build the text embedded for ``tool``.
+
+    Deterministic: the same tool always yields the same string, which is what
+    makes :func:`tool_fingerprint` a valid cache key.
+    """
+    name = getattr(tool, "name", "") or ""
+    description = (getattr(tool, "description", "") or "").strip()
+
+    parts: List[str] = [f"{split_identifier(app_name)} {split_identifier(name)}".strip()]
+    if description:
+        parts.append(description)
+
+    params = _param_lines(tool)
+    if params:
+        parts.append("Parameters: " + "; ".join(params))
+
+    returns = _response_field_names(response_doc)
+    if returns:
+        parts.append("Returns: " + ", ".join(returns))
+
+    return "\n".join(p for p in parts if p)
+
+
+def tool_fingerprint(document: str, model_name: str) -> str:
+    """Cache key for an embedded document.
+
+    Keyed on **content**, not tool name, so an edited description or a changed
+    embedding model re-embeds automatically instead of serving a stale vector.
+    """
+    digest = hashlib.sha256()
+    digest.update((model_name or "").encode("utf-8"))
+    digest.update(b"\x00")
+    digest.update((document or "").encode("utf-8"))
+    return digest.hexdigest()
+
+
+def app_name_for_tool(tool: StructuredTool, fallback: Optional[str] = None) -> str:
+    """Best-effort app name; the registry provider stamps ``_app_name``."""
+    for target in (tool, getattr(tool, "func", None), getattr(tool, "coroutine", None)):
+        if target is None:
+            continue
+        value = getattr(target, "_app_name", None)
+        if value:
+            return str(value)
+    return fallback or ""

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/embedding.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/embedding.py
@@ -1,0 +1,348 @@
+"""Cosine-similarity shortlister — ranks tools without calling an LLM.
+
+Compares one vector built from the user's question against one vector per tool
+(name + description + parameter names + return field names; see ``doc.py``).
+
+Three properties worth knowing before changing anything here:
+
+* **It is a recall device, not a precision device.** ``get_contacts`` (list) and
+  ``get_contact`` (by id) differ by one character and embed almost identically.
+  Use it to cut a large catalogue down for an LLM to finish (``hybrid``), or
+  where only "don't drop the needed tool" matters (the bind-time cap). Issue
+  #150 documented exactly this failure class for the LLM shortlister.
+* **A query must never wait on a model download.** Mirrors the contract in
+  ``knowledge/reranker.py``: if the backend is not ready we start a background
+  load and raise :class:`ShortlisterUnavailableError` so the caller degrades to
+  the LLM strategy for that one call.
+* **Query and task context are blended as vectors, not strings.** Concatenating
+  them lets a long first message drown a short per-step query, which would make
+  every step of a multi-step task retrieve the same tools.
+
+Local (``provider = "local"``, the default) runs entirely offline via fastembed
+— no network call, nothing billed. ``provider = "openai"`` is available when a
+deployment explicitly wants it, and trades those properties for a hosted model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from typing import Any, ClassVar, Dict, List, Sequence, Tuple
+
+import numpy as np
+from loguru import logger
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.doc import (
+    app_name_for_tool,
+    tool_document,
+    tool_fingerprint,
+)
+
+#: Ready backends, keyed by ``provider:model``. Weights load once per process.
+_MODELS: Dict[str, Any] = {}
+_LOADING: set = set()
+_RETRY_AFTER: Dict[str, float] = {}
+_LOCK = threading.Lock()
+
+#: Normalized document vectors, keyed by content fingerprint.
+_VECTORS: Dict[str, np.ndarray] = {}
+
+#: After a failed load (offline / not cached / missing API key) wait this long
+#: before retrying, so a broken deploy does not hammer the network or spam logs.
+_RETRY_COOLDOWN_S = 30.0
+
+#: Never return nothing: an empty result is a dead end for the agent and the
+#: bind-time cap raises on it.
+_MIN_FALLBACK_RESULTS = 3
+
+DEFAULT_PROVIDER = "local"
+
+
+def backend_key(provider: str, model_name: str) -> str:
+    return f"{provider or DEFAULT_PROVIDER}:{model_name}"
+
+
+def _is_asymmetric(model_name: str) -> bool:
+    """Whether the model wants distinct query/passage encodings.
+
+    ``BAAI/bge-*`` models are trained with a query-side instruction prefix.
+    ``all-MiniLM-L6-v2`` (our default) is symmetric — applying bge's prefix to
+    it *degrades* results. Default to symmetric so an unknown model behaves
+    sanely rather than oddly.
+    """
+    lowered = (model_name or "").lower()
+    return "bge" in lowered and "reranker" not in lowered
+
+
+class _LocalBackend:
+    """fastembed, on-device. No network at query time, nothing billed."""
+
+    def __init__(self, model_name: str) -> None:
+        from fastembed import TextEmbedding
+
+        cache_dir = os.environ.get("FASTEMBED_CACHE_PATH")
+        local_files_only = os.environ.get("HF_HUB_OFFLINE", "0") == "1"
+        self._model_name = model_name
+        self._asymmetric = _is_asymmetric(model_name)
+        self._model = TextEmbedding(model_name, cache_dir=cache_dir, local_files_only=local_files_only)
+
+    def _embed_sync(self, texts: Sequence[str], *, as_query: bool) -> np.ndarray:
+        if self._asymmetric:
+            method = self._model.query_embed if as_query else self._model.passage_embed
+        else:
+            method = self._model.embed
+        return np.array([np.asarray(v, dtype=np.float32) for v in method(list(texts))], dtype=np.float32)
+
+    async def aembed(self, texts: Sequence[str], *, as_query: bool) -> np.ndarray:
+        # fastembed is synchronous and CPU-bound; keep it off the event loop.
+        return await asyncio.to_thread(self._embed_sync, texts, as_query=as_query)
+
+
+class _OpenAIBackend:
+    """Hosted embeddings. Opt-in — this makes shortlisting a billed network call.
+
+    ``OpenAIEmbeddings`` already distinguishes documents from queries and
+    batches natively, so no asymmetry heuristic is needed here.
+    """
+
+    def __init__(self, model_name: str) -> None:
+        from langchain_openai import OpenAIEmbeddings
+
+        from cuga.backend.storage.embedding.embedding_service import get_embedding_config
+
+        cfg = get_embedding_config()
+        api_key = cfg.get("api_key") or os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise ShortlisterUnavailableError(
+                "shortlister.embedding_provider = 'openai' but no API key found "
+                "(set OPENAI_API_KEY or storage.embedding.api_key)"
+            )
+        kwargs: Dict[str, Any] = {"model": model_name or "text-embedding-3-small", "api_key": api_key}
+        if cfg.get("base_url"):
+            kwargs["base_url"] = str(cfg["base_url"]).rstrip("/")
+        self._embeddings = OpenAIEmbeddings(**kwargs)
+
+    async def aembed(self, texts: Sequence[str], *, as_query: bool) -> np.ndarray:
+        items = list(texts)
+        if as_query:
+            vectors = [await self._embeddings.aembed_query(t) for t in items]
+        else:
+            vectors = await self._embeddings.aembed_documents(items)
+        return np.array([np.asarray(v, dtype=np.float32) for v in vectors], dtype=np.float32)
+
+
+_BACKENDS = {"local": _LocalBackend, "openai": _OpenAIBackend}
+
+
+def is_ready(provider: str, model_name: str) -> bool:
+    """True if the backend is resident and ranking will not block on a load."""
+    return backend_key(provider, model_name) in _MODELS
+
+
+def _build_backend(provider: str, model_name: str) -> Any:
+    name = (provider or DEFAULT_PROVIDER).strip().lower()
+    builder = _BACKENDS.get(name)
+    if builder is None:
+        raise ShortlisterUnavailableError(
+            f"unknown shortlister.embedding_provider {provider!r}; "
+            f"expected one of {', '.join(sorted(_BACKENDS))}"
+        )
+    return builder(model_name)
+
+
+def prewarm(provider: str, model_name: str) -> bool:
+    """Build the backend synchronously. Returns True on success."""
+    key = backend_key(provider, model_name)
+    if key in _MODELS:
+        return True
+    try:
+        backend = _build_backend(provider, model_name)
+    except Exception as e:
+        with _LOCK:
+            _RETRY_AFTER[key] = time.monotonic() + _RETRY_COOLDOWN_S
+        logger.warning("Shortlister embedding backend {!r} failed to load: {}", key, e)
+        return False
+    with _LOCK:
+        _MODELS[key] = backend
+        _RETRY_AFTER.pop(key, None)
+    logger.info("Shortlister embedding backend ready: {}", key)
+    return True
+
+
+def ensure_loading(provider: str, model_name: str) -> None:
+    """Kick a background load if one is not already running or cooling down."""
+    key = backend_key(provider, model_name)
+    with _LOCK:
+        if key in _MODELS or key in _LOADING:
+            return
+        retry_at = _RETRY_AFTER.get(key)
+        if retry_at is not None and time.monotonic() < retry_at:
+            return
+        _LOADING.add(key)
+
+    def _load() -> None:
+        try:
+            prewarm(provider, model_name)
+        finally:
+            with _LOCK:
+                _LOADING.discard(key)
+
+    threading.Thread(target=_load, name=f"shortlister-embed-load:{key}", daemon=True).start()
+
+
+def reset_caches() -> None:
+    """Clear backend and vector caches. Tests only."""
+    with _LOCK:
+        _MODELS.clear()
+        _LOADING.clear()
+        _RETRY_AFTER.clear()
+        _VECTORS.clear()
+
+
+def _normalize(vectors: np.ndarray) -> np.ndarray:
+    """L2-normalize row-wise; zero rows stay zero (they score 0, never NaN)."""
+    matrix = np.atleast_2d(np.asarray(vectors, dtype=np.float32))
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return matrix / norms
+
+
+class EmbeddingShortlister:
+    """Ranks tools by cosine similarity between query and tool documents."""
+
+    name: ClassVar[str] = "embedding"
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        provider: str = DEFAULT_PROVIDER,
+        query_weight: float = 0.7,
+        min_score: float = 0.15,
+    ) -> None:
+        self._model_name = model_name
+        self._provider = (provider or DEFAULT_PROVIDER).strip().lower()
+        self._query_weight = min(max(float(query_weight), 0.0), 1.0)
+        self._min_score = float(min_score)
+
+    @property
+    def _key(self) -> str:
+        return backend_key(self._provider, self._model_name)
+
+    # -- backend access ----------------------------------------------------
+
+    def _require_backend(self) -> Any:
+        """Return the ready backend, or start loading and signal unavailability."""
+        backend = _MODELS.get(self._key)
+        if backend is not None:
+            return backend
+        ensure_loading(self._provider, self._model_name)
+        raise ShortlisterUnavailableError(
+            f"embedding backend {self._key!r} is not ready yet; loading in the "
+            f"background and serving this call with the fallback strategy"
+        )
+
+    # -- vectors -----------------------------------------------------------
+
+    async def _document_matrix(self, backend: Any, tools: List[Any]) -> np.ndarray:
+        """Normalized document vectors for ``tools``, embedding only cache misses."""
+        from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+        fingerprints: List[str] = []
+        missing_texts: List[str] = []
+        missing_indexes: List[int] = []
+
+        for index, tool in enumerate(tools):
+            try:
+                _, response_doc = PromptUtils.get_tool_docs(tool)
+            except Exception:
+                response_doc = ""
+            document = tool_document(tool, app_name_for_tool(tool), response_doc)
+            # Keyed on the backend, not just the model: two providers serving the
+            # same model name still produce different vector spaces.
+            fingerprint = tool_fingerprint(document, self._key)
+            fingerprints.append(fingerprint)
+            if fingerprint not in _VECTORS:
+                missing_texts.append(document)
+                missing_indexes.append(index)
+
+        if missing_texts:
+            raw = await backend.aembed(missing_texts, as_query=False)
+            normalized = _normalize(raw)
+            for position, index in enumerate(missing_indexes):
+                _VECTORS[fingerprints[index]] = normalized[position]
+
+        return np.vstack([_VECTORS[f] for f in fingerprints])
+
+    async def _query_vector(self, backend: Any, request: ShortlistRequest) -> np.ndarray:
+        """Blend the step query and task context as weighted unit vectors.
+
+        String concatenation would let a long task context dominate a short step
+        query — the weighting would become an accident of relative length.
+        """
+        step = (request.query or "").strip()
+        context = (request.task_context or "").strip()
+
+        texts = [t for t in (step, context) if t]
+        if not texts:
+            raise ShortlisterUnavailableError("empty query — nothing to rank against")
+
+        normalized = _normalize(await backend.aembed(texts, as_query=True))
+        if len(texts) == 1:
+            return normalized[0]
+
+        alpha = self._query_weight
+        blended = alpha * normalized[0] + (1.0 - alpha) * normalized[1]
+        return _normalize(blended)[0]
+
+    # -- ranking -----------------------------------------------------------
+
+    def _select(
+        self,
+        scores: np.ndarray,
+        tools: List[Any],
+        request: ShortlistRequest,
+    ) -> List[Tuple[int, float]]:
+        """Apply ``top_k`` / ``min_score`` / ``max_results``, never returning empty."""
+        limit = request.top_k if request.top_k else len(tools)
+        if request.max_results:
+            limit = min(limit, request.max_results)
+        limit = max(1, min(limit, len(tools)))
+
+        order = np.argsort(-scores)[:limit]
+        kept = [(int(i), float(scores[i])) for i in order if float(scores[i]) >= self._min_score]
+
+        if not kept:
+            # Nothing cleared the floor. Returning nothing is worse than
+            # returning the best guesses: the agent has no next move, and the
+            # bind-time cap raises on an empty ranking.
+            fallback = min(_MIN_FALLBACK_RESULTS, limit, len(tools))
+            kept = [(int(i), float(scores[i])) for i in order[:fallback]]
+        return kept
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        if not request.tools or (request.top_k is not None and request.top_k <= 0):
+            return []
+
+        backend = self._require_backend()
+        document_matrix = await self._document_matrix(backend, request.tools)
+        query_vector = await self._query_vector(backend, request)
+
+        scores = document_matrix @ query_vector
+        selected = self._select(scores, request.tools, request)
+
+        return [
+            ShortlistCandidate(
+                name=request.tools[index].name,
+                score=score,
+                reasoning=f"Cosine similarity {score:.3f} to the query.",
+            )
+            for index, score in selected
+        ]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/factory.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/factory.py
@@ -1,0 +1,133 @@
+"""Build a strategy from a resolved :class:`ShortlisterPlan`.
+
+Name resolution follows the repo's existing idiom: a bare name selects a
+built-in, anything containing a dot is loaded as a class path via
+``cuga.config.get_class`` — the same mechanism as
+``page_understanding.transformer_path``.
+
+Instances are cached per plan signature so the embedding model's weights load
+once per process rather than once per call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+from loguru import logger
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterStrategy,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.hybrid import HybridShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import BUILTIN_STRATEGIES, ShortlisterPlan
+
+_INSTANCES: Dict[str, ShortlisterStrategy] = {}
+
+
+def clear_instance_cache() -> None:
+    """Drop cached strategy instances. Tests only."""
+    _INSTANCES.clear()
+
+
+def _build_llm(plan: ShortlisterPlan) -> LLMShortlister:
+    return LLMShortlister()
+
+
+def _build_embedding(plan: ShortlisterPlan) -> EmbeddingShortlister:
+    return EmbeddingShortlister(
+        model_name=plan.embedding_model,
+        provider=plan.embedding_provider,
+        query_weight=plan.query_weight,
+        min_score=plan.min_score,
+    )
+
+
+def _build_hybrid(plan: ShortlisterPlan) -> HybridShortlister:
+    return HybridShortlister(embedding=_build_embedding(plan), llm=_build_llm(plan))
+
+
+_BUILDERS: Dict[str, Callable[[ShortlisterPlan], Any]] = {
+    "llm": _build_llm,
+    "embedding": _build_embedding,
+    "hybrid": _build_hybrid,
+}
+
+
+def _build_from_dotted_path(path: str, plan: ShortlisterPlan) -> Any:
+    """Instantiate a user-supplied strategy class.
+
+    Tries ``Cls(plan=plan)`` first so custom strategies can read configuration,
+    falling back to a no-argument constructor.
+    """
+    from cuga.config import get_class
+
+    cls = get_class(path)
+    try:
+        return cls(plan=plan)
+    except TypeError:
+        return cls()
+
+
+def resolve_shortlister(plan: ShortlisterPlan) -> ShortlisterStrategy:
+    """Return the strategy described by ``plan``, cached where possible."""
+    if plan.instance is not None:
+        return plan.instance
+
+    key = plan.cache_key()
+    cached = _INSTANCES.get(key)
+    if cached is not None:
+        return cached
+
+    strategy_name = plan.strategy
+    if strategy_name in _BUILDERS:
+        strategy = _BUILDERS[strategy_name](plan)
+    elif "." in strategy_name:
+        try:
+            strategy = _build_from_dotted_path(strategy_name, plan)
+        except Exception as e:
+            logger.error(
+                "Could not load custom shortlister {!r}: {}. Falling back to {!r}.",
+                strategy_name,
+                e,
+                plan.fallback_strategy,
+            )
+            strategy = _BUILDERS.get(plan.fallback_strategy, _build_llm)(plan)
+    else:
+        # ShortlisterRouter normally rewrites unknown names; this covers a plan
+        # constructed directly in code.
+        raise ValueError(
+            f"Unknown shortlister strategy {strategy_name!r}. Expected one of "
+            f"{', '.join(BUILTIN_STRATEGIES)} or a dotted class path."
+        )
+
+    _INSTANCES[key] = strategy
+    return strategy
+
+
+async def run_shortlister(plan: ShortlisterPlan, request: ShortlistRequest) -> List[ShortlistCandidate]:
+    """Run the planned strategy, degrading to the fallback if it cannot run.
+
+    Only :class:`ShortlisterUnavailableError` triggers the fallback — a missing
+    model or dependency. Genuine ranking failures propagate so each call site
+    keeps its own error contract (``find_tools`` turns them into a message for
+    the agent; the bind-time cap raises).
+    """
+    strategy = resolve_shortlister(plan)
+    try:
+        return await strategy.shortlist(request)
+    except ShortlisterUnavailableError as e:
+        fallback_name = plan.fallback_strategy
+        if fallback_name == plan.strategy or fallback_name not in _BUILDERS:
+            raise
+        logger.warning(
+            "Shortlister {!r} unavailable ({}); using {!r} for this call.",
+            plan.strategy,
+            e,
+            fallback_name,
+        )
+        return await _BUILDERS[fallback_name](plan).shortlist(request)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/hybrid.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/hybrid.py
@@ -1,0 +1,68 @@
+"""Cosine prefilter, then LLM rerank.
+
+Cosine cuts a large catalogue down cheaply (high recall, poor precision on
+near-identical CRUD siblings); the LLM then makes the final selection with full
+schemas in front of it, on a pool small enough to be affordable.
+
+If the embedding leg is unavailable — model still downloading, fastembed
+missing — this degrades to plain LLM shortlisting, which is exactly today's
+behavior, so the degraded path is already well covered by existing tests.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, ClassVar, List
+
+from loguru import logger
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+
+
+class HybridShortlister:
+    """Embedding prefilter to ``top_k``, then :class:`LLMShortlister` ranks."""
+
+    name: ClassVar[str] = "hybrid"
+
+    def __init__(self, embedding: EmbeddingShortlister, llm: LLMShortlister) -> None:
+        self._embedding = embedding
+        self._llm = llm
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        if not request.tools:
+            return []
+
+        pool: List[Any] = request.tools
+
+        # Prefilter only when there is something to cut. At or below the cut
+        # width the LLM would see the same set either way.
+        width = request.top_k or 0
+        if width and len(pool) > width:
+            try:
+                prefiltered = await self._embedding.shortlist(
+                    dataclasses.replace(
+                        request,
+                        top_k=width,
+                        max_results=None,  # the cut width governs here, not the render cap
+                    )
+                )
+                by_name = {t.name: t for t in pool}
+                narrowed = [by_name[c.name] for c in prefiltered if c.name in by_name]
+                if narrowed:
+                    logger.debug("Hybrid shortlister: cosine cut {} tools to {}", len(pool), len(narrowed))
+                    pool = narrowed
+            except ShortlisterUnavailableError as e:
+                logger.warning(
+                    "Hybrid shortlister: embedding leg unavailable ({}); ranking all {} tools "
+                    "with the LLM for this call",
+                    e,
+                    len(pool),
+                )
+
+        return await self._llm.shortlist(dataclasses.replace(request, tools=pool))

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/llm.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/llm.py
@@ -1,0 +1,100 @@
+"""The LLM shortlister — today's behavior, behind the strategy interface.
+
+This is the default and is deliberately a faithful port: same prompt template,
+same ``ShortListerOutputLite`` schema, same model, same composed query string.
+Callers already drop names that match no tool, so nothing is filtered here.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, List, Optional
+
+from cuga.config import settings
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+)
+
+
+def compose_query(query: str, task_context: Optional[str]) -> str:
+    """Join a step query with the task context exactly as CugaLite always has.
+
+    Kept identical to ``helpers/find_tools._compose_find_tools_shortlister_query``
+    so the prompt text does not change now that the two parts travel separately.
+    """
+    q = (query or "").strip()
+    init = (task_context or "").strip()
+    if not init:
+        return q
+    return f"Query: {q}\nTask context (initial user message): {init}"
+
+
+def top_k_instruction(top_k: int) -> str:
+    """The instruction the bind-time cap has always injected."""
+    return (
+        f"Return the {top_k} most relevant tools (or fewer if not enough are relevant), "
+        "ordered best-first by relevance. Do not exceed this count."
+    )
+
+
+class LLMShortlister:
+    """Ranks tools by asking the model, using the shortlister prompt."""
+
+    name: ClassVar[str] = "llm"
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        from cuga.backend.llm.models import LLMManager
+        from cuga.backend.cuga_graph.nodes.api.shortlister_agent.prompts.load_prompt import (
+            ShortListerOutputLite,
+        )
+        from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
+        from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
+        from cuga.backend.llm.utils.helpers import create_chat_prompt_from_templates
+
+        if not request.tools:
+            return []
+
+        if request.instructions is not None:
+            instructions = request.instructions
+        elif request.top_k:
+            instructions = top_k_instruction(request.top_k)
+        else:
+            instructions = ""
+
+        prompt = create_chat_prompt_from_templates(
+            system_path='../prompts/shortlister/system.jinja2',
+            message_templates=[
+                (
+                    'human',
+                    """
+                Current Apps: {all_apps}
+                Current Available Tools: {all_tools}
+                """,
+                ),
+                ('ai', 'Sure, now give me the intent'),
+                ('human', '{input}'),
+            ],
+        )
+        tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(request.tools, request.apps)
+
+        model = request.llm or LLMManager().get_model(settings.agent.code.model)
+        chain = BaseAgent.get_chain(prompt, model, ShortListerOutputLite)
+        response = await chain.ainvoke(
+            {
+                "input": compose_query(request.query, request.task_context),
+                "all_apps": apps_as_dict,
+                "all_tools": tools_as_dict,
+                "instructions": instructions,
+            },
+            config=nested_langgraph_invoke_config(request.run_config),
+        )
+
+        return [
+            ShortlistCandidate(
+                name=getattr(detail, "name", ""),
+                score=float(getattr(detail, "relevance_score", 0.0) or 0.0),
+                reasoning=str(getattr(detail, "reasoning", "") or ""),
+            )
+            for detail in (getattr(response, "result", None) or [])
+        ]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/plan.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/plan.py
@@ -1,0 +1,189 @@
+"""Resolve shortlister settings into an explicit :class:`ShortlisterPlan`.
+
+Mirrors ``cuga_agent_core/policy/execution_policy.py`` (``ExecutionRouter`` →
+``ExecutionPlan``): settings in, one typed, log-visible object out.
+
+Precedence, highest first:
+  1. ``override``                       — a live object / dataclass from the SDK
+  2. ``configurable["shortlister_*"]``  — per-invoke
+  3. ``[shortlister.<seam>]``           — per-seam TOML
+  4. ``[shortlister]``                  — global TOML
+  5. module defaults below
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+Seam = Literal["discovery", "bind_cap"]
+
+BUILTIN_STRATEGIES = ("llm", "embedding", "hybrid")
+
+# Defaults live here, not in settings.toml, so a missing section can never break
+# resolution. settings.toml restates them for discoverability.
+DEFAULT_STRATEGY = "llm"
+DEFAULT_FALLBACK_STRATEGY = "llm"
+DEFAULT_THRESHOLD = 128
+DEFAULT_TOP_K = 128
+DEFAULT_MAX_RESULTS = 10
+DEFAULT_MIN_SCORE = 0.15
+DEFAULT_QUERY_WEIGHT = 0.7
+DEFAULT_EMBEDDING_PROVIDER = "local"
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+_INT_FIELDS = ("threshold", "top_k", "max_results")
+_FLOAT_FIELDS = ("min_score", "query_weight")
+_STR_FIELDS = (
+    "strategy",
+    "fallback_strategy",
+    "embedding_provider",
+    "embedding_model",
+)
+ALL_FIELDS = _INT_FIELDS + _FLOAT_FIELDS + _STR_FIELDS
+
+#: ``configurable`` keys, e.g. ``shortlister_strategy``.
+CONFIGURABLE_PREFIX = "shortlister_"
+
+
+class ShortlisterPlan(BaseModel):
+    """Explicit description of how shortlisting will run for one seam."""
+
+    seam: Seam = "discovery"
+    strategy: str = DEFAULT_STRATEGY
+    fallback_strategy: str = DEFAULT_FALLBACK_STRATEGY
+    threshold: int = DEFAULT_THRESHOLD
+    top_k: int = DEFAULT_TOP_K
+    max_results: int = DEFAULT_MAX_RESULTS
+    min_score: float = DEFAULT_MIN_SCORE
+    query_weight: float = DEFAULT_QUERY_WEIGHT
+    embedding_provider: str = DEFAULT_EMBEDDING_PROVIDER
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL
+    #: Live strategy object injected via the SDK; bypasses ``strategy``.
+    instance: Optional[Any] = Field(default=None, exclude=True)
+    notes: List[str] = Field(default_factory=list)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    @property
+    def is_llm_only(self) -> bool:
+        """True when no cosine stage can run — i.e. today's behavior exactly."""
+        return self.instance is None and self.strategy == "llm"
+
+    def cache_key(self) -> str:
+        """Identity for the strategy-instance cache (excludes per-call knobs)."""
+        return "|".join(
+            [
+                self.strategy,
+                self.fallback_strategy,
+                self.embedding_provider,
+                self.embedding_model,
+                f"qw={self.query_weight}",
+            ]
+        )
+
+
+def _coerce(field_name: str, raw: Any) -> Any:
+    """Coerce a settings/configurable value, returning ``None`` when unusable.
+
+    Values arrive from TOML, env (always strings) and Python, so every field is
+    coerced rather than trusted. A bad value is dropped in favour of the lower
+    precedence source instead of raising — a typo in one key must not take the
+    agent down.
+    """
+    if raw is None:
+        return None
+    try:
+        if field_name in _INT_FIELDS:
+            return int(raw)
+        if field_name in _FLOAT_FIELDS:
+            return float(raw)
+        text = str(raw).strip()
+        return text or None
+    except (TypeError, ValueError):
+        return None
+
+
+def _layer(target: Dict[str, Any], source: Any, *, keys: Any = ALL_FIELDS, prefix: str = "") -> None:
+    """Copy recognised, non-``None`` values from ``source`` onto ``target``."""
+    if source is None:
+        return
+    for field_name in keys:
+        lookup = f"{prefix}{field_name}"
+        if isinstance(source, dict):
+            if lookup not in source:
+                continue
+            raw = source.get(lookup)
+        else:
+            raw = getattr(source, lookup, None)
+        value = _coerce(field_name, raw)
+        if value is not None:
+            target[field_name] = value
+
+
+class ShortlisterRouter:
+    """Resolves settings + overrides into a :class:`ShortlisterPlan`."""
+
+    @staticmethod
+    def resolve(
+        settings: Any,
+        *,
+        seam: Seam = "discovery",
+        configurable: Optional[Dict[str, Any]] = None,
+        override: Optional[Any] = None,
+    ) -> ShortlisterPlan:
+        values: Dict[str, Any] = {}
+        notes: List[str] = []
+
+        section = getattr(settings, "shortlister", None)
+        _layer(values, section)
+        _layer(values, getattr(section, seam, None) if section is not None else None)
+        _layer(values, configurable, prefix=CONFIGURABLE_PREFIX)
+
+        instance = None
+        if configurable:
+            instance = configurable.get("shortlister_instance") or _instance_of(
+                configurable.get("shortlister")
+            )
+            _layer(values, _as_mapping(configurable.get("shortlister")))
+
+        if override is not None:
+            instance = _instance_of(override) or instance
+            _layer(values, _as_mapping(override))
+
+        plan = ShortlisterPlan(seam=seam, instance=instance, notes=notes, **values)
+
+        # Append to ``plan.notes``, not the local list — pydantic copies it on
+        # validation, so mutating ``notes`` here would silently do nothing.
+        if plan.instance is None and plan.strategy not in BUILTIN_STRATEGIES and "." not in plan.strategy:
+            plan.notes.append(
+                f"unknown shortlister strategy {plan.strategy!r}; falling back to "
+                f"{DEFAULT_STRATEGY!r} (expected one of {', '.join(BUILTIN_STRATEGIES)} "
+                f"or a dotted class path)"
+            )
+            plan.strategy = DEFAULT_STRATEGY
+        if plan.top_k < 0:
+            plan.top_k = 0
+        if plan.max_results <= 0:
+            plan.max_results = DEFAULT_MAX_RESULTS
+        return plan
+
+
+def _instance_of(candidate: Any) -> Optional[Any]:
+    """Extract a live strategy object from an SDK config or raw instance."""
+    if candidate is None:
+        return None
+    inner = getattr(candidate, "instance", None)
+    if inner is not None:
+        return inner
+    if hasattr(candidate, "shortlist"):
+        return candidate
+    return None
+
+
+def _as_mapping(candidate: Any) -> Optional[Any]:
+    """Return ``candidate`` if it can carry plan fields, else ``None``."""
+    if candidate is None or hasattr(candidate, "shortlist"):
+        return None
+    return candidate

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/render.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/render.py
@@ -1,0 +1,128 @@
+"""Render ranked candidates as the markdown ``find_tools`` returns.
+
+Extracted verbatim from ``PromptUtils.find_tools`` so that ranking and
+presentation can vary independently: a cosine strategy produces the same output
+shape as the LLM one, just with ``reasoning`` supplied differently.
+
+Output format is load-bearing — the agent reads this string from sandbox stdout
+— so changes here are behavior changes. Keep byte-compatible with the pre-split
+implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import ShortlistCandidate
+
+NO_MATCH_MESSAGE = "No matching tools found for your query."
+
+
+def _output_schema_for(tool: StructuredTool) -> Dict[str, Any]:
+    """Normalize ``_response_schemas['success']`` into a dict schema."""
+    func = getattr(tool, "func", None)
+    if func is None or not hasattr(func, "_response_schemas"):
+        return {}
+    response_schemas = func._response_schemas
+    if not (response_schemas and isinstance(response_schemas, dict) and 'success' in response_schemas):
+        return {}
+    raw = response_schemas['success']
+    if isinstance(raw, list):
+        if len(raw) > 0 and isinstance(raw[0], dict):
+            return {"type": "array", "items": raw[0]}
+        return {"type": "array", "items": raw[0] if raw else {}}
+    if isinstance(raw, dict):
+        return raw
+    return {"value": raw} if raw is not None else {}
+
+
+def _input_schema_for(tool: StructuredTool) -> Dict[str, Any]:
+    args_schema = getattr(tool, "args_schema", None)
+    if not args_schema:
+        return {}
+    try:
+        return args_schema.schema()
+    except Exception:
+        return {}
+
+
+def render_tools_markdown(
+    candidates: List[ShortlistCandidate],
+    tools: List[StructuredTool],
+    display_query: str,
+) -> str:
+    """Render ``candidates`` as markdown.
+
+    ``display_query`` is shown verbatim in the ``**Query:**`` header — callers
+    pass the same composed string the LLM saw, so output is unchanged.
+
+    Candidates whose name matches no tool in ``tools`` are silently skipped,
+    preserving the original ``if not actual_tool: continue``.
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils, Tool
+
+    by_name = {t.name: t for t in tools}
+
+    enriched_tools: List[Tool] = []
+    for candidate in candidates:
+        actual_tool = by_name.get(candidate.name)
+        if not actual_tool:
+            continue
+        params_doc, response_doc = PromptUtils.get_tool_docs(actual_tool)
+        enriched_tools.append(
+            Tool(
+                name=candidate.name,
+                input=VariableUtils.sanitize_value(_input_schema_for(actual_tool)),
+                reasoning=candidate.reasoning,
+                output_schema=VariableUtils.sanitize_value(_output_schema_for(actual_tool)),
+                params_doc=params_doc,
+                response_doc=response_doc,
+            )
+        )
+
+    if not enriched_tools:
+        return NO_MATCH_MESSAGE
+
+    tool_descriptions = {
+        tool.name: getattr(tool, 'description', None) for tool in tools if hasattr(tool, 'description')
+    }
+
+    markdown_lines = [
+        f"# Found {len(enriched_tools)} Matching Tool(s)\n",
+        f"**Query:** {display_query}\n",
+    ]
+
+    for idx, tool in enumerate(enriched_tools, 1):
+        markdown_lines.append(f"## {idx}. `{tool.name}`\n")
+
+        tool_description = tool_descriptions.get(tool.name)
+        if tool_description:
+            markdown_lines.append(f"**Description:** {tool_description}\n")
+
+        markdown_lines.append(f"**Reasoning:** {tool.reasoning}\n")
+
+        if tool.params_doc:
+            markdown_lines.append("**Parameters:**\n")
+            markdown_lines.append(f"{tool.params_doc}\n")
+        else:
+            markdown_lines.append("**Parameters:** No parameters required\n")
+
+        if tool.response_doc:
+            markdown_lines.append("**Response Schema:**\n")
+            markdown_lines.append(f"{tool.response_doc}\n")
+
+        if tool.input_ and tool.input_ != {}:
+            markdown_lines.append("**Input Schema:**\n")
+            markdown_lines.append(f"```json\n{json.dumps(tool.input_, indent=2)}\n```\n")
+
+        if tool.output_schema and tool.output_schema != {}:
+            markdown_lines.append("**Output Schema:**\n")
+            markdown_lines.append(f"```json\n{json.dumps(tool.output_schema, indent=2)}\n```\n")
+
+        markdown_lines.append("---\n")
+
+    return "\n".join(markdown_lines)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_defaults.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_defaults.py
@@ -1,0 +1,221 @@
+"""Defaults and the `threshold` contract.
+
+The load-bearing guarantee of this feature: with the default settings, or at or
+below `threshold` candidates, shortlisting behaves exactly as it did before the
+strategy seam existed — same prompt, same LLM call, no embedding work.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    ShortlisterRouter,
+    clear_instance_cache,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import (
+    DEFAULT_MAX_RESULTS,
+    DEFAULT_THRESHOLD,
+    DEFAULT_TOP_K,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_instance_cache()
+    yield
+    clear_instance_cache()
+
+
+def _tool(name: str) -> StructuredTool:
+    def fn(**kwargs):
+        return name
+
+    fn.__name__ = name
+    return StructuredTool.from_function(func=fn, name=name, description=f"{name} description")
+
+
+def _tools(count: int):
+    return [_tool(f"tool_{i}") for i in range(count)]
+
+
+def _settings(**shortlister_overrides):
+    """Minimal settings stand-in exposing only what the router reads."""
+    return SimpleNamespace(shortlister=SimpleNamespace(**shortlister_overrides))
+
+
+# --- defaults ---------------------------------------------------------------
+
+
+def test_defaults_are_llm_and_128():
+    """Shipping defaults: LLM strategy, K=128, threshold=128, max_results=10."""
+    plan = ShortlisterRouter.resolve(SimpleNamespace())
+    assert plan.strategy == "llm"
+    assert plan.threshold == DEFAULT_THRESHOLD == 128
+    assert plan.top_k == DEFAULT_TOP_K == 128
+    assert plan.max_results == DEFAULT_MAX_RESULTS == 10
+    assert plan.is_llm_only is True
+
+
+def test_real_settings_defaults_match_plan_defaults():
+    """settings.toml and plan.py must not drift apart."""
+    from cuga.config import settings
+
+    plan = ShortlisterRouter.resolve(settings)
+    assert plan.strategy == "llm"
+    assert plan.threshold == 128
+    assert plan.top_k == 128
+    assert plan.max_results == 10
+
+
+def test_missing_shortlister_section_is_safe():
+    """A settings object with no [shortlister] must not raise."""
+    plan = ShortlisterRouter.resolve(SimpleNamespace())
+    assert plan.strategy == "llm"
+
+
+# --- the threshold contract -------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_count,expect_cosine",
+    [(128, False), (129, True)],
+    ids=["at-threshold-unchanged", "above-threshold-engages"],
+)
+async def test_threshold_gates_the_cosine_stage(tool_count, expect_cosine):
+    """At or below `threshold`, the cosine strategy must not run at all."""
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    tools = _tools(tool_count)
+    llm_result = AsyncMock(return_value=_empty_result())
+    embed_result = AsyncMock(return_value=_empty_result())
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm.LLMShortlister.shortlist",
+            llm_result,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding.EmbeddingShortlister.shortlist",
+            embed_result,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(strategy="embedding", threshold=128),
+        ),
+    ):
+        await PromptUtils.find_tools(query="q", all_tools=tools, all_apps=[])
+
+    assert embed_result.await_count == (1 if expect_cosine else 0)
+    assert llm_result.await_count == (0 if expect_cosine else 1)
+
+
+@pytest.mark.asyncio
+async def test_threshold_zero_always_engages():
+    """`threshold = 0` opts out of the gate entirely."""
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    embed_result = AsyncMock(return_value=_empty_result())
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding.EmbeddingShortlister.shortlist",
+            embed_result,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(strategy="embedding", threshold=0),
+        ),
+    ):
+        await PromptUtils.find_tools(query="q", all_tools=_tools(2), all_apps=[])
+
+    embed_result.assert_awaited_once()
+
+
+# --- K handling -------------------------------------------------------------
+
+
+def test_top_k_negative_clamps_to_zero():
+    plan = ShortlisterRouter.resolve(_settings(top_k=-5))
+    assert plan.top_k == 0
+
+
+def test_max_results_non_positive_falls_back_to_default():
+    plan = ShortlisterRouter.resolve(_settings(max_results=0))
+    assert plan.max_results == DEFAULT_MAX_RESULTS
+
+
+@pytest.mark.asyncio
+async def test_bind_cap_k_never_exceeds_caller_cap():
+    """A configured top_k may lower the bind cap, never raise it past the provider limit."""
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    tools = _tools(200)
+    captured = {}
+
+    async def _capture(self, request):
+        captured["top_k"] = request.top_k
+        return _empty_result()
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm.LLMShortlister.shortlist",
+            _capture,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(top_k=9999, threshold=0),
+        ),
+    ):
+        await PromptUtils.shortlist_tool_names(query="q", all_tools=tools, all_apps=[], top_k=16)
+
+    assert captured["top_k"] == 16, "caller cap must win over a larger configured top_k"
+
+
+@pytest.mark.asyncio
+async def test_configured_top_k_can_lower_bind_cap():
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    captured = {}
+
+    async def _capture(self, request):
+        captured["top_k"] = request.top_k
+        return _empty_result()
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm.LLMShortlister.shortlist",
+            _capture,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(top_k=4, threshold=0),
+        ),
+    ):
+        await PromptUtils.shortlist_tool_names(query="q", all_tools=_tools(50), all_apps=[], top_k=32)
+
+    assert captured["top_k"] == 4
+
+
+# --- distinct from the older threshold --------------------------------------
+
+
+def test_shortlister_threshold_is_not_shortlisting_tool_threshold():
+    """Two different settings, two different meanings — easy to confuse.
+
+    `advanced_features.shortlisting_tool_threshold` (35) decides when tools hide
+    behind find_tools in the prompt. `shortlister.threshold` (128) decides when
+    the cosine stage engages inside the shortlister.
+    """
+    from cuga.config import settings
+
+    assert settings.advanced_features.shortlisting_tool_threshold == 35
+    assert ShortlisterRouter.resolve(settings).threshold == 128
+
+
+def _empty_result():
+    return []

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_doc_render.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_doc_render.py
@@ -1,0 +1,159 @@
+"""Tool→text conversion and markdown rendering.
+
+`split_identifier` is the single highest-leverage detail in the cosine path:
+real tool names are machine-generated (`crm_get_contacts_contacts_get`) and
+embed poorly until split back into words.
+
+The render tests guard the rank/render extraction — output format is what the
+agent reads from sandbox stdout, so drift here is a behavior change.
+"""
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import ShortlistCandidate
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.doc import (
+    app_name_for_tool,
+    split_identifier,
+    tool_document,
+    tool_fingerprint,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.render import (
+    NO_MATCH_MESSAGE,
+    render_tools_markdown,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- split_identifier -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # The real shape CRM produces: path segments collide, so names fall
+        # back to FastAPI operationIds.
+        ("crm_get_contacts_contacts_get", "crm get contacts contacts get"),
+        ("crm_get_contacts_contacts__get", "crm get contacts contacts get"),
+        ("getAccountContacts", "get account contacts"),
+        ("crm-get.contacts", "crm get contacts"),
+        ("HTTPResponseCode", "http response code"),
+        ("tool_v2_lookup", "tool v2 lookup"),
+        ("", ""),
+        ("___", ""),
+    ],
+)
+def test_split_identifier(raw, expected):
+    assert split_identifier(raw) == expected
+
+
+# --- tool_document ----------------------------------------------------------
+
+
+class _ContactArgs(BaseModel):
+    email: str = Field(..., description="filter by email address")
+    limit: int = Field(default=10, description="")
+
+
+def _tool(name="crm_get_contacts_contacts_get", description="Get Contacts", args=_ContactArgs):
+    def fn(**kwargs):
+        return None
+
+    fn.__name__ = "fn"
+    return StructuredTool.from_function(func=fn, name=name, description=description, args_schema=args)
+
+
+def test_tool_document_includes_the_signal_bearing_fields():
+    document = tool_document(_tool(), app_name="crm", response_doc="- items (array): rows\n- total (int)")
+
+    assert "crm get contacts contacts get" in document
+    assert "Get Contacts" in document
+    assert "email: filter by email address" in document
+    assert "Returns: items, total" in document
+
+
+def test_tool_document_excludes_raw_schema_noise():
+    """args_schema JSON is what makes the LLM prompt expensive; in a fixed-size
+    vector it dilutes signal rather than adding to it."""
+    document = tool_document(_tool(), app_name="crm")
+    assert "properties" not in document
+    assert "$defs" not in document
+    assert "anyOf" not in document
+
+
+def test_tool_document_handles_missing_description_and_params():
+    def fn():
+        return None
+
+    fn.__name__ = "bare"
+    tool = StructuredTool.from_function(func=fn, name="bare_tool", description="")
+    assert "bare tool" in tool_document(tool, app_name="app")
+
+
+def test_tool_document_is_deterministic():
+    a, b = tool_document(_tool(), "crm"), tool_document(_tool(), "crm")
+    assert a == b
+
+
+# --- fingerprints -----------------------------------------------------------
+
+
+def test_fingerprint_changes_with_content_and_model():
+    base = tool_fingerprint("doc", "model")
+    assert tool_fingerprint("doc", "model") == base
+    assert tool_fingerprint("doc changed", "model") != base
+    assert tool_fingerprint("doc", "other-model") != base
+
+
+def test_app_name_from_registry_metadata():
+    tool = _tool()
+    tool.func._app_name = "crm"
+    assert app_name_for_tool(tool) == "crm"
+    assert app_name_for_tool(_tool(), fallback="fallback_app") == "fallback_app"
+
+
+# --- rendering --------------------------------------------------------------
+
+
+def test_render_produces_the_expected_markdown_shape():
+    tools = [_tool(name="tool_a", description="Tool A does things")]
+    out = render_tools_markdown(
+        [ShortlistCandidate(name="tool_a", score=0.9, reasoning="because")],
+        tools,
+        display_query="find contacts",
+    )
+
+    assert out.startswith("# Found 1 Matching Tool(s)")
+    assert "**Query:** find contacts" in out
+    assert "## 1. `tool_a`" in out
+    assert "**Description:** Tool A does things" in out
+    assert "**Reasoning:** because" in out
+    assert "**Parameters:**" in out
+    assert "---" in out
+
+
+def test_render_empty_returns_the_no_match_message():
+    assert render_tools_markdown([], [], display_query="q") == NO_MATCH_MESSAGE
+
+
+def test_render_skips_candidates_with_no_matching_tool():
+    """Preserves the original `if not actual_tool: continue`."""
+    tools = [_tool(name="real_tool")]
+    out = render_tools_markdown(
+        [ShortlistCandidate(name="hallucinated"), ShortlistCandidate(name="real_tool")],
+        tools,
+        display_query="q",
+    )
+    assert "# Found 1 Matching Tool(s)" in out
+    assert "hallucinated" not in out
+
+
+def test_render_uses_the_composed_query_verbatim():
+    """The header must show what the LLM saw, unchanged by the query split."""
+    composed = "Query: list contacts\nTask context (initial user message): Book a flight"
+    out = render_tools_markdown(
+        [ShortlistCandidate(name="tool_a")], [_tool(name="tool_a")], display_query=composed
+    )
+    assert f"**Query:** {composed}" in out

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_embedding.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_embedding.py
@@ -1,0 +1,335 @@
+"""EmbeddingShortlister: ranking, selection, query blending, cold start.
+
+Uses a deterministic bag-of-words fake embedder rather than a real model, so
+these run offline and assert exact ordering. Real-model behavior (does cosine
+actually pick the right tool) is a separate, slower concern — see the CRUD
+sibling harness.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import embedding as embedding_module
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import (
+    EmbeddingShortlister,
+    _is_asymmetric,
+    is_ready,
+    reset_caches,
+)
+
+pytestmark = pytest.mark.unit
+
+VOCAB = ["contact", "account", "email", "delete", "create", "list", "weather", "flight"]
+MODEL = "test-model"
+
+
+class FakeBackend:
+    """Bag-of-words backend: one dimension per vocabulary word."""
+
+    def __init__(self):
+        self.embed_calls = []
+        self.query_calls = []
+        self.passage_calls = []
+
+    async def aembed(self, texts, *, as_query):
+        items = list(texts)
+        self.embed_calls.append(items)
+        (self.query_calls if as_query else self.passage_calls).append(items)
+        return np.array(
+            [np.array([float((t or "").lower().count(w)) for w in VOCAB], dtype=np.float32) for t in items],
+            dtype=np.float32,
+        )
+
+
+class FakeTextEmbedding:
+    """Stand-in for fastembed's TextEmbedding, to test the local backend."""
+
+    def __init__(self):
+        self.embed_calls = []
+        self.query_calls = []
+        self.passage_calls = []
+
+    def _vectors(self, texts):
+        return [np.array([float((t or "").lower().count(w)) for w in VOCAB], dtype=np.float32) for t in texts]
+
+    def embed(self, texts):
+        self.embed_calls.append(list(texts))
+        return self._vectors(texts)
+
+    def query_embed(self, texts):
+        self.query_calls.append(list(texts))
+        return self._vectors(texts)
+
+    def passage_embed(self, texts):
+        self.passage_calls.append(list(texts))
+        return self._vectors(texts)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_caches()
+    yield
+    reset_caches()
+
+
+@pytest.fixture
+def fake_model():
+    backend = FakeBackend()
+    embedding_module._MODELS[embedding_module.backend_key("local", MODEL)] = backend
+    return backend
+
+
+def _tool(name: str, description: str = "") -> StructuredTool:
+    def fn(**kwargs):
+        return name
+
+    fn.__name__ = name
+    return StructuredTool.from_function(func=fn, name=name, description=description)
+
+
+def _request(query: str, tools, **kwargs) -> ShortlistRequest:
+    return ShortlistRequest(query=query, tools=tools, apps=[], **kwargs)
+
+
+# --- ranking ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ranks_by_cosine_similarity(fake_model):
+    tools = [
+        _tool("weather_lookup", "weather forecast"),
+        _tool("contact_finder", "find a contact by email"),
+        _tool("flight_booker", "book a flight"),
+    ]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    result = await strategy.shortlist(_request("find the contact email", tools))
+
+    assert result[0].name == "contact_finder"
+    assert result[0].score > result[-1].score
+
+
+@pytest.mark.asyncio
+async def test_reasoning_is_populated_for_rendering(fake_model):
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    result = await strategy.shortlist(_request("contact", [_tool("contact_finder", "contact")]))
+    assert "Cosine similarity" in result[0].reasoning
+
+
+@pytest.mark.asyncio
+async def test_never_returns_empty_even_when_nothing_clears_min_score(fake_model):
+    """An empty result is a dead end for the agent and makes the bind cap raise."""
+    tools = [_tool("weather_lookup", "weather"), _tool("flight_booker", "flight")]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.99)
+    result = await strategy.shortlist(_request("contact email", tools))
+
+    assert result, "must fall back to best-guess rather than returning nothing"
+    assert len(result) <= 3
+
+
+@pytest.mark.asyncio
+async def test_min_score_filters_when_some_clear_it(fake_model):
+    tools = [_tool("contact_finder", "contact email"), _tool("weather_lookup", "weather")]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.5)
+    result = await strategy.shortlist(_request("contact email", tools))
+
+    assert [c.name for c in result] == ["contact_finder"]
+
+
+@pytest.mark.asyncio
+async def test_top_k_and_max_results_cap_the_result(fake_model):
+    tools = [_tool(f"contact_{i}", "contact email") for i in range(10)]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+
+    assert len(await strategy.shortlist(_request("contact", tools, top_k=3))) == 3
+    assert len(await strategy.shortlist(_request("contact", tools, max_results=2))) == 2
+    # The tighter of the two wins.
+    capped = await strategy.shortlist(_request("contact", tools, top_k=8, max_results=4))
+    assert len(capped) == 4
+
+
+@pytest.mark.asyncio
+async def test_top_k_zero_returns_nothing(fake_model):
+    strategy = EmbeddingShortlister(MODEL)
+    result = await strategy.shortlist(_request("contact", [_tool("contact_finder")], top_k=0))
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_empty_tools_returns_empty(fake_model):
+    strategy = EmbeddingShortlister(MODEL)
+    assert await strategy.shortlist(_request("contact", [])) == []
+
+
+# --- query blending ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_and_task_context_are_embedded_separately(fake_model):
+    """Not concatenated — a long context must not swamp a short step query."""
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    await strategy.shortlist(
+        _request("list contacts", [_tool("contact_finder", "contact")], task_context="book a flight")
+    )
+    assert fake_model.embed_calls[-1] == ["list contacts", "book a flight"]
+
+
+@pytest.mark.asyncio
+async def test_query_weight_shifts_ranking_toward_the_step_query(fake_model):
+    """The whole point of vector blending: the weighting is explicit, not a
+    side effect of how long each string happens to be."""
+    tools = [_tool("contact_finder", "contact"), _tool("flight_booker", "flight")]
+    request = dict(task_context="book a flight flight flight flight flight")
+
+    query_heavy = EmbeddingShortlister(MODEL, query_weight=1.0, min_score=0.0)
+    context_heavy = EmbeddingShortlister(MODEL, query_weight=0.0, min_score=0.0)
+
+    top_query = (await query_heavy.shortlist(_request("contact", tools, **request)))[0]
+    top_context = (await context_heavy.shortlist(_request("contact", tools, **request)))[0]
+
+    assert top_query.name == "contact_finder"
+    assert top_context.name == "flight_booker"
+
+
+@pytest.mark.asyncio
+async def test_missing_task_context_uses_query_alone(fake_model):
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    await strategy.shortlist(_request("list contacts", [_tool("contact_finder", "contact")]))
+    assert fake_model.embed_calls[-1] == ["list contacts"]
+
+
+@pytest.mark.asyncio
+async def test_blank_query_and_context_is_unavailable(fake_model):
+    strategy = EmbeddingShortlister(MODEL)
+    with pytest.raises(ShortlisterUnavailableError):
+        await strategy.shortlist(_request("   ", [_tool("contact_finder")], task_context="  "))
+
+
+# --- caching ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_vectors_are_cached_across_calls(fake_model):
+    tools = [_tool("contact_finder", "contact"), _tool("weather_lookup", "weather")]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+
+    await strategy.shortlist(_request("contact", tools))
+    documents_embedded_first = sum(len(c) for c in fake_model.embed_calls[:-1])
+    calls_after_first = len(fake_model.embed_calls)
+
+    await strategy.shortlist(_request("weather", tools))
+
+    # Second run embeds only the query, not the two tool documents again.
+    assert documents_embedded_first == 2
+    assert len(fake_model.embed_calls) == calls_after_first + 1
+    assert fake_model.embed_calls[-1] == ["weather"]
+
+
+@pytest.mark.asyncio
+async def test_changed_description_reembeds(fake_model):
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    await strategy.shortlist(_request("contact", [_tool("t", "contact")]))
+    before = len(fake_model.embed_calls)
+    await strategy.shortlist(_request("contact", [_tool("t", "totally different email text")]))
+    # One call for the new document + one for the query.
+    assert len(fake_model.embed_calls) == before + 2
+
+
+# --- cold start -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unloaded_model_raises_unavailable_and_starts_background_load():
+    """A user query must never block on a model download."""
+    strategy = EmbeddingShortlister("not-loaded-model")
+    with patch.object(embedding_module, "ensure_loading") as mock_loading:
+        with pytest.raises(ShortlisterUnavailableError):
+            await strategy.shortlist(_request("contact", [_tool("contact_finder")]))
+    mock_loading.assert_called_once_with("local", "not-loaded-model")
+
+
+def test_is_ready_reflects_residency(fake_model):
+    assert is_ready("local", MODEL) is True
+    assert is_ready("local", "some-other-model") is False
+
+
+def test_failed_load_sets_a_retry_cooldown():
+    """An airgapped deploy must not hammer the network on every call."""
+    with patch.object(embedding_module, "_build_backend", side_effect=OSError("offline")):
+        assert embedding_module.prewarm("local", "missing-model") is False
+    assert embedding_module.backend_key("local", "missing-model") in embedding_module._RETRY_AFTER
+
+    with patch.object(embedding_module, "_build_backend") as builder:
+        embedding_module.ensure_loading("local", "missing-model")
+        builder.assert_not_called()
+
+
+# --- symmetric vs asymmetric ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        ("sentence-transformers/all-MiniLM-L6-v2", False),
+        ("all-MiniLM-L6-v2", False),
+        ("BAAI/bge-small-en-v1.5", True),
+        ("BAAI/bge-reranker-base", False),
+        ("some-unknown-model", False),
+    ],
+)
+def test_asymmetric_detection(model_name, expected):
+    """bge wants a query prefix; MiniLM does not, and applying one degrades it.
+    Unknown models default to symmetric."""
+    assert _is_asymmetric(model_name) is expected
+
+
+def _local_backend_with(model_name: str, fake: "FakeTextEmbedding"):
+    backend = embedding_module._LocalBackend.__new__(embedding_module._LocalBackend)
+    backend._model_name = model_name
+    backend._asymmetric = embedding_module._is_asymmetric(model_name)
+    backend._model = fake
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_bge_backend_uses_query_and_passage_encoders():
+    fake = FakeTextEmbedding()
+    backend = _local_backend_with("BAAI/bge-small-en-v1.5", fake)
+
+    await backend.aembed(["a document"], as_query=False)
+    await backend.aembed(["a query"], as_query=True)
+
+    assert fake.passage_calls == [["a document"]]
+    assert fake.query_calls == [["a query"]]
+    assert not fake.embed_calls
+
+
+@pytest.mark.asyncio
+async def test_minilm_backend_uses_the_symmetric_encoder():
+    """Applying bge's query prefix to MiniLM degrades it, so it must not be used."""
+    fake = FakeTextEmbedding()
+    backend = _local_backend_with(MODEL, fake)
+
+    await backend.aembed(["a document"], as_query=False)
+    await backend.aembed(["a query"], as_query=True)
+
+    assert fake.embed_calls == [["a document"], ["a query"]]
+    assert not fake.query_calls and not fake.passage_calls
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_is_unavailable_not_silently_ignored():
+    """A provider typo must surface, not quietly fall back to local."""
+    with pytest.raises(ShortlisterUnavailableError, match="unknown shortlister.embedding_provider"):
+        embedding_module._build_backend("gpt4all", MODEL)
+
+
+def test_provider_is_part_of_the_backend_identity():
+    """Two providers serving the same model name are different vector spaces."""
+    assert embedding_module.backend_key("local", MODEL) != embedding_module.backend_key("openai", MODEL)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_factory.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_factory.py
@@ -1,0 +1,233 @@
+"""Strategy resolution: built-ins, dotted paths, precedence, caching, fallback."""
+
+from types import SimpleNamespace
+from typing import Any, ClassVar, List
+
+import pytest
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    Shortlister,
+    ShortlistRequest,
+    ShortlistCandidate,
+    ShortlisterPlan,
+    ShortlisterRouter,
+    ShortlisterUnavailableError,
+    clear_instance_cache,
+    resolve_shortlister,
+    run_shortlister,
+    shortlister_to_configurable,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.hybrid import HybridShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+
+pytestmark = pytest.mark.unit
+
+
+class CustomShortlister:
+    """Stand-in for a user-supplied strategy loaded by dotted path."""
+
+    name: ClassVar[str] = "custom"
+
+    def __init__(self, plan: Any = None):
+        self.plan = plan
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        return [ShortlistCandidate(name="custom_pick", score=1.0)]
+
+
+class AlwaysUnavailable:
+    name: ClassVar[str] = "unavailable"
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        raise ShortlisterUnavailableError("model missing")
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    clear_instance_cache()
+    yield
+    clear_instance_cache()
+
+
+def _settings(**kwargs):
+    return SimpleNamespace(shortlister=SimpleNamespace(**kwargs))
+
+
+# --- built-ins --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [("llm", LLMShortlister), ("embedding", EmbeddingShortlister), ("hybrid", HybridShortlister)],
+)
+def test_builtin_strategies_resolve(name, expected):
+    assert isinstance(resolve_shortlister(ShortlisterPlan(strategy=name)), expected)
+
+
+def test_unknown_bare_name_is_rewritten_by_the_router():
+    """A typo must not take the agent down — it degrades with a note."""
+    plan = ShortlisterRouter.resolve(_settings(strategy="cosinee"))
+    assert plan.strategy == "llm"
+    assert any("cosinee" in n for n in plan.notes)
+
+
+def test_unknown_name_on_a_hand_built_plan_raises():
+    """Bypassing the router is a programming error, so it is loud."""
+    with pytest.raises(ValueError, match="Unknown shortlister strategy"):
+        resolve_shortlister(ShortlisterPlan(strategy="nonsense"))
+
+
+# --- dotted paths -----------------------------------------------------------
+
+
+def test_dotted_path_loads_a_custom_strategy():
+    path = f"{__name__}.CustomShortlister"
+    strategy = resolve_shortlister(ShortlisterPlan(strategy=path))
+    assert isinstance(strategy, CustomShortlister)
+
+
+def test_dotted_path_receives_the_plan():
+    plan = ShortlisterPlan(strategy=f"{__name__}.CustomShortlister", top_k=7)
+    assert resolve_shortlister(plan).plan.top_k == 7
+
+
+def test_broken_dotted_path_falls_back_rather_than_crashing():
+    plan = ShortlisterPlan(strategy="does.not.Exist", fallback_strategy="llm")
+    assert isinstance(resolve_shortlister(plan), LLMShortlister)
+
+
+# --- precedence -------------------------------------------------------------
+
+
+def test_configurable_beats_settings():
+    plan = ShortlisterRouter.resolve(
+        _settings(strategy="llm", top_k=99),
+        configurable={"shortlister_strategy": "embedding", "shortlister_top_k": 12},
+    )
+    assert plan.strategy == "embedding"
+    assert plan.top_k == 12
+
+
+def test_per_seam_section_beats_global():
+    settings = SimpleNamespace(
+        shortlister=SimpleNamespace(
+            strategy="llm",
+            bind_cap=SimpleNamespace(strategy="embedding"),
+            discovery=SimpleNamespace(strategy="hybrid"),
+        )
+    )
+    assert ShortlisterRouter.resolve(settings, seam="bind_cap").strategy == "embedding"
+    assert ShortlisterRouter.resolve(settings, seam="discovery").strategy == "hybrid"
+
+
+def test_override_beats_configurable():
+    plan = ShortlisterRouter.resolve(
+        _settings(strategy="llm"),
+        configurable={"shortlister_strategy": "embedding"},
+        override=Shortlister(strategy="hybrid"),
+    )
+    assert plan.strategy == "hybrid"
+
+
+def test_injected_instance_wins_over_named_strategy():
+    custom = CustomShortlister()
+    plan = ShortlisterRouter.resolve(_settings(strategy="embedding"), override=Shortlister(instance=custom))
+    assert resolve_shortlister(plan) is custom
+
+
+def test_env_style_string_values_are_coerced():
+    """Env vars arrive as strings; ints/floats/bools must still land correctly."""
+    plan = ShortlisterRouter.resolve(_settings(top_k="64", min_score="0.42", threshold="256"))
+    assert plan.top_k == 64
+    assert plan.min_score == pytest.approx(0.42)
+    assert plan.threshold == 256
+
+
+def test_garbage_value_falls_through_to_the_default():
+    plan = ShortlisterRouter.resolve(_settings(top_k="not-a-number"))
+    assert plan.top_k == 128
+
+
+# --- caching ----------------------------------------------------------------
+
+
+def test_instances_are_cached_so_the_model_loads_once():
+    a = resolve_shortlister(ShortlisterPlan(strategy="embedding"))
+    b = resolve_shortlister(ShortlisterPlan(strategy="embedding"))
+    assert a is b
+
+
+def test_different_embedding_models_get_different_instances():
+    a = resolve_shortlister(ShortlisterPlan(strategy="embedding", embedding_model="model-a"))
+    b = resolve_shortlister(ShortlisterPlan(strategy="embedding", embedding_model="model-b"))
+    assert a is not b
+
+
+def test_per_call_knobs_do_not_fragment_the_cache():
+    a = resolve_shortlister(ShortlisterPlan(strategy="embedding", top_k=10))
+    b = resolve_shortlister(ShortlisterPlan(strategy="embedding", top_k=99))
+    assert a is b
+
+
+# --- fallback ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unavailable_strategy_degrades_to_fallback():
+    plan = ShortlisterPlan(strategy="embedding", fallback_strategy="llm", instance=AlwaysUnavailable())
+    called = {}
+
+    async def _fake(self, request):
+        called["yes"] = True
+        return [ShortlistCandidate(name="from_llm")]
+
+    from unittest.mock import patch
+
+    with patch.object(LLMShortlister, "shortlist", _fake):
+        result = await run_shortlister(plan, ShortlistRequest(query="q", tools=[], apps=[]))
+
+    assert called
+    assert result[0].name == "from_llm"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_with_no_distinct_fallback_reraises():
+    plan = ShortlisterPlan(strategy="llm", fallback_strategy="llm", instance=AlwaysUnavailable())
+    with pytest.raises(ShortlisterUnavailableError):
+        await run_shortlister(plan, ShortlistRequest(query="q", tools=[], apps=[]))
+
+
+@pytest.mark.asyncio
+async def test_ordinary_errors_are_not_swallowed():
+    """Only unavailability triggers the fallback; real failures keep each call
+    site's own error contract."""
+
+    class Boom:
+        name = "boom"
+
+        async def shortlist(self, request):
+            raise RuntimeError("ranking blew up")
+
+    plan = ShortlisterPlan(strategy="embedding", instance=Boom())
+    with pytest.raises(RuntimeError, match="ranking blew up"):
+        await run_shortlister(plan, ShortlistRequest(query="q", tools=[], apps=[]))
+
+
+# --- SDK serialization ------------------------------------------------------
+
+
+def test_shortlister_to_configurable_is_empty_when_unset():
+    assert shortlister_to_configurable(None) == {}
+    assert shortlister_to_configurable(Shortlister()) == {}
+
+
+def test_shortlister_to_configurable_emits_only_set_fields():
+    cfg = shortlister_to_configurable(Shortlister(strategy="hybrid", top_k=32))
+    assert cfg == {"shortlister_strategy": "hybrid", "shortlister_top_k": 32}
+
+
+def test_shortlister_to_configurable_passes_an_instance_through():
+    custom = CustomShortlister()
+    cfg = shortlister_to_configurable(Shortlister(instance=custom))
+    assert cfg["shortlister_instance"] is custom

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_hybrid.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_hybrid.py
@@ -1,0 +1,105 @@
+"""HybridShortlister: cosine prefilters, the LLM decides."""
+
+from typing import Any, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.hybrid import HybridShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(name: str) -> StructuredTool:
+    def fn(**kwargs):
+        return name
+
+    fn.__name__ = name
+    return StructuredTool.from_function(func=fn, name=name, description=name)
+
+
+def _tools(n: int) -> List[StructuredTool]:
+    return [_tool(f"tool_{i}") for i in range(n)]
+
+
+def _request(tools, **kwargs) -> ShortlistRequest:
+    return ShortlistRequest(query="find contacts", tools=tools, apps=[], **kwargs)
+
+
+class _RecordingLLM(LLMShortlister):
+    def __init__(self):
+        super().__init__()
+        self.seen: List[Any] = []
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        self.seen.append([t.name for t in request.tools])
+        return [ShortlistCandidate(name=request.tools[0].name)]
+
+
+def _hybrid(embedding=None, llm=None):
+    return HybridShortlister(embedding=embedding or EmbeddingShortlister("model"), llm=llm or _RecordingLLM())
+
+
+@pytest.mark.asyncio
+async def test_cosine_narrows_the_pool_before_the_llm_sees_it():
+    llm = _RecordingLLM()
+    prefiltered = [ShortlistCandidate(name=f"tool_{i}") for i in range(5)]
+
+    with patch.object(EmbeddingShortlister, "shortlist", AsyncMock(return_value=prefiltered)):
+        await _hybrid(llm=llm).shortlist(_request(_tools(100), top_k=5))
+
+    assert llm.seen == [[f"tool_{i}" for i in range(5)]]
+
+
+@pytest.mark.asyncio
+async def test_prefilter_is_skipped_when_the_pool_already_fits():
+    """Below the cut width the LLM would see the same set either way."""
+    llm = _RecordingLLM()
+    embed = AsyncMock()
+
+    with patch.object(EmbeddingShortlister, "shortlist", embed):
+        await _hybrid(llm=llm).shortlist(_request(_tools(4), top_k=10))
+
+    embed.assert_not_awaited()
+    assert llm.seen == [[f"tool_{i}" for i in range(4)]]
+
+
+@pytest.mark.asyncio
+async def test_llm_ordering_wins():
+    llm_result = [ShortlistCandidate(name="tool_9"), ShortlistCandidate(name="tool_1")]
+    prefiltered = [ShortlistCandidate(name=f"tool_{i}") for i in range(10)]
+
+    with (
+        patch.object(EmbeddingShortlister, "shortlist", AsyncMock(return_value=prefiltered)),
+        patch.object(LLMShortlister, "shortlist", AsyncMock(return_value=llm_result)),
+    ):
+        # A plain LLMShortlister, so the patch above actually applies.
+        result = await _hybrid(llm=LLMShortlister()).shortlist(_request(_tools(50), top_k=10))
+
+    assert [c.name for c in result] == ["tool_9", "tool_1"]
+
+
+@pytest.mark.asyncio
+async def test_degrades_to_plain_llm_when_embeddings_are_unavailable():
+    """Cold start must not break discovery — this path is exactly today's behavior."""
+    llm = _RecordingLLM()
+    unavailable = AsyncMock(side_effect=ShortlisterUnavailableError("still downloading"))
+
+    with patch.object(EmbeddingShortlister, "shortlist", unavailable):
+        result = await _hybrid(llm=llm).shortlist(_request(_tools(50), top_k=10))
+
+    assert llm.seen == [[f"tool_{i}" for i in range(50)]], "LLM must see the full pool"
+    assert result
+
+
+@pytest.mark.asyncio
+async def test_empty_tools_short_circuits():
+    assert await _hybrid().shortlist(_request([])) == []

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_real_model.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_real_model.py
@@ -1,0 +1,149 @@
+"""Real-embedding accuracy checks — no fake embedder.
+
+Marked ``stability``: excluded from the default run because a cold cache
+downloads ~90MB. Run with ``uv run pytest -m stability -k shortlister_real``.
+
+The tool names here are the real shapes CUGA produces, not idealized ones:
+CRM's ``/contacts/`` and ``/contacts/{contact_id}`` collide on path segment 1,
+so ``determine_operation_name_strategy`` falls back to FastAPI operationIds and
+the parser's description degrades to the auto-summary. If cosine works on
+these, it works on the real catalogue.
+"""
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import ShortlistRequest
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import (
+    EmbeddingShortlister,
+    prewarm,
+    reset_caches,
+)
+
+pytestmark = [pytest.mark.stability, pytest.mark.slow]
+
+MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class _Args(BaseModel):
+    email: str = Field(default="", description="filter by email address")
+    limit: int = Field(default=10, description="max rows")
+
+
+def _tool(name: str, description: str) -> StructuredTool:
+    def fn(**kwargs):
+        return None
+
+    fn.__name__ = "fn"
+    return StructuredTool.from_function(func=fn, name=name, description=description, args_schema=_Args)
+
+
+CRM_TOOLS = [
+    _tool("crm_get_contacts_contacts_get", "Get Contacts"),
+    _tool("crm_get_contact_contacts_contact_id_get", "Get Contact"),
+    _tool("crm_create_contact_contacts_post", "Create Contact"),
+    _tool("crm_update_contact_contacts_contact_id_put", "Update Contact"),
+    _tool("crm_delete_contact_contacts_contact_id_delete", "Delete Contact"),
+    _tool("crm_get_accounts_accounts_get", "Get Accounts"),
+    _tool("crm_get_account_accounts_account_id_get", "Get Account"),
+    _tool("crm_create_account_accounts_post", "Create Account"),
+    _tool("crm_get_opportunities_opportunities_get", "Get Opportunities"),
+    _tool("crm_create_opportunity_opportunities_post", "Create Opportunity"),
+    _tool("crm_get_leads_leads_get", "Get Leads"),
+    _tool("crm_delete_lead_leads_lead_id_delete", "Delete Lead"),
+]
+NOISE_TOOLS = [_tool(f"other_app_operation_{i}_thing_get", f"Operation {i}") for i in range(200)]
+CATALOGUE = CRM_TOOLS + NOISE_TOOLS
+
+CASES = [
+    ("list all my contacts", "crm_get_contacts_contacts_get"),
+    ("add a new account", "crm_create_account_accounts_post"),
+    ("remove a lead from the system", "crm_delete_lead_leads_lead_id_delete"),
+    ("what sales opportunities are open", "crm_get_opportunities_opportunities_get"),
+]
+
+
+@pytest.fixture(scope="module")
+def strategy():
+    reset_caches()
+    if not prewarm("local", MODEL):
+        pytest.skip(f"embedding model {MODEL} unavailable (offline?)")
+    return EmbeddingShortlister(MODEL, provider="local", query_weight=0.7, min_score=0.15)
+
+
+async def _rank(strategy, query, top_k=5, task_context=None):
+    result = await strategy.shortlist(
+        ShortlistRequest(query=query, tools=CATALOGUE, apps=[], top_k=top_k, task_context=task_context)
+    )
+    return [c.name for c in result]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query,expected", CASES, ids=[c[0][:20] for c in CASES])
+async def test_expected_tool_survives_the_cosine_cut(strategy, query, expected):
+    """Recall is the property that matters — the hybrid prefilter and the bind
+    cap both only need "don't drop the needed tool"."""
+    assert expected in await _rank(strategy, query, top_k=5)
+
+
+@pytest.mark.asyncio
+async def test_recall_at_top_k_over_a_realistic_catalogue(strategy):
+    """Recall@k across k, so the default top_k is a measured choice."""
+    for k in (8, 32, 128):
+        hits = 0
+        for query, expected in CASES:
+            if expected in await _rank(strategy, query, top_k=k):
+                hits += 1
+        assert hits == len(CASES), f"recall@{k} was {hits}/{len(CASES)}"
+
+
+@pytest.mark.asyncio
+async def test_crud_siblings_are_barely_separated(strategy):
+    """Documents the limitation rather than asserting a score.
+
+    ``get_contacts`` (list) and ``get_contact`` (by id) are one character apart
+    and embed almost identically. If this margin is ever comfortably wide, the
+    assumption behind preferring `hybrid` for discovery has changed and the
+    defaults should be re-measured — so this test failing is a prompt to think,
+    not simply to bump a number.
+    """
+    result = await strategy.shortlist(
+        ShortlistRequest(query="list all my contacts", tools=CATALOGUE, apps=[], top_k=2)
+    )
+    scores = {c.name: c.score for c in result}
+    margin = abs(scores["crm_get_contacts_contacts_get"] - scores["crm_get_contact_contacts_contact_id_get"])
+    assert margin < 0.15, (
+        f"list-vs-get-by-id margin is {margin:.3f}; cosine now separates CRUD siblings "
+        f"better than assumed — re-measure before trusting it for final selection"
+    )
+
+
+@pytest.mark.asyncio
+async def test_steps_of_one_task_retrieve_different_tools(strategy):
+    """The vector-blend fix: a long task context must not swamp the step query.
+
+    With string concatenation both steps would embed nearly identically and
+    return the same tools, defeating per-step discovery entirely.
+    """
+    context = "I need a full CRM cleanup for the quarterly review across all our accounts"
+
+    contacts = await _rank(strategy, "list all contacts", top_k=3, task_context=context)
+    deletion = await _rank(strategy, "delete the stale lead", top_k=3, task_context=context)
+
+    assert contacts[0] == "crm_get_contacts_contacts_get"
+    assert deletion[0] == "crm_delete_lead_leads_lead_id_delete"
+    assert contacts[0] != deletion[0]
+
+
+@pytest.mark.asyncio
+async def test_repeated_queries_reuse_cached_vectors(strategy):
+    """Second call must not re-embed the catalogue."""
+    import time
+
+    await _rank(strategy, "list all my contacts")
+    start = time.time()
+    await _rank(strategy, "add a new account")
+    warm = time.time() - start
+
+    assert warm < 1.0, f"warm query took {warm:.2f}s — document vectors are not being cached"

--- a/src/cuga/config.py
+++ b/src/cuga/config.py
@@ -216,6 +216,20 @@ validators = [
     Validator("advanced_features.cuga_lite_bind_tools_tool_names", default=[]),
     Validator("advanced_features.cuga_lite_bind_tools_max_count", default=128),
     Validator("advanced_features.cuga_lite_bind_tools_pad_to_cap", default=False),
+    # Read at prepare_node without a getattr guard; without this a settings.toml
+    # missing the key raises AttributeError mid-run instead of using the default.
+    Validator("advanced_features.shortlisting_tool_threshold", default=35),
+    # Pluggable shortlister — see docs/design/pluggable-shortlister.md.
+    # Defaults mirror shortlister/plan.py so a missing [shortlister] section is safe.
+    Validator("shortlister.strategy", default="llm"),
+    Validator("shortlister.fallback_strategy", default="llm"),
+    Validator("shortlister.threshold", default=128, is_type_of=int),
+    Validator("shortlister.top_k", default=128, is_type_of=int),
+    Validator("shortlister.max_results", default=10, is_type_of=int),
+    Validator("shortlister.min_score", default=0.15),
+    Validator("shortlister.query_weight", default=0.7),
+    Validator("shortlister.embedding_provider", default="local"),
+    Validator("shortlister.embedding_model", default="sentence-transformers/all-MiniLM-L6-v2"),
     # Evolve integration
     Validator("evolve.enabled", default=False),
     Validator("evolve.url", default="http://127.0.0.1:8201/sse"),

--- a/src/cuga/sdk.py
+++ b/src/cuga/sdk.py
@@ -81,6 +81,7 @@ from cuga.config import settings
 
 if TYPE_CHECKING:
     from cuga.backend.cuga_graph.nodes.cuga_lite.providers.base import ToolProviderInterface
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import Shortlister
     from cuga.backend.cuga_graph.policy.configurable import PolicyConfigurable
 
 from langchain_core.messages import BaseMessage
@@ -1743,6 +1744,7 @@ class CugaAgent:
         enable_citations: Optional[bool] = None,
         enable_skills: Optional[bool] = None,
         skills_folder: Optional[str] = None,
+        shortlister: Optional["Shortlister"] = None,
     ):
         """
         Initialize the CUGA Agent.
@@ -1762,6 +1764,9 @@ class CugaAgent:
             enable_citations: None = follow knowledge settings; True/False override knowledge.citations_enabled for this agent instance
             enable_skills: If True, enable agent skills (SKILL.md / load_skill). None = auto from settings.
             skills_folder: Workspace root or `.cuga` folder containing `skills/`. Defaults to cwd / CUGA_FOLDER env var.
+            shortlister: How to shrink a large tool set before the model sees it, e.g.
+                `Shortlister(strategy="hybrid")`. None = use `[shortlister]` settings
+                (default `"llm"`, i.e. unchanged behavior). Overridable per invoke()/stream().
 
         Example with tool approval policy:
             ```python
@@ -1812,6 +1817,10 @@ class CugaAgent:
         # Skills configuration
         self._enable_skills = enable_skills  # None = auto from settings
         self._skills_folder = skills_folder  # None = use CUGA_FOLDER / cwd
+
+        # Tool shortlisting. None => [shortlister] settings, whose default ("llm")
+        # is the pre-feature behavior.
+        self._shortlister = shortlister
 
         # Setup tool provider. ToolGuard is installed immediately as a transparent
         # provider-level decorator so create-agent-first, add-guard-later flows work.
@@ -1920,6 +1929,29 @@ class CugaAgent:
         run_config: dict = dict(config) if config else {}
         run_config["configurable"] = dict(run_config.get("configurable") or {})
         return run_config
+
+    def _apply_shortlister(self, run_config: dict, shortlister: Optional[Any] = None) -> None:
+        """Merge shortlister config into ``run_config['configurable']``.
+
+        A per-invoke ``shortlister`` overrides the constructor default. Raw
+        ``shortlister_*`` keys already set by the caller win over both — we
+        ``setdefault`` rather than overwrite. No-op when nothing is configured,
+        so the default (LLM shortlisting) path is untouched.
+        """
+        try:
+            from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+                shortlister_to_configurable,
+            )
+
+            effective = shortlister if shortlister is not None else self._shortlister
+            cfg = shortlister_to_configurable(effective)
+            if not cfg:
+                return
+            configurable = run_config["configurable"]
+            for key, value in cfg.items():
+                configurable.setdefault(key, value)
+        except Exception as e:
+            logger.warning(f"Applying Shortlister config failed; using default shortlisting: {e}")
 
     def _apply_callbacks(self, run_config: dict) -> None:
         """
@@ -2356,6 +2388,7 @@ class CugaAgent:
         user_context: Optional[str] = None,
         track_tool_calls: bool = False,
         variables: Optional[Dict[str, Any]] = None,
+        shortlister: Optional["Shortlister"] = None,
     ) -> InvokeResult:
         """
         Invoke the agent with a message and get the response.
@@ -2441,6 +2474,7 @@ class CugaAgent:
 
         # Setup config (shallow-copied so we don't mutate the caller's dict)
         run_config = self._prepare_run_config(config)
+        self._apply_shortlister(run_config, shortlister)
 
         # Pass track_tool_calls flag via configurable
         run_config["configurable"]["track_tool_calls"] = track_tool_calls
@@ -2798,6 +2832,7 @@ class CugaAgent:
         thread_id: Optional[str] = None,
         config: Optional[Dict[str, Any]] = None,
         action_response: Optional[Any] = None,  # ActionResponse for resuming after HITL
+        shortlister: Optional["Shortlister"] = None,
     ):
         """
         Stream the agent's execution step by step.
@@ -2842,6 +2877,7 @@ class CugaAgent:
 
         # Setup config (shallow-copied so we don't mutate the caller's dict)
         run_config = self._prepare_run_config(config)
+        self._apply_shortlister(run_config, shortlister)
 
         # Pass skills configuration via configurable (overrides settings when set)
         if self._enable_skills is not None:

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -76,6 +76,33 @@ enable_shell_tool = false
 #   "local"       — no sandbox (runs directly on host; always pairs with run_command tool approval)
 sandbox_mode = "native"
 
+[shortlister]
+# How CugaLite shrinks a large tool set before the model sees it.
+# Applies to both find_tools (runtime discovery) and the bind_tools provider cap.
+# See docs/design/pluggable-shortlister.md
+#
+# strategy: llm | embedding | hybrid | "my.pkg.MyShortlister" (dotted class path)
+#   llm       — ask the model (default; identical to pre-feature behavior)
+#   embedding — local cosine similarity, no LLM call
+#   hybrid    — cosine prefilter to top_k, then the LLM makes the final pick
+strategy = "llm"
+fallback_strategy = "llm"  # used when the chosen strategy can't run (e.g. model still downloading)
+# Engage the cosine stage only above this many candidates. At or below it, shortlisting
+# behaves exactly as it always has. NOTE: distinct from advanced_features.shortlisting_tool_threshold
+# (=35), which decides when tools are hidden behind find_tools in the prompt.
+threshold = 128
+top_k = 128        # how many candidates the cosine stage keeps (also the hybrid prefilter width)
+max_results = 10   # find_tools only: max tools rendered to the agent (128 would overflow output limits)
+min_score = 0.15   # cosine floor — deliberately LOW; this is a recall filter, not a precision knob
+query_weight = 0.7 # blend of step query vs initial user message when embedding the query
+# Embeddings are self-contained by default: always local, never a network call, never billed.
+# Deliberately does NOT inherit [storage.embedding], which may be set to "openai".
+embedding_provider = "local"
+embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+# Per-seam overrides are supported and inherit the values above; add a
+# [shortlister.discovery] (find_tools) or [shortlister.bind_cap] (provider cap)
+# section only when the two seams need different settings.
+
 [agent_spawn]
 # When false, sub-agent spawning via spawn_agent / get_agent_result is fully disabled.
 # Zero overhead in prompt, tools, and timing when disabled (NFR-1).

--- a/tests/unit/test_find_tools_exception.py
+++ b/tests/unit/test_find_tools_exception.py
@@ -89,8 +89,14 @@ async def test_find_tools_func_success_passes_through(mock_tools, mock_apps):
 
 
 @pytest.mark.asyncio
-async def test_find_tools_composes_query_with_initial_user_message(mock_tools, mock_apps):
-    """When initial_user_message is set, shortlister query includes task context."""
+async def test_find_tools_forwards_query_and_task_context_separately(mock_tools, mock_apps):
+    """The step query and the initial user message reach the shortlister as two values.
+
+    They used to be pre-joined into one string here. They now travel separately so a
+    non-LLM strategy can weight them independently (a long task context would otherwise
+    dominate a short step query). ``LLMShortlister`` re-joins them — see the companion
+    test below, which pins that the composed text is unchanged.
+    """
     from cuga.backend.cuga_graph.nodes.cuga_lite.helpers.find_tools import create_find_tools_tool
 
     app_to_tools_map = {"test_app": mock_tools}
@@ -110,6 +116,27 @@ async def test_find_tools_composes_query_with_initial_user_message(mock_tools, m
 
     mock_find.assert_awaited_once()
     call_kw = mock_find.await_args.kwargs
-    assert call_kw["query"] == (
-        "Query: list calendar tools\nTask context (initial user message): Book a flight to NYC"
+    assert call_kw["query"] == "list calendar tools"
+    assert call_kw["task_context"] == "Book a flight to NYC"
+
+
+def test_compose_query_matches_legacy_find_tools_format():
+    """The text the LLM sees is byte-identical to the pre-split composition.
+
+    Guards the refactor: ``LLMShortlister`` must reproduce exactly what
+    ``_compose_find_tools_shortlister_query`` produced, or every shortlister prompt
+    silently changes.
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.helpers.find_tools import (
+        _compose_find_tools_shortlister_query,
     )
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import compose_query
+
+    cases = [
+        ("list calendar tools", "Book a flight to NYC"),
+        ("  padded  ", "  context  "),
+        ("only a query", None),
+        ("only a query", ""),
+    ]
+    for query, context in cases:
+        assert compose_query(query, context) == _compose_find_tools_shortlister_query(query, context)

--- a/tests/unit/test_shortlister_config_surfaces.py
+++ b/tests/unit/test_shortlister_config_surfaces.py
@@ -1,0 +1,198 @@
+"""One assertion per configuration surface.
+
+A setting wired into only some surfaces is the usual reason "my config does
+nothing" bugs happen. Each test here covers one control plane end to end.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# --- 1. settings.toml -------------------------------------------------------
+
+
+def test_settings_toml_ships_the_shortlister_section():
+    from cuga.config import settings
+
+    assert settings.shortlister.strategy == "llm"
+    assert settings.shortlister.threshold == 128
+    assert settings.shortlister.top_k == 128
+    assert settings.shortlister.max_results == 10
+    assert settings.shortlister.embedding_model == "sentence-transformers/all-MiniLM-L6-v2"
+    assert settings.shortlister.embedding_provider == "local"
+
+
+# --- 2 & 3. validators supply defaults without the section ------------------
+
+
+def test_validators_cover_every_plan_field():
+    """A settings.toml missing [shortlister] must not AttributeError at runtime."""
+    from cuga.config import validators
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import ALL_FIELDS
+
+    declared = {
+        v.names[0].split(".", 1)[1] for v in validators if v.names and v.names[0].startswith("shortlister.")
+    }
+    assert set(ALL_FIELDS) <= declared, f"missing validators for {set(ALL_FIELDS) - declared}"
+
+
+def test_missing_shortlisting_tool_threshold_validator_regression():
+    """prepare_node reads this without a getattr guard (see design doc §7.1)."""
+    from cuga.config import settings
+
+    assert settings.advanced_features.shortlisting_tool_threshold == 35
+
+
+# --- 4. configurable (per-invoke) ------------------------------------------
+
+
+def test_configurable_overrides_settings():
+    from cuga.config import settings
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import ShortlisterRouter
+
+    plan = ShortlisterRouter.resolve(
+        settings,
+        configurable={"shortlister_strategy": "hybrid", "shortlister_max_results": 3},
+    )
+    assert plan.strategy == "hybrid"
+    assert plan.max_results == 3
+
+
+@pytest.mark.asyncio
+async def test_configurable_reaches_find_tools_through_run_config():
+    """The full path: RunnableConfig -> prompt_utils -> router -> strategy."""
+    from langchain_core.tools import StructuredTool
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    def fn(**kwargs):
+        return "x"
+
+    fn.__name__ = "sample_tool"
+    tools = [StructuredTool.from_function(func=fn, name="sample_tool", description="d")]
+
+    captured = {}
+
+    async def _capture(self, request):
+        captured["max_results"] = request.max_results
+        captured["top_k"] = request.top_k
+        return []
+
+    with patch(
+        "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding.EmbeddingShortlister.shortlist",
+        _capture,
+    ):
+        await PromptUtils.find_tools(
+            query="q",
+            all_tools=tools,
+            all_apps=[],
+            run_config={
+                "configurable": {
+                    "shortlister_strategy": "embedding",
+                    "shortlister_threshold": 0,
+                    "shortlister_max_results": 5,
+                    "shortlister_top_k": 7,
+                }
+            },
+        )
+
+    assert captured["max_results"] == 5
+    assert captured["top_k"] == 7
+
+
+def test_malformed_run_config_is_tolerated():
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import _configurable_of
+
+    assert _configurable_of(None) == {}
+    assert _configurable_of({}) == {}
+    assert _configurable_of({"configurable": None}) == {}
+    assert _configurable_of("nonsense") == {}
+    assert _configurable_of({"configurable": {"a": 1}}) == {"a": 1}
+
+
+# --- 5. SDK -----------------------------------------------------------------
+
+
+def test_cuga_agent_accepts_a_shortlister_argument():
+    import inspect
+    from cuga.sdk import CugaAgent
+
+    for method in (CugaAgent.__init__, CugaAgent.invoke, CugaAgent.stream):
+        assert "shortlister" in inspect.signature(method).parameters, method.__name__
+
+
+def test_apply_shortlister_writes_configurable_keys():
+    from cuga.sdk import CugaAgent
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import Shortlister
+
+    agent = CugaAgent.__new__(CugaAgent)
+    agent._shortlister = Shortlister(strategy="hybrid", top_k=32)
+    run_config = {"configurable": {}}
+    CugaAgent._apply_shortlister(agent, run_config)
+
+    assert run_config["configurable"]["shortlister_strategy"] == "hybrid"
+    assert run_config["configurable"]["shortlister_top_k"] == 32
+
+
+def test_per_invoke_shortlister_overrides_the_constructor_default():
+    from cuga.sdk import CugaAgent
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import Shortlister
+
+    agent = CugaAgent.__new__(CugaAgent)
+    agent._shortlister = Shortlister(strategy="hybrid")
+    run_config = {"configurable": {}}
+    CugaAgent._apply_shortlister(agent, run_config, Shortlister(strategy="embedding"))
+
+    assert run_config["configurable"]["shortlister_strategy"] == "embedding"
+
+
+def test_explicit_raw_keys_are_never_clobbered():
+    from cuga.sdk import CugaAgent
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import Shortlister
+
+    agent = CugaAgent.__new__(CugaAgent)
+    agent._shortlister = Shortlister(strategy="hybrid")
+    run_config = {"configurable": {"shortlister_strategy": "llm"}}
+    CugaAgent._apply_shortlister(agent, run_config)
+
+    assert run_config["configurable"]["shortlister_strategy"] == "llm"
+
+
+def test_apply_shortlister_is_a_noop_when_unconfigured():
+    """The default path must stay untouched."""
+    from cuga.sdk import CugaAgent
+
+    agent = CugaAgent.__new__(CugaAgent)
+    agent._shortlister = None
+    run_config = {"configurable": {}}
+    CugaAgent._apply_shortlister(agent, run_config)
+
+    assert run_config == {"configurable": {}}
+
+
+def test_apply_shortlister_never_raises_on_bad_input():
+    from cuga.sdk import CugaAgent
+
+    agent = CugaAgent.__new__(CugaAgent)
+    agent._shortlister = object()  # not a Shortlister
+    run_config = {"configurable": {}}
+    CugaAgent._apply_shortlister(agent, run_config)  # must not raise
+
+
+# --- 6. public export -------------------------------------------------------
+
+
+def test_shortlister_is_importable_from_the_package_root():
+    from cuga import Shortlister, ShortlisterStrategy
+
+    assert Shortlister(strategy="hybrid").strategy == "hybrid"
+    assert ShortlisterStrategy is not None
+
+
+def test_shortlister_is_in_dunder_all():
+    import cuga
+
+    assert "Shortlister" in cuga.__all__
+    assert "ShortlisterStrategy" in cuga.__all__


### PR DESCRIPTION
## Feature

Closes #624

> **Reviewing this?** Jump to the **Reviewer guide** below — 28 files, but only 3 need real scrutiny, and there is a mechanical proof that the refactor half is a no-op.

### Summary

Tool shortlisting is hardcoded to the LLM at two call sites — `find_tools` (runtime discovery) and the `bind_tools` provider cap — with no way to swap the ranker. This routes both through a `ShortlisterStrategy` protocol selectable by config name, dotted class path, or the SDK.

**Default behavior is unchanged.** `strategy = "llm"` is a faithful port of the existing chain, and the cosine stage is additionally gated behind `threshold = 128`, so catalogues at or below that size are untouched whatever the strategy.

| Strategy | Ranking | Cost |
|---|---|---|
| `llm` (default) | asks the model | one LLM call per shortlist |
| `embedding` | local cosine similarity | no LLM call, ~67ms warm |
| `hybrid` | cosine cuts to `top_k`, LLM picks | one LLM call, much smaller prompt |

**Why:** #150 (AppWorld trace analysis) rated shortlister mis-selection a **high-severity top cause of first divergence** — generic product search over wishlist retrieval, order-creation over order-lookup — and was closed with "review the prompt", so accuracy has only ever been attacked prompt-side. `hybrid` attacks it from the retrieval side. Separately, the bind-cap shortlister runs on *the same model being bound*, which is why `BindToolsUnsupportedError` exists; a non-LLM ranker removes that coupling.

No new dependencies (`fastembed` is already core). Embeddings default to local `all-MiniLM-L6-v2` — no network call, nothing billed.

### Reviewer guide

**Only 3 files need real scrutiny.**

| Priority | File | What to check | Lines |
|---|---|---|---|
| 🔴 1 | `cuga_lite/prompt_utils.py` | The only edit to existing logic. Both public functions keep their signatures and delegate; **net −100 lines** because rendering moved out | +84 / −182 |
| 🔴 2 | `shortlister/llm.py` | Faithful port of the chain that lived in `prompt_utils`? (proof below) | new, 100 |
| 🟠 3 | `shortlister/render.py` | Moved verbatim from `find_tools`; skim for drift — this output is what the agent reads from stdout | new, 128 |
| 🟡 4 | `shortlister/{plan,factory,base,doc,embedding,hybrid,config}.py` | New, self-contained. No existing behavior touched | new |
| ⚪ 5 | `config.py`, `settings.toml`, `sdk.py`, `__init__.py` | Config surface + a **bug fix**: `shortlisting_tool_threshold` had no validator and `prepare_node` reads it without a `getattr` guard | small |
| ⚪ 6 | tests, README, `docs/design/` | ~2.6k of the 4k lines | — |

**Deliberately untouched** — worth confirming from the file list: `bind_tools/cap.py`, `helpers/bind_tools.py`, `adapter/graph_adapter.py`, `adapter/prepare_node.py`, `prompts/shortlister/system.jinja2`.

### Proof the refactor is a no-op

Stubbing `BaseAgent.get_chain` (no credentials needed), I captured on **`main`** and on **this branch**, at both call sites: rendered system prompt, structured schema, prompt message structure, exact `input`/`instructions` strings, full serialized tool payload, final rendered markdown, and returned names.

**Byte-identical** — same sha256 after normalizing Python object addresses in a `repr` (per-process noise, not prompt content).

```
system prompt sha   : ba2b45656d43346e6d235236…   (unchanged)
structured schema   : ShortListerOutputLite       (unchanged)
prompt messages     : System, Human, AI, Human    (unchanged)
find_tools instrs   : ''                          (unchanged)
bind-cap instrs     : 'Return the 2 most relevant tools (or fewer if not enough are relevant), …'
markdown bytes      : 2117                        (identical output)
hallucinated name dropped : True                  (same silent-drop behavior as main)
```

That last line matters: `main` silently drops names matching no tool, and so does this. **No retry logic was added** — that is #549's unmerged work and deliberately stays out.

### Testing

- [x] Tested locally; tests pass

```
303 passed   # shortlister + all pre-existing shortlister/bind-tools suites
  8 passed   # stability, against the real embedding model
```

**Full suite, `main` vs this branch, back to back:** `main` **118 failed / 2256 passed**; this branch **97 failed / 2374 passed**. Set difference (branch − main) is **empty** — no new failures. Pre-existing ones are cross-test DB pollution in `sdk_core` policies / `test_output_schema` / `test_filesystem_sync`, which pass in isolation on both.

Verified end to end against a real LLM and real embeddings, no mocks: cosine ranking through both seams; the threshold gate leaving sub-threshold catalogues on the LLM path with zero vectors embedded; fallback to the LLM when a backend cannot load; per-call SDK overrides.

CI passed all 13 checks (including CodeRabbit) on the seam commit as PR #661 before consolidation.

### Configuration

Documented in the README with every option, four ways to set it (settings.toml incl. per-seam sections, env, SDK per-agent and per-call, raw `configurable`), a which-strategy-when table, and gotchas.

```toml
[shortlister]
strategy = "hybrid"   # llm | embedding | hybrid | "my.pkg.MyShortlister"
threshold = 128       # engage the cosine stage only above this many candidates
top_k = 128
max_results = 10
```

### Notes for review

- **One existing test changed.** `test_find_tools_composes_query_with_initial_user_message` asserted `find_tools` receives a *pre-joined* query string; query and task context now travel separately so a non-LLM ranker can weight them. Replaced with two tests — one pinning the new plumbing, one asserting `compose_query()` is byte-identical to the old `_compose_find_tools_shortlister_query()`. Behavior unchanged, test contract changed — flag it if you'd rather keep the old shape.
- **Not included, deliberately:** name-validation/retry (#549's unmerged work), `prewarm`, `prompt_preselect`, a per-seam LLM `model` key, and the server/demo-UI override path (#660). `docs/design/pluggable-shortlister.md` records each omission and why.
- **Three commits, split by concern** (seam / strategies / SDK+docs) if you would rather review them one at a time — the seam commit is the pure refactor and stands alone.
