### PR TITLE
refactor(cuga-lite): extract a pluggable shortlister strategy seam (#624)

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/helpers/find_tools.py
@@ -97,17 +97,22 @@ async def create_find_tools_tool(
                 f"App '{app_name}' not found in available apps. Available apps: {[app.name if hasattr(app, 'name') else str(app) for app in all_apps]}"
             )
 
+        # Kept for the log/except paths below, which report on the full text.
         shortlister_query = _compose_find_tools_shortlister_query(query, initial_user_message)
 
         from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
 
         try:
+            # Query and task context travel separately so a non-LLM strategy can
+            # weight them; the LLM strategy re-joins them into the same string
+            # `_compose_find_tools_shortlister_query` produces above.
             return await PromptUtils.find_tools(
-                query=shortlister_query,
+                query=query,
                 all_tools=filtered_tools,
                 all_apps=filtered_apps,
                 llm=llm,
                 run_config=nested_langgraph_invoke_config(),
+                task_context=initial_user_message,
             )
         except OutputParserException as e:
             logger.bind(

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -12,8 +12,6 @@ from loguru import logger
 from pydantic import BaseModel, Field
 from langchain_core.tools import StructuredTool
 from cuga.backend.cuga_graph.nodes.cuga_lite.providers.base import AppDefinition
-from cuga.backend.llm.utils.helpers import create_chat_prompt_from_templates
-from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
 from cuga.backend.cuga_graph.nodes.cuga_lite.model_runtime_profile import runtime_defaults_for_model
 from cuga.backend.tools_env.registry.utils.schema_utils import json_schema_type
 
@@ -63,6 +61,25 @@ def resolve_cuga_lite_few_shots_enabled(
     if "cuga_lite_enable_few_shots" in prof:
         return _coerce_bool_setting(prof["cuga_lite_enable_few_shots"])
     return few_shots_enabled_from_settings()
+
+
+def _configurable_of(run_config: Optional[Any]) -> Dict[str, Any]:
+    """Pull ``configurable`` out of a RunnableConfig, tolerating any shape.
+
+    ``run_config`` reaches shortlisting from several call sites and is sometimes
+    a plain dict, sometimes absent. Shortlister settings are never important
+    enough to fail a run over, so anything unexpected reads as "no overrides".
+    """
+    if not run_config:
+        return {}
+    try:
+        if isinstance(run_config, dict):
+            configurable = run_config.get("configurable")
+        else:
+            configurable = getattr(run_config, "configurable", None)
+        return configurable if isinstance(configurable, dict) else {}
+    except Exception:
+        return {}
 
 
 class Tool(BaseModel):
@@ -301,18 +318,23 @@ class PromptUtils:
         all_apps: List[AppDefinition],
         llm: Optional[Any] = None,
         run_config: Optional[Any] = None,
+        task_context: Optional[str] = None,
     ) -> str:
         """
         Search tools from given applications and return the relevant matching tools with reasoning.
 
-        This method uses an LLM to analyze available tools from all loaded applications and
-        select the ones needed for the query (including chaining). No fixed result count.
-        Each returned tool includes reasoning plus parameter and response documentation.
+        Ranking is delegated to the configured shortlister strategy (``[shortlister]
+        strategy``, default ``"llm"`` — the original behavior). See
+        ``docs/design/pluggable-shortlister.md``.
 
         Args:
             query: A natural language query describing what tools are needed.
             all_tools: List of all available tools
             all_apps: List of all available app definitions
+            task_context: The initial user message, kept separate from ``query`` so a
+                non-LLM strategy can weight the two (the LLM strategy re-joins them into
+                the string it has always sent). When omitted, ``query`` is assumed to be
+                already composed.
 
         Returns:
             str: A markdown-formatted string of matching tools, each with:
@@ -321,141 +343,30 @@ class PromptUtils:
                  - parameters: Formatted parameter documentation
                  - response schema: Response/return value schema
         """
-        prompt = create_chat_prompt_from_templates(
-            system_path='./prompts/shortlister/system.jinja2',
-            message_templates=[
-                (
-                    'human',
-                    """
-                Current Apps: {all_apps}
-                Current Available Tools: {all_tools}
-                """,
-                ),
-                ('ai', 'Sure, now give me the intent'),
-                ('human', '{input}'),
-            ],
+        from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+            ShortlistRequest,
+            ShortlisterRouter,
+            render_tools_markdown,
+            run_shortlister,
         )
-        tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(all_tools, all_apps)
-        from cuga.backend.llm.models import LLMManager
-        from cuga.backend.cuga_graph.nodes.api.shortlister_agent.prompts.load_prompt import (
-            ShortListerOutputLite,
+        from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import compose_query
+
+        plan = ShortlisterRouter.resolve(
+            settings, seam="discovery", configurable=_configurable_of(run_config)
         )
-        from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
-
-        llm_manager = LLMManager()
-        model = llm or llm_manager.get_model(settings.agent.code.model)
-        chain = BaseAgent.get_chain(prompt, model, ShortListerOutputLite)
-        response = await chain.ainvoke(
-            {
-                "input": query,
-                "all_apps": apps_as_dict,
-                "all_tools": tools_as_dict,
-                "instructions": "",
-            },
-            config=nested_langgraph_invoke_config(run_config),
+        candidates = await run_shortlister(
+            plan,
+            ShortlistRequest(
+                query=query,
+                tools=all_tools,
+                apps=all_apps,
+                task_context=task_context,
+                llm=llm,
+                run_config=run_config,
+            ),
         )
-
-        enriched_tools = []
-        for api_detail in response.result:
-            # Find the actual tool to get input schema and output schema
-            actual_tool = None
-            for t in all_tools:
-                if t.name == api_detail.name:
-                    actual_tool = t
-                    break
-
-            if not actual_tool:
-                continue
-
-            params_doc, response_doc = PromptUtils.get_tool_docs(actual_tool)
-
-            # Get input schema from the actual tool
-            input_schema = {}
-            if hasattr(actual_tool, 'args_schema') and actual_tool.args_schema:
-                try:
-                    input_schema = actual_tool.args_schema.schema()
-                except Exception:
-                    input_schema = {}
-
-            # Get output schema from response_schemas if available
-            output_schema = {}
-            if hasattr(actual_tool, 'func') and hasattr(actual_tool.func, '_response_schemas'):
-                response_schemas = actual_tool.func._response_schemas
-                if response_schemas and isinstance(response_schemas, dict) and 'success' in response_schemas:
-                    raw_output_schema = response_schemas['success']
-                    # Ensure output_schema is always a dict
-                    if isinstance(raw_output_schema, list):
-                        # If it's a list, wrap it in a proper JSON schema format
-                        if len(raw_output_schema) > 0 and isinstance(raw_output_schema[0], dict):
-                            # List of objects - create array schema with items
-                            output_schema = {"type": "array", "items": raw_output_schema[0]}
-                        else:
-                            # List of primitives - create array schema
-                            output_schema = {
-                                "type": "array",
-                                "items": raw_output_schema[0] if raw_output_schema else {},
-                            }
-                    elif isinstance(raw_output_schema, dict):
-                        output_schema = raw_output_schema
-                    else:
-                        # Fallback for other types
-                        output_schema = {"value": raw_output_schema} if raw_output_schema is not None else {}
-
-            enriched_tool = Tool(
-                name=api_detail.name,
-                input=VariableUtils.sanitize_value(input_schema),
-                reasoning=api_detail.reasoning,
-                output_schema=VariableUtils.sanitize_value(output_schema),
-                params_doc=params_doc,
-                response_doc=response_doc,
-            )
-            enriched_tools.append(enriched_tool)
-
-        if not enriched_tools:
-            return "No matching tools found for your query."
-
-        tool_descriptions = {
-            tool.name: getattr(tool, 'description', None)
-            for tool in all_tools
-            if hasattr(tool, 'description')
-        }
-
-        markdown_lines = [
-            f"# Found {len(enriched_tools)} Matching Tool(s)\n",
-            f"**Query:** {query}\n",
-        ]
-
-        for idx, tool in enumerate(enriched_tools, 1):
-            markdown_lines.append(f"## {idx}. `{tool.name}`\n")
-
-            tool_description = tool_descriptions.get(tool.name)
-            if tool_description:
-                markdown_lines.append(f"**Description:** {tool_description}\n")
-
-            markdown_lines.append(f"**Reasoning:** {tool.reasoning}\n")
-
-            if tool.params_doc:
-                markdown_lines.append("**Parameters:**\n")
-                markdown_lines.append(f"{tool.params_doc}\n")
-            else:
-                markdown_lines.append("**Parameters:** No parameters required\n")
-
-            if tool.response_doc:
-                markdown_lines.append("**Response Schema:**\n")
-                markdown_lines.append(f"{tool.response_doc}\n")
-
-            if tool.input_ and tool.input_ != {}:
-                markdown_lines.append("**Input Schema:**\n")
-                markdown_lines.append(f"```json\n{json.dumps(tool.input_, indent=2)}\n```\n")
-
-            if tool.output_schema and tool.output_schema != {}:
-                markdown_lines.append("**Output Schema:**\n")
-                markdown_lines.append(f"```json\n{json.dumps(tool.output_schema, indent=2)}\n```\n")
-
-            markdown_lines.append("---\n")
-
-        return "\n".join(markdown_lines)
+        display_query = compose_query(query, task_context) if task_context else query
+        return render_tools_markdown(candidates, all_tools, display_query)
 
     @staticmethod
     async def shortlist_tool_names(
@@ -481,57 +392,31 @@ class PromptUtils:
         if not query or not query.strip():
             return []
 
-        from cuga.backend.llm.models import LLMManager
-        from cuga.backend.cuga_graph.nodes.api.shortlister_agent.prompts.load_prompt import (
-            ShortListerOutputLite,
-        )
-        from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
-
-        effective_instructions = (
-            instructions
-            if instructions is not None
-            else (
-                f"Return the {top_k} most relevant tools (or fewer if not enough are relevant), "
-                "ordered best-first by relevance. Do not exceed this count."
-            )
+        from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+            ShortlistRequest,
+            ShortlisterRouter,
+            run_shortlister,
         )
 
-        prompt = create_chat_prompt_from_templates(
-            system_path='./prompts/shortlister/system.jinja2',
-            message_templates=[
-                (
-                    'human',
-                    """
-                Current Apps: {all_apps}
-                Current Available Tools: {all_tools}
-                """,
-                ),
-                ('ai', 'Sure, now give me the intent'),
-                ('human', '{input}'),
-            ],
-        )
-        tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(all_tools, all_apps)
-
-        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
-
-        llm_manager = LLMManager()
-        model = llm or llm_manager.get_model(settings.agent.code.model)
-        chain = BaseAgent.get_chain(prompt, model, ShortListerOutputLite)
-        response = await chain.ainvoke(
-            {
-                "input": query,
-                "all_apps": apps_as_dict,
-                "all_tools": tools_as_dict,
-                "instructions": effective_instructions,
-            },
-            config=nested_langgraph_invoke_config(run_config),
+        plan = ShortlisterRouter.resolve(settings, seam="bind_cap", configurable=_configurable_of(run_config))
+        candidates = await run_shortlister(
+            plan,
+            ShortlistRequest(
+                query=query,
+                tools=all_tools,
+                apps=all_apps,
+                top_k=top_k,
+                llm=llm,
+                run_config=run_config,
+                instructions=instructions,
+            ),
         )
 
         valid_names = {t.name for t in all_tools}
         ranked: List[str] = []
         seen: set = set()
-        for api_detail in getattr(response, "result", None) or []:
-            name = getattr(api_detail, "name", None)
+        for candidate in candidates:
+            name = getattr(candidate, "name", None)
             if not name or name in seen or name not in valid_names:
                 continue
             seen.add(name)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/__init__.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/__init__.py
@@ -1,0 +1,37 @@
+"""Pluggable tool shortlisting for CugaLite.
+
+See ``docs/design/pluggable-shortlister.md``. Default (``strategy = "llm"``)
+reproduces the pre-existing behavior exactly.
+"""
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterStrategy,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.factory import (
+    clear_instance_cache,
+    resolve_shortlister,
+    run_shortlister,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import (
+    BUILTIN_STRATEGIES,
+    ShortlisterPlan,
+    ShortlisterRouter,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.render import render_tools_markdown
+
+__all__ = [
+    "BUILTIN_STRATEGIES",
+    "ShortlistCandidate",
+    "ShortlistRequest",
+    "ShortlisterPlan",
+    "ShortlisterRouter",
+    "ShortlisterStrategy",
+    "ShortlisterUnavailableError",
+    "clear_instance_cache",
+    "render_tools_markdown",
+    "resolve_shortlister",
+    "run_shortlister",
+]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/base.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/base.py
@@ -1,0 +1,78 @@
+"""Core types for pluggable tool shortlisting.
+
+A *shortlister* reduces a candidate tool set down to the ones worth showing the
+model. CugaLite does this at two call sites — runtime discovery (``find_tools``)
+and the bind-time provider cap — and both route through
+:class:`ShortlisterStrategy` so the ranker can be swapped by configuration.
+
+See ``docs/design/pluggable-shortlister.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar, List, Optional, Protocol
+
+from langchain_core.tools import StructuredTool
+
+
+@dataclass
+class ShortlistCandidate:
+    """One ranked tool.
+
+    ``score`` is strategy-defined (LLM relevance, cosine similarity, …) and is
+    used only for ordering — never compared across strategies.
+    """
+
+    name: str
+    score: float = 0.0
+    reasoning: str = ""
+
+
+@dataclass
+class ShortlistRequest:
+    """Everything a strategy needs to rank ``tools`` against ``query``.
+
+    ``query`` and ``task_context`` are kept **separate** rather than pre-joined:
+    the LLM strategy re-composes them into the exact prompt string it has always
+    sent, while the embedding strategy weights them independently (a long task
+    context would otherwise dominate a short per-step query and make every step
+    of a task retrieve the same tools).
+
+    ``top_k=None`` means "strategy decides how many" — the ``find_tools``
+    semantic, where the result count varies with the query.
+    """
+
+    query: str
+    tools: List[StructuredTool]
+    apps: List[Any]
+    task_context: Optional[str] = None
+    top_k: Optional[int] = None
+    max_results: Optional[int] = None
+    llm: Optional[Any] = None
+    run_config: Any = None
+    instructions: Optional[str] = None
+
+
+class ShortlisterUnavailableError(RuntimeError):
+    """Strategy cannot run right now (model not loaded, dependency missing).
+
+    Deliberately distinct from a genuine ranking failure: the factory catches
+    this and degrades to ``fallback_strategy`` instead of failing the run. A
+    strategy that is merely *bad* at ranking must not raise this.
+    """
+
+
+class ShortlisterStrategy(Protocol):
+    """Swap-in ranker. Implement this to provide a custom shortlister.
+
+    Register it via ``[shortlister] strategy = "my.pkg.MyShortlister"`` or
+    ``CugaAgent(shortlister=Shortlister(instance=MyShortlister()))``.
+
+    Returns candidates best-first. Names that match no tool in the request are
+    dropped by the caller, so a strategy need not filter them itself.
+    """
+
+    name: ClassVar[str]
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]: ...

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/factory.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/factory.py
@@ -1,0 +1,115 @@
+"""Build a strategy from a resolved :class:`ShortlisterPlan`.
+
+Name resolution follows the repo's existing idiom: a bare name selects a
+built-in, anything containing a dot is loaded as a class path via
+``cuga.config.get_class`` — the same mechanism as
+``page_understanding.transformer_path``.
+
+Instances are cached per plan signature so the embedding model's weights load
+once per process rather than once per call.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+from loguru import logger
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterStrategy,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import BUILTIN_STRATEGIES, ShortlisterPlan
+
+_INSTANCES: Dict[str, ShortlisterStrategy] = {}
+
+
+def clear_instance_cache() -> None:
+    """Drop cached strategy instances. Tests only."""
+    _INSTANCES.clear()
+
+
+def _build_llm(plan: ShortlisterPlan) -> LLMShortlister:
+    return LLMShortlister()
+
+
+#: Built-in strategies. Additional rankers register here.
+_BUILDERS: Dict[str, Callable[[ShortlisterPlan], Any]] = {"llm": _build_llm}
+
+
+def _build_from_dotted_path(path: str, plan: ShortlisterPlan) -> Any:
+    """Instantiate a user-supplied strategy class.
+
+    Tries ``Cls(plan=plan)`` first so custom strategies can read configuration,
+    falling back to a no-argument constructor.
+    """
+    from cuga.config import get_class
+
+    cls = get_class(path)
+    try:
+        return cls(plan=plan)
+    except TypeError:
+        return cls()
+
+
+def resolve_shortlister(plan: ShortlisterPlan) -> ShortlisterStrategy:
+    """Return the strategy described by ``plan``, cached where possible."""
+    if plan.instance is not None:
+        return plan.instance
+
+    key = plan.cache_key()
+    cached = _INSTANCES.get(key)
+    if cached is not None:
+        return cached
+
+    strategy_name = plan.strategy
+    if strategy_name in _BUILDERS:
+        strategy = _BUILDERS[strategy_name](plan)
+    elif "." in strategy_name:
+        try:
+            strategy = _build_from_dotted_path(strategy_name, plan)
+        except Exception as e:
+            logger.error(
+                "Could not load custom shortlister {!r}: {}. Falling back to {!r}.",
+                strategy_name,
+                e,
+                plan.fallback_strategy,
+            )
+            strategy = _BUILDERS.get(plan.fallback_strategy, _build_llm)(plan)
+    else:
+        # ShortlisterRouter normally rewrites unknown names; this covers a plan
+        # constructed directly in code.
+        raise ValueError(
+            f"Unknown shortlister strategy {strategy_name!r}. Expected one of "
+            f"{', '.join(BUILTIN_STRATEGIES)} or a dotted class path."
+        )
+
+    _INSTANCES[key] = strategy
+    return strategy
+
+
+async def run_shortlister(plan: ShortlisterPlan, request: ShortlistRequest) -> List[ShortlistCandidate]:
+    """Run the planned strategy, degrading to the fallback if it cannot run.
+
+    Only :class:`ShortlisterUnavailableError` triggers the fallback — a missing
+    model or dependency. Genuine ranking failures propagate so each call site
+    keeps its own error contract (``find_tools`` turns them into a message for
+    the agent; the bind-time cap raises).
+    """
+    strategy = resolve_shortlister(plan)
+    try:
+        return await strategy.shortlist(request)
+    except ShortlisterUnavailableError as e:
+        fallback_name = plan.fallback_strategy
+        if fallback_name == plan.strategy or fallback_name not in _BUILDERS:
+            raise
+        logger.warning(
+            "Shortlister {!r} unavailable ({}); using {!r} for this call.",
+            plan.strategy,
+            e,
+            fallback_name,
+        )
+        return await _BUILDERS[fallback_name](plan).shortlist(request)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/llm.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/llm.py
@@ -1,0 +1,100 @@
+"""The LLM shortlister — today's behavior, behind the strategy interface.
+
+This is the default and is deliberately a faithful port: same prompt template,
+same ``ShortListerOutputLite`` schema, same model, same composed query string.
+Callers already drop names that match no tool, so nothing is filtered here.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar, List, Optional
+
+from cuga.config import settings
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+)
+
+
+def compose_query(query: str, task_context: Optional[str]) -> str:
+    """Join a step query with the task context exactly as CugaLite always has.
+
+    Kept identical to ``helpers/find_tools._compose_find_tools_shortlister_query``
+    so the prompt text does not change now that the two parts travel separately.
+    """
+    q = (query or "").strip()
+    init = (task_context or "").strip()
+    if not init:
+        return q
+    return f"Query: {q}\nTask context (initial user message): {init}"
+
+
+def top_k_instruction(top_k: int) -> str:
+    """The instruction the bind-time cap has always injected."""
+    return (
+        f"Return the {top_k} most relevant tools (or fewer if not enough are relevant), "
+        "ordered best-first by relevance. Do not exceed this count."
+    )
+
+
+class LLMShortlister:
+    """Ranks tools by asking the model, using the shortlister prompt."""
+
+    name: ClassVar[str] = "llm"
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        from cuga.backend.llm.models import LLMManager
+        from cuga.backend.cuga_graph.nodes.api.shortlister_agent.prompts.load_prompt import (
+            ShortListerOutputLite,
+        )
+        from cuga.backend.cuga_graph.nodes.shared.base_agent import BaseAgent
+        from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+        from cuga.backend.cuga_graph.utils.langfuse_tracing import nested_langgraph_invoke_config
+        from cuga.backend.llm.utils.helpers import create_chat_prompt_from_templates
+
+        if not request.tools:
+            return []
+
+        if request.instructions is not None:
+            instructions = request.instructions
+        elif request.top_k:
+            instructions = top_k_instruction(request.top_k)
+        else:
+            instructions = ""
+
+        prompt = create_chat_prompt_from_templates(
+            system_path='../prompts/shortlister/system.jinja2',
+            message_templates=[
+                (
+                    'human',
+                    """
+                Current Apps: {all_apps}
+                Current Available Tools: {all_tools}
+                """,
+                ),
+                ('ai', 'Sure, now give me the intent'),
+                ('human', '{input}'),
+            ],
+        )
+        tools_as_dict, apps_as_dict = PromptUtils._build_shortlister_payload(request.tools, request.apps)
+
+        model = request.llm or LLMManager().get_model(settings.agent.code.model)
+        chain = BaseAgent.get_chain(prompt, model, ShortListerOutputLite)
+        response = await chain.ainvoke(
+            {
+                "input": compose_query(request.query, request.task_context),
+                "all_apps": apps_as_dict,
+                "all_tools": tools_as_dict,
+                "instructions": instructions,
+            },
+            config=nested_langgraph_invoke_config(request.run_config),
+        )
+
+        return [
+            ShortlistCandidate(
+                name=getattr(detail, "name", ""),
+                score=float(getattr(detail, "relevance_score", 0.0) or 0.0),
+                reasoning=str(getattr(detail, "reasoning", "") or ""),
+            )
+            for detail in (getattr(response, "result", None) or [])
+        ]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/plan.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/plan.py
@@ -1,0 +1,153 @@
+"""Resolve shortlister settings into an explicit :class:`ShortlisterPlan`.
+
+Mirrors ``cuga_agent_core/policy/execution_policy.py`` (``ExecutionRouter`` →
+``ExecutionPlan``): settings in, one typed, log-visible object out.
+
+Precedence, highest first:
+  1. ``override``                       — a live object / dataclass from the SDK
+  2. ``configurable["shortlister_*"]``  — per-invoke
+  3. ``[shortlister.<seam>]``           — per-seam TOML
+  4. ``[shortlister]``                  — global TOML
+  5. module defaults below
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+Seam = Literal["discovery", "bind_cap"]
+
+BUILTIN_STRATEGIES = ("llm",)
+
+# Defaults live here, not in settings.toml, so a missing section can never break
+# resolution. settings.toml restates them for discoverability.
+DEFAULT_STRATEGY = "llm"
+DEFAULT_FALLBACK_STRATEGY = "llm"
+
+_INT_FIELDS: tuple = ()
+_FLOAT_FIELDS: tuple = ()
+_STR_FIELDS = ("strategy", "fallback_strategy")
+ALL_FIELDS = _INT_FIELDS + _FLOAT_FIELDS + _STR_FIELDS
+
+#: ``configurable`` keys, e.g. ``shortlister_strategy``.
+CONFIGURABLE_PREFIX = "shortlister_"
+
+
+class ShortlisterPlan(BaseModel):
+    """Explicit description of how shortlisting will run for one seam."""
+
+    seam: Seam = "discovery"
+    strategy: str = DEFAULT_STRATEGY
+    fallback_strategy: str = DEFAULT_FALLBACK_STRATEGY
+    #: Live strategy object injected via the SDK; bypasses ``strategy``.
+    instance: Optional[Any] = Field(default=None, exclude=True)
+    notes: List[str] = Field(default_factory=list)
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def cache_key(self) -> str:
+        """Identity for the strategy-instance cache (excludes per-call knobs)."""
+        return "|".join([self.strategy, self.fallback_strategy])
+
+
+def _coerce(field_name: str, raw: Any) -> Any:
+    """Coerce a settings/configurable value, returning ``None`` when unusable.
+
+    Values arrive from TOML, env (always strings) and Python, so every field is
+    coerced rather than trusted. A bad value is dropped in favour of the lower
+    precedence source instead of raising — a typo in one key must not take the
+    agent down.
+    """
+    if raw is None:
+        return None
+    try:
+        if field_name in _INT_FIELDS:
+            return int(raw)
+        if field_name in _FLOAT_FIELDS:
+            return float(raw)
+        text = str(raw).strip()
+        return text or None
+    except (TypeError, ValueError):
+        return None
+
+
+def _layer(target: Dict[str, Any], source: Any, *, keys: Any = ALL_FIELDS, prefix: str = "") -> None:
+    """Copy recognised, non-``None`` values from ``source`` onto ``target``."""
+    if source is None:
+        return
+    for field_name in keys:
+        lookup = f"{prefix}{field_name}"
+        if isinstance(source, dict):
+            if lookup not in source:
+                continue
+            raw = source.get(lookup)
+        else:
+            raw = getattr(source, lookup, None)
+        value = _coerce(field_name, raw)
+        if value is not None:
+            target[field_name] = value
+
+
+class ShortlisterRouter:
+    """Resolves settings + overrides into a :class:`ShortlisterPlan`."""
+
+    @staticmethod
+    def resolve(
+        settings: Any,
+        *,
+        seam: Seam = "discovery",
+        configurable: Optional[Dict[str, Any]] = None,
+        override: Optional[Any] = None,
+    ) -> ShortlisterPlan:
+        values: Dict[str, Any] = {}
+        notes: List[str] = []
+
+        section = getattr(settings, "shortlister", None)
+        _layer(values, section)
+        _layer(values, getattr(section, seam, None) if section is not None else None)
+        _layer(values, configurable, prefix=CONFIGURABLE_PREFIX)
+
+        instance = None
+        if configurable:
+            instance = configurable.get("shortlister_instance") or _instance_of(
+                configurable.get("shortlister")
+            )
+            _layer(values, _as_mapping(configurable.get("shortlister")))
+
+        if override is not None:
+            instance = _instance_of(override) or instance
+            _layer(values, _as_mapping(override))
+
+        plan = ShortlisterPlan(seam=seam, instance=instance, notes=notes, **values)
+
+        # Append to ``plan.notes``, not the local list — pydantic copies it on
+        # validation, so mutating ``notes`` here would silently do nothing.
+        if plan.instance is None and plan.strategy not in BUILTIN_STRATEGIES and "." not in plan.strategy:
+            plan.notes.append(
+                f"unknown shortlister strategy {plan.strategy!r}; falling back to "
+                f"{DEFAULT_STRATEGY!r} (expected one of {', '.join(BUILTIN_STRATEGIES)} "
+                f"or a dotted class path)"
+            )
+            plan.strategy = DEFAULT_STRATEGY
+        return plan
+
+
+def _instance_of(candidate: Any) -> Optional[Any]:
+    """Extract a live strategy object from an SDK config or raw instance."""
+    if candidate is None:
+        return None
+    inner = getattr(candidate, "instance", None)
+    if inner is not None:
+        return inner
+    if hasattr(candidate, "shortlist"):
+        return candidate
+    return None
+
+
+def _as_mapping(candidate: Any) -> Optional[Any]:
+    """Return ``candidate`` if it can carry plan fields, else ``None``."""
+    if candidate is None or hasattr(candidate, "shortlist"):
+        return None
+    return candidate

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/render.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/render.py
@@ -1,0 +1,128 @@
+"""Render ranked candidates as the markdown ``find_tools`` returns.
+
+Extracted verbatim from ``PromptUtils.find_tools`` so that ranking and
+presentation can vary independently: a cosine strategy produces the same output
+shape as the LLM one, just with ``reasoning`` supplied differently.
+
+Output format is load-bearing — the agent reads this string from sandbox stdout
+— so changes here are behavior changes. Keep byte-compatible with the pre-split
+implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import ShortlistCandidate
+
+NO_MATCH_MESSAGE = "No matching tools found for your query."
+
+
+def _output_schema_for(tool: StructuredTool) -> Dict[str, Any]:
+    """Normalize ``_response_schemas['success']`` into a dict schema."""
+    func = getattr(tool, "func", None)
+    if func is None or not hasattr(func, "_response_schemas"):
+        return {}
+    response_schemas = func._response_schemas
+    if not (response_schemas and isinstance(response_schemas, dict) and 'success' in response_schemas):
+        return {}
+    raw = response_schemas['success']
+    if isinstance(raw, list):
+        if len(raw) > 0 and isinstance(raw[0], dict):
+            return {"type": "array", "items": raw[0]}
+        return {"type": "array", "items": raw[0] if raw else {}}
+    if isinstance(raw, dict):
+        return raw
+    return {"value": raw} if raw is not None else {}
+
+
+def _input_schema_for(tool: StructuredTool) -> Dict[str, Any]:
+    args_schema = getattr(tool, "args_schema", None)
+    if not args_schema:
+        return {}
+    try:
+        return args_schema.schema()
+    except Exception:
+        return {}
+
+
+def render_tools_markdown(
+    candidates: List[ShortlistCandidate],
+    tools: List[StructuredTool],
+    display_query: str,
+) -> str:
+    """Render ``candidates`` as markdown.
+
+    ``display_query`` is shown verbatim in the ``**Query:**`` header — callers
+    pass the same composed string the LLM saw, so output is unchanged.
+
+    Candidates whose name matches no tool in ``tools`` are silently skipped,
+    preserving the original ``if not actual_tool: continue``.
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.variable_utils import VariableUtils
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils, Tool
+
+    by_name = {t.name: t for t in tools}
+
+    enriched_tools: List[Tool] = []
+    for candidate in candidates:
+        actual_tool = by_name.get(candidate.name)
+        if not actual_tool:
+            continue
+        params_doc, response_doc = PromptUtils.get_tool_docs(actual_tool)
+        enriched_tools.append(
+            Tool(
+                name=candidate.name,
+                input=VariableUtils.sanitize_value(_input_schema_for(actual_tool)),
+                reasoning=candidate.reasoning,
+                output_schema=VariableUtils.sanitize_value(_output_schema_for(actual_tool)),
+                params_doc=params_doc,
+                response_doc=response_doc,
+            )
+        )
+
+    if not enriched_tools:
+        return NO_MATCH_MESSAGE
+
+    tool_descriptions = {
+        tool.name: getattr(tool, 'description', None) for tool in tools if hasattr(tool, 'description')
+    }
+
+    markdown_lines = [
+        f"# Found {len(enriched_tools)} Matching Tool(s)\n",
+        f"**Query:** {display_query}\n",
+    ]
+
+    for idx, tool in enumerate(enriched_tools, 1):
+        markdown_lines.append(f"## {idx}. `{tool.name}`\n")
+
+        tool_description = tool_descriptions.get(tool.name)
+        if tool_description:
+            markdown_lines.append(f"**Description:** {tool_description}\n")
+
+        markdown_lines.append(f"**Reasoning:** {tool.reasoning}\n")
+
+        if tool.params_doc:
+            markdown_lines.append("**Parameters:**\n")
+            markdown_lines.append(f"{tool.params_doc}\n")
+        else:
+            markdown_lines.append("**Parameters:** No parameters required\n")
+
+        if tool.response_doc:
+            markdown_lines.append("**Response Schema:**\n")
+            markdown_lines.append(f"{tool.response_doc}\n")
+
+        if tool.input_ and tool.input_ != {}:
+            markdown_lines.append("**Input Schema:**\n")
+            markdown_lines.append(f"```json\n{json.dumps(tool.input_, indent=2)}\n```\n")
+
+        if tool.output_schema and tool.output_schema != {}:
+            markdown_lines.append("**Output Schema:**\n")
+            markdown_lines.append(f"```json\n{json.dumps(tool.output_schema, indent=2)}\n```\n")
+
+        markdown_lines.append("---\n")
+
+    return "\n".join(markdown_lines)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_factory.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_factory.py
@@ -1,0 +1,160 @@
+"""Strategy resolution: built-ins, dotted paths, precedence, caching, fallback."""
+
+from types import SimpleNamespace
+from typing import Any, ClassVar, List
+
+import pytest
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    ShortlistRequest,
+    ShortlistCandidate,
+    ShortlisterPlan,
+    ShortlisterRouter,
+    ShortlisterUnavailableError,
+    clear_instance_cache,
+    resolve_shortlister,
+    run_shortlister,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+
+pytestmark = pytest.mark.unit
+
+
+class CustomShortlister:
+    """Stand-in for a user-supplied strategy loaded by dotted path."""
+
+    name: ClassVar[str] = "custom"
+
+    def __init__(self, plan: Any = None):
+        self.plan = plan
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        return [ShortlistCandidate(name="custom_pick", score=1.0)]
+
+
+class AlwaysUnavailable:
+    name: ClassVar[str] = "unavailable"
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        raise ShortlisterUnavailableError("model missing")
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    clear_instance_cache()
+    yield
+    clear_instance_cache()
+
+
+def _settings(**kwargs):
+    return SimpleNamespace(shortlister=SimpleNamespace(**kwargs))
+
+
+# --- built-ins --------------------------------------------------------------
+
+
+def test_builtin_llm_strategy_resolves():
+    assert isinstance(resolve_shortlister(ShortlisterPlan(strategy="llm")), LLMShortlister)
+
+
+def test_unknown_bare_name_is_rewritten_by_the_router():
+    """A typo must not take the agent down — it degrades with a note."""
+    plan = ShortlisterRouter.resolve(_settings(strategy="cosinee"))
+    assert plan.strategy == "llm"
+    assert any("cosinee" in n for n in plan.notes)
+
+
+def test_unknown_name_on_a_hand_built_plan_raises():
+    """Bypassing the router is a programming error, so it is loud."""
+    with pytest.raises(ValueError, match="Unknown shortlister strategy"):
+        resolve_shortlister(ShortlisterPlan(strategy="nonsense"))
+
+
+# --- dotted paths -----------------------------------------------------------
+
+
+def test_dotted_path_loads_a_custom_strategy():
+    path = f"{__name__}.CustomShortlister"
+    strategy = resolve_shortlister(ShortlisterPlan(strategy=path))
+    assert isinstance(strategy, CustomShortlister)
+
+
+def test_broken_dotted_path_falls_back_rather_than_crashing():
+    plan = ShortlisterPlan(strategy="does.not.Exist", fallback_strategy="llm")
+    assert isinstance(resolve_shortlister(plan), LLMShortlister)
+
+
+# --- precedence -------------------------------------------------------------
+
+
+# --- caching ----------------------------------------------------------------
+
+
+# --- fallback ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unavailable_strategy_degrades_to_fallback():
+    plan = ShortlisterPlan(strategy="embedding", fallback_strategy="llm", instance=AlwaysUnavailable())
+    called = {}
+
+    async def _fake(self, request):
+        called["yes"] = True
+        return [ShortlistCandidate(name="from_llm")]
+
+    from unittest.mock import patch
+
+    with patch.object(LLMShortlister, "shortlist", _fake):
+        result = await run_shortlister(plan, ShortlistRequest(query="q", tools=[], apps=[]))
+
+    assert called
+    assert result[0].name == "from_llm"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_with_no_distinct_fallback_reraises():
+    plan = ShortlisterPlan(strategy="llm", fallback_strategy="llm", instance=AlwaysUnavailable())
+    with pytest.raises(ShortlisterUnavailableError):
+        await run_shortlister(plan, ShortlistRequest(query="q", tools=[], apps=[]))
+
+
+@pytest.mark.asyncio
+async def test_ordinary_errors_are_not_swallowed():
+    """Only unavailability triggers the fallback; real failures keep each call
+    site's own error contract."""
+
+    class Boom:
+        name = "boom"
+
+        async def shortlist(self, request):
+            raise RuntimeError("ranking blew up")
+
+    plan = ShortlisterPlan(strategy="embedding", instance=Boom())
+    with pytest.raises(RuntimeError, match="ranking blew up"):
+        await run_shortlister(plan, ShortlistRequest(query="q", tools=[], apps=[]))
+
+
+def test_configurable_beats_settings():
+    plan = ShortlisterRouter.resolve(
+        _settings(strategy="llm"), configurable={"shortlister_strategy": f"{__name__}.CustomShortlister"}
+    )
+    assert plan.strategy == f"{__name__}.CustomShortlister"
+
+
+def test_per_seam_section_beats_global():
+    dotted = f"{__name__}.CustomShortlister"
+    settings = SimpleNamespace(
+        shortlister=SimpleNamespace(strategy="llm", bind_cap=SimpleNamespace(strategy=dotted))
+    )
+    assert ShortlisterRouter.resolve(settings, seam="bind_cap").strategy == dotted
+    assert ShortlisterRouter.resolve(settings, seam="discovery").strategy == "llm"
+
+
+def test_injected_instance_wins_over_named_strategy():
+    custom = CustomShortlister()
+    plan = ShortlisterRouter.resolve(_settings(strategy="llm"), override=custom)
+    assert resolve_shortlister(plan) is custom
+
+
+def test_instances_are_cached():
+    assert resolve_shortlister(ShortlisterPlan()) is resolve_shortlister(ShortlisterPlan())

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_render.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_render.py
@@ -1,0 +1,75 @@
+"""Markdown rendering.
+
+Guards the rank/render extraction: the output format is what the agent reads
+from sandbox stdout, so drift here is a behavior change.
+"""
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import ShortlistCandidate
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.render import (
+    NO_MATCH_MESSAGE,
+    render_tools_markdown,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _ContactArgs(BaseModel):
+    email: str = Field(..., description="filter by email address")
+    limit: int = Field(default=10, description="")
+
+
+def _tool(name="crm_get_contacts_contacts_get", description="Get Contacts", args=_ContactArgs):
+    def fn(**kwargs):
+        return None
+
+    fn.__name__ = "fn"
+    return StructuredTool.from_function(func=fn, name=name, description=description, args_schema=args)
+
+
+# --- rendering --------------------------------------------------------------
+
+
+def test_render_produces_the_expected_markdown_shape():
+    tools = [_tool(name="tool_a", description="Tool A does things")]
+    out = render_tools_markdown(
+        [ShortlistCandidate(name="tool_a", score=0.9, reasoning="because")],
+        tools,
+        display_query="find contacts",
+    )
+
+    assert out.startswith("# Found 1 Matching Tool(s)")
+    assert "**Query:** find contacts" in out
+    assert "## 1. `tool_a`" in out
+    assert "**Description:** Tool A does things" in out
+    assert "**Reasoning:** because" in out
+    assert "**Parameters:**" in out
+    assert "---" in out
+
+
+def test_render_empty_returns_the_no_match_message():
+    assert render_tools_markdown([], [], display_query="q") == NO_MATCH_MESSAGE
+
+
+def test_render_skips_candidates_with_no_matching_tool():
+    """Preserves the original `if not actual_tool: continue`."""
+    tools = [_tool(name="real_tool")]
+    out = render_tools_markdown(
+        [ShortlistCandidate(name="hallucinated"), ShortlistCandidate(name="real_tool")],
+        tools,
+        display_query="q",
+    )
+    assert "# Found 1 Matching Tool(s)" in out
+    assert "hallucinated" not in out
+
+
+def test_render_uses_the_composed_query_verbatim():
+    """The header must show what the LLM saw, unchanged by the query split."""
+    composed = "Query: list contacts\nTask context (initial user message): Book a flight"
+    out = render_tools_markdown(
+        [ShortlistCandidate(name="tool_a")], [_tool(name="tool_a")], display_query=composed
+    )
+    assert f"**Query:** {composed}" in out

--- a/src/cuga/config.py
+++ b/src/cuga/config.py
@@ -216,6 +216,13 @@ validators = [
     Validator("advanced_features.cuga_lite_bind_tools_tool_names", default=[]),
     Validator("advanced_features.cuga_lite_bind_tools_max_count", default=128),
     Validator("advanced_features.cuga_lite_bind_tools_pad_to_cap", default=False),
+    # Read at prepare_node without a getattr guard; without this a settings.toml
+    # missing the key raises AttributeError mid-run instead of using the default.
+    Validator("advanced_features.shortlisting_tool_threshold", default=35),
+    # Pluggable shortlister — see docs/design/pluggable-shortlister.md.
+    # Defaults mirror shortlister/plan.py so a missing [shortlister] section is safe.
+    Validator("shortlister.strategy", default="llm"),
+    Validator("shortlister.fallback_strategy", default="llm"),
     # Evolve integration
     Validator("evolve.enabled", default=False),
     Validator("evolve.url", default="http://127.0.0.1:8201/sse"),

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -76,6 +76,19 @@ enable_shell_tool = false
 #   "local"       — no sandbox (runs directly on host; always pairs with run_command tool approval)
 sandbox_mode = "native"
 
+[shortlister]
+# How CugaLite shrinks a large tool set before the model sees it.
+# Applies to both find_tools (runtime discovery) and the bind_tools provider cap.
+# See docs/design/pluggable-shortlister.md
+#
+# strategy: llm (default) or a dotted class path, e.g. "my.pkg.MyShortlister".
+# The default reproduces the pre-existing behavior exactly.
+strategy = "llm"
+fallback_strategy = "llm"  # used when the chosen strategy cannot run
+# Per-seam overrides inherit the values above; add a [shortlister.discovery]
+# (find_tools) or [shortlister.bind_cap] (provider cap) section only when the
+# two seams need different settings.
+
 [agent_spawn]
 # When false, sub-agent spawning via spawn_agent / get_agent_result is fully disabled.
 # Zero overhead in prompt, tools, and timing when disabled (NFR-1).

--- a/tests/unit/test_find_tools_exception.py
+++ b/tests/unit/test_find_tools_exception.py
@@ -89,8 +89,14 @@ async def test_find_tools_func_success_passes_through(mock_tools, mock_apps):
 
 
 @pytest.mark.asyncio
-async def test_find_tools_composes_query_with_initial_user_message(mock_tools, mock_apps):
-    """When initial_user_message is set, shortlister query includes task context."""
+async def test_find_tools_forwards_query_and_task_context_separately(mock_tools, mock_apps):
+    """The step query and the initial user message reach the shortlister as two values.
+
+    They used to be pre-joined into one string here. They now travel separately so a
+    non-LLM strategy can weight them independently (a long task context would otherwise
+    dominate a short step query). ``LLMShortlister`` re-joins them — see the companion
+    test below, which pins that the composed text is unchanged.
+    """
     from cuga.backend.cuga_graph.nodes.cuga_lite.helpers.find_tools import create_find_tools_tool
 
     app_to_tools_map = {"test_app": mock_tools}
@@ -110,6 +116,27 @@ async def test_find_tools_composes_query_with_initial_user_message(mock_tools, m
 
     mock_find.assert_awaited_once()
     call_kw = mock_find.await_args.kwargs
-    assert call_kw["query"] == (
-        "Query: list calendar tools\nTask context (initial user message): Book a flight to NYC"
+    assert call_kw["query"] == "list calendar tools"
+    assert call_kw["task_context"] == "Book a flight to NYC"
+
+
+def test_compose_query_matches_legacy_find_tools_format():
+    """The text the LLM sees is byte-identical to the pre-split composition.
+
+    Guards the refactor: ``LLMShortlister`` must reproduce exactly what
+    ``_compose_find_tools_shortlister_query`` produced, or every shortlister prompt
+    silently changes.
+    """
+    from cuga.backend.cuga_graph.nodes.cuga_lite.helpers.find_tools import (
+        _compose_find_tools_shortlister_query,
     )
+    from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import compose_query
+
+    cases = [
+        ("list calendar tools", "Book a flight to NYC"),
+        ("  padded  ", "  context  "),
+        ("only a query", None),
+        ("only a query", ""),
+    ]
+    for query, context in cases:
+        assert compose_query(query, context) == _compose_find_tools_shortlister_query(query, context)


### PR DESCRIPTION
> **Reviewing this stack?** Start with this PR only — it is a pure refactor with a byte-identical-output proof in the comments below. #662 and #663 are drafts until this merges (CI and CodeRabbit do not run against a feature-branch base).

## Feature

Refs #624 — part 1 of 3. **Merge order: this → #B → #C.**

### Summary

Tool shortlisting is hardcoded to the LLM at two call sites — `find_tools` (runtime discovery) and the `bind_tools` provider cap — with no way to swap the ranker. This routes both through a `ShortlisterStrategy` protocol resolved from `[shortlister]` settings, a `configurable` key, or a dotted class path.

**Pure refactor: no behavior change and no new ranker.** The only built-in strategy is `llm`, a faithful port of the existing chain — same prompt template, same schema, same model, same composed query string, unknown names still silently dropped by the caller rather than retried. Cosine ranking (#B) and the SDK surface (#C) land on top of this.

`PromptUtils.find_tools` and `shortlist_tool_names` keep their signatures, so `cap.py`, `bind_tools.py`, `graph_adapter.py` and `prepare_node.py` need no changes. `find_tools` gains an optional `task_context` so the step query and initial user message can travel separately; the LLM strategy re-joins them into the identical string.

`prompt_utils.py` shrinks ~100 lines net — the markdown half of `find_tools` moves to `render.py` so ranking and presentation can vary independently.

Also fixes a latent bug: `advanced_features.shortlisting_tool_threshold` had no dynaconf validator, and `prepare_node` reads it without a `getattr` guard, so a settings file lacking the key raised `AttributeError` mid-run.

### Testing
- [x] Tested locally; tests pass — 223 passed (includes all pre-existing shortlister/bind-tools suites unchanged)

One existing test changed: `test_find_tools_composes_query_with_initial_user_message` asserted `find_tools` receives a *pre-joined* query string. Replaced with two tests — one pinning the new plumbing, one asserting `compose_query` is byte-identical to the old `_compose_find_tools_shortlister_query`, so the LLM prompt provably did not change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable tool discovery and ranking strategies.
  - Tool selection can now consider both the current query and conversation context.
  - Added support for fallback strategies when the preferred ranking method is unavailable.
  - Improved tool result formatting with descriptions, parameters, response details, and schemas.

- **Bug Fixes**
  - Preserved existing query display and no-match behavior while improving tool selection reliability.

- **Tests**
  - Added coverage for strategy selection, fallback handling, context-aware queries, and formatted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->