### PR TITLE
feat(cuga-lite): add cosine and hybrid shortlister strategies (#624)

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/prompt_utils.py
@@ -354,6 +354,15 @@ class PromptUtils:
         plan = ShortlisterRouter.resolve(
             settings, seam="discovery", configurable=_configurable_of(run_config)
         )
+        # Below the threshold the cosine stage would add cost without cutting
+        # anything, so the LLM ranks the full set exactly as it does today.
+        # Uniform on purpose: "at or below threshold, shortlisting behaves as it
+        # always did" is easier to reason about than per-strategy exceptions.
+        # Set ``threshold = 0`` to always engage the configured strategy.
+        engage_cosine = len(all_tools) > plan.threshold
+        if not engage_cosine:
+            plan = plan.model_copy(update={"strategy": "llm", "instance": None})
+
         candidates = await run_shortlister(
             plan,
             ShortlistRequest(
@@ -361,6 +370,8 @@ class PromptUtils:
                 tools=all_tools,
                 apps=all_apps,
                 task_context=task_context,
+                top_k=plan.top_k if engage_cosine else None,
+                max_results=plan.max_results if engage_cosine else None,
                 llm=llm,
                 run_config=run_config,
             ),
@@ -399,13 +410,19 @@ class PromptUtils:
         )
 
         plan = ShortlisterRouter.resolve(settings, seam="bind_cap", configurable=_configurable_of(run_config))
+        # ``top_k`` here is the provider cap the caller computed; it is a hard
+        # ceiling, so never let a configured value raise it.
+        effective_top_k = min(top_k, plan.top_k) if plan.top_k else top_k
+        if len(all_tools) <= plan.threshold:
+            plan = plan.model_copy(update={"strategy": "llm", "instance": None})
+
         candidates = await run_shortlister(
             plan,
             ShortlistRequest(
                 query=query,
                 tools=all_tools,
                 apps=all_apps,
-                top_k=top_k,
+                top_k=effective_top_k,
                 llm=llm,
                 run_config=run_config,
                 instructions=instructions,
@@ -421,7 +438,7 @@ class PromptUtils:
                 continue
             seen.add(name)
             ranked.append(name)
-            if len(ranked) >= top_k:
+            if len(ranked) >= effective_top_k:
                 break
         return ranked
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/doc.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/doc.py
@@ -1,0 +1,153 @@
+"""Turn a tool into the short text that gets embedded.
+
+Tool text in practice is much weaker than it looks. Sampling the bundled CRM
+demo: endpoints carry no docstring and no ``summary=``/``description=``, so the
+OpenAPI parser falls back to FastAPI's auto-summary (``"Get Contacts"``) or
+nothing. Names are machine-generated — ``determine_operation_name_strategy``
+only uses a path segment when segments are unique, and ``/contacts/`` collides
+with ``/contacts/{contact_id}``, so names fall back to operationIds:
+``crm_get_contacts_contacts_get``.
+
+So the **name carries most of the signal**, but only once split back into words:
+``crm_get_contacts_contacts_get`` tokenizes badly, ``crm get contacts contacts
+get`` matches "list all contacts" well.
+
+Deliberately excluded from the embedded text: ``args_schema`` JSON, full
+response schemas, param constraints. They are what makes the *LLM* prompt
+expensive, and in a fixed-size vector they dilute signal rather than add it.
+They still reach the agent via the rendered markdown — they are simply not part
+of the ranking.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, List, Optional
+
+from langchain_core.tools import StructuredTool
+
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+_NON_WORD = re.compile(r"[^0-9a-zA-Z]+")
+_WS = re.compile(r"\s+")
+
+#: Trailing HTTP-verb noise that operationId-derived names accumulate.
+_NOISE_SUFFIXES = {"get", "post", "put", "patch", "delete"}
+
+
+def split_identifier(name: str) -> str:
+    """Split a tool identifier into space-separated lowercase words.
+
+    ``crm_get_contacts_contacts__get``  -> ``crm get contacts contacts get``
+    ``getAccountContacts``              -> ``get account contacts``
+    ``crm-get.contacts``                -> ``crm get contacts``
+
+    Duplicate words are kept: repetition in an operationId is genuine emphasis
+    on the entity ("contacts" twice) and helps rather than hurts the match.
+    """
+    if not name:
+        return ""
+    spaced = _CAMEL_BOUNDARY.sub(" ", str(name))
+    spaced = _NON_WORD.sub(" ", spaced)
+    return _WS.sub(" ", spaced).strip().lower()
+
+
+def _response_field_names(response_doc: str, limit: int = 24) -> List[str]:
+    """Pull bare field names out of a rendered response doc.
+
+    We want ``items, total, skip`` — not the JSON Schema they came from. Parsing
+    the already-rendered doc keeps this in step with whatever
+    ``PromptUtils.get_tool_docs`` produces instead of re-walking schemas here.
+    """
+    names: List[str] = []
+    for raw_line in (response_doc or "").splitlines():
+        line = raw_line.strip().lstrip("-*• ").strip()
+        if not line:
+            continue
+        match = re.match(r"^`?([A-Za-z_][A-Za-z0-9_]*)`?\s*[:(]", line)
+        if match:
+            candidate = match.group(1)
+            if candidate not in names:
+                names.append(candidate)
+        if len(names) >= limit:
+            break
+    return names
+
+
+def _param_lines(tool: StructuredTool, limit: int = 24) -> List[str]:
+    """``name: description`` for each parameter, description optional.
+
+    With tool descriptions frequently empty, parameter text is often the only
+    real natural language available for a tool.
+    """
+    schema: Dict[str, Any] = {}
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is not None:
+        try:
+            if hasattr(args_schema, "model_json_schema"):
+                schema = args_schema.model_json_schema()
+            elif hasattr(args_schema, "schema"):
+                schema = args_schema.schema()
+        except (AttributeError, TypeError, ValueError):
+            schema = {}
+    properties = (schema or {}).get("properties") or {}
+    lines: List[str] = []
+    for param_name, spec in list(properties.items())[:limit]:
+        description = ""
+        if isinstance(spec, dict):
+            description = str(spec.get("description") or "").strip()
+        words = split_identifier(param_name)
+        lines.append(f"{words}: {description}" if description else words)
+    return lines
+
+
+def tool_document(
+    tool: StructuredTool,
+    app_name: str = "",
+    response_doc: str = "",
+) -> str:
+    """Build the text embedded for ``tool``.
+
+    Deterministic: the same tool always yields the same string, which is what
+    makes :func:`tool_fingerprint` a valid cache key.
+    """
+    name = getattr(tool, "name", "") or ""
+    description = (getattr(tool, "description", "") or "").strip()
+
+    parts: List[str] = [f"{split_identifier(app_name)} {split_identifier(name)}".strip()]
+    if description:
+        parts.append(description)
+
+    params = _param_lines(tool)
+    if params:
+        parts.append("Parameters: " + "; ".join(params))
+
+    returns = _response_field_names(response_doc)
+    if returns:
+        parts.append("Returns: " + ", ".join(returns))
+
+    return "\n".join(p for p in parts if p)
+
+
+def tool_fingerprint(document: str, model_name: str) -> str:
+    """Cache key for an embedded document.
+
+    Keyed on **content**, not tool name, so an edited description or a changed
+    embedding model re-embeds automatically instead of serving a stale vector.
+    """
+    digest = hashlib.sha256()
+    digest.update((model_name or "").encode("utf-8"))
+    digest.update(b"\x00")
+    digest.update((document or "").encode("utf-8"))
+    return digest.hexdigest()
+
+
+def app_name_for_tool(tool: StructuredTool, fallback: Optional[str] = None) -> str:
+    """Best-effort app name; the registry provider stamps ``_app_name``."""
+    for target in (tool, getattr(tool, "func", None), getattr(tool, "coroutine", None)):
+        if target is None:
+            continue
+        value = getattr(target, "_app_name", None)
+        if value:
+            return str(value)
+    return fallback or ""

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/embedding.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/embedding.py
@@ -1,0 +1,348 @@
+"""Cosine-similarity shortlister — ranks tools without calling an LLM.
+
+Compares one vector built from the user's question against one vector per tool
+(name + description + parameter names + return field names; see ``doc.py``).
+
+Three properties worth knowing before changing anything here:
+
+* **It is a recall device, not a precision device.** ``get_contacts`` (list) and
+  ``get_contact`` (by id) differ by one character and embed almost identically.
+  Use it to cut a large catalogue down for an LLM to finish (``hybrid``), or
+  where only "don't drop the needed tool" matters (the bind-time cap). Issue
+  #150 documented exactly this failure class for the LLM shortlister.
+* **A query must never wait on a model download.** Mirrors the contract in
+  ``knowledge/reranker.py``: if the backend is not ready we start a background
+  load and raise :class:`ShortlisterUnavailableError` so the caller degrades to
+  the LLM strategy for that one call.
+* **Query and task context are blended as vectors, not strings.** Concatenating
+  them lets a long first message drown a short per-step query, which would make
+  every step of a multi-step task retrieve the same tools.
+
+Local (``provider = "local"``, the default) runs entirely offline via fastembed
+— no network call, nothing billed. ``provider = "openai"`` is available when a
+deployment explicitly wants it, and trades those properties for a hosted model.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+import time
+from typing import Any, ClassVar, Dict, List, Sequence, Tuple
+
+import numpy as np
+from loguru import logger
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.doc import (
+    app_name_for_tool,
+    tool_document,
+    tool_fingerprint,
+)
+
+#: Ready backends, keyed by ``provider:model``. Weights load once per process.
+_MODELS: Dict[str, Any] = {}
+_LOADING: set = set()
+_RETRY_AFTER: Dict[str, float] = {}
+_LOCK = threading.Lock()
+
+#: Normalized document vectors, keyed by content fingerprint.
+_VECTORS: Dict[str, np.ndarray] = {}
+
+#: After a failed load (offline / not cached / missing API key) wait this long
+#: before retrying, so a broken deploy does not hammer the network or spam logs.
+_RETRY_COOLDOWN_S = 30.0
+
+#: Never return nothing: an empty result is a dead end for the agent and the
+#: bind-time cap raises on it.
+_MIN_FALLBACK_RESULTS = 3
+
+DEFAULT_PROVIDER = "local"
+
+
+def backend_key(provider: str, model_name: str) -> str:
+    return f"{provider or DEFAULT_PROVIDER}:{model_name}"
+
+
+def _is_asymmetric(model_name: str) -> bool:
+    """Whether the model wants distinct query/passage encodings.
+
+    ``BAAI/bge-*`` models are trained with a query-side instruction prefix.
+    ``all-MiniLM-L6-v2`` (our default) is symmetric — applying bge's prefix to
+    it *degrades* results. Default to symmetric so an unknown model behaves
+    sanely rather than oddly.
+    """
+    lowered = (model_name or "").lower()
+    return "bge" in lowered and "reranker" not in lowered
+
+
+class _LocalBackend:
+    """fastembed, on-device. No network at query time, nothing billed."""
+
+    def __init__(self, model_name: str) -> None:
+        from fastembed import TextEmbedding
+
+        cache_dir = os.environ.get("FASTEMBED_CACHE_PATH")
+        local_files_only = os.environ.get("HF_HUB_OFFLINE", "0") == "1"
+        self._model_name = model_name
+        self._asymmetric = _is_asymmetric(model_name)
+        self._model = TextEmbedding(model_name, cache_dir=cache_dir, local_files_only=local_files_only)
+
+    def _embed_sync(self, texts: Sequence[str], *, as_query: bool) -> np.ndarray:
+        if self._asymmetric:
+            method = self._model.query_embed if as_query else self._model.passage_embed
+        else:
+            method = self._model.embed
+        return np.array([np.asarray(v, dtype=np.float32) for v in method(list(texts))], dtype=np.float32)
+
+    async def aembed(self, texts: Sequence[str], *, as_query: bool) -> np.ndarray:
+        # fastembed is synchronous and CPU-bound; keep it off the event loop.
+        return await asyncio.to_thread(self._embed_sync, texts, as_query=as_query)
+
+
+class _OpenAIBackend:
+    """Hosted embeddings. Opt-in — this makes shortlisting a billed network call.
+
+    ``OpenAIEmbeddings`` already distinguishes documents from queries and
+    batches natively, so no asymmetry heuristic is needed here.
+    """
+
+    def __init__(self, model_name: str) -> None:
+        from langchain_openai import OpenAIEmbeddings
+
+        from cuga.backend.storage.embedding.embedding_service import get_embedding_config
+
+        cfg = get_embedding_config()
+        api_key = cfg.get("api_key") or os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise ShortlisterUnavailableError(
+                "shortlister.embedding_provider = 'openai' but no API key found "
+                "(set OPENAI_API_KEY or storage.embedding.api_key)"
+            )
+        kwargs: Dict[str, Any] = {"model": model_name or "text-embedding-3-small", "api_key": api_key}
+        if cfg.get("base_url"):
+            kwargs["base_url"] = str(cfg["base_url"]).rstrip("/")
+        self._embeddings = OpenAIEmbeddings(**kwargs)
+
+    async def aembed(self, texts: Sequence[str], *, as_query: bool) -> np.ndarray:
+        items = list(texts)
+        if as_query:
+            vectors = [await self._embeddings.aembed_query(t) for t in items]
+        else:
+            vectors = await self._embeddings.aembed_documents(items)
+        return np.array([np.asarray(v, dtype=np.float32) for v in vectors], dtype=np.float32)
+
+
+_BACKENDS = {"local": _LocalBackend, "openai": _OpenAIBackend}
+
+
+def is_ready(provider: str, model_name: str) -> bool:
+    """True if the backend is resident and ranking will not block on a load."""
+    return backend_key(provider, model_name) in _MODELS
+
+
+def _build_backend(provider: str, model_name: str) -> Any:
+    name = (provider or DEFAULT_PROVIDER).strip().lower()
+    builder = _BACKENDS.get(name)
+    if builder is None:
+        raise ShortlisterUnavailableError(
+            f"unknown shortlister.embedding_provider {provider!r}; "
+            f"expected one of {', '.join(sorted(_BACKENDS))}"
+        )
+    return builder(model_name)
+
+
+def prewarm(provider: str, model_name: str) -> bool:
+    """Build the backend synchronously. Returns True on success."""
+    key = backend_key(provider, model_name)
+    if key in _MODELS:
+        return True
+    try:
+        backend = _build_backend(provider, model_name)
+    except Exception as e:
+        with _LOCK:
+            _RETRY_AFTER[key] = time.monotonic() + _RETRY_COOLDOWN_S
+        logger.warning("Shortlister embedding backend {!r} failed to load: {}", key, e)
+        return False
+    with _LOCK:
+        _MODELS[key] = backend
+        _RETRY_AFTER.pop(key, None)
+    logger.info("Shortlister embedding backend ready: {}", key)
+    return True
+
+
+def ensure_loading(provider: str, model_name: str) -> None:
+    """Kick a background load if one is not already running or cooling down."""
+    key = backend_key(provider, model_name)
+    with _LOCK:
+        if key in _MODELS or key in _LOADING:
+            return
+        retry_at = _RETRY_AFTER.get(key)
+        if retry_at is not None and time.monotonic() < retry_at:
+            return
+        _LOADING.add(key)
+
+    def _load() -> None:
+        try:
+            prewarm(provider, model_name)
+        finally:
+            with _LOCK:
+                _LOADING.discard(key)
+
+    threading.Thread(target=_load, name=f"shortlister-embed-load:{key}", daemon=True).start()
+
+
+def reset_caches() -> None:
+    """Clear backend and vector caches. Tests only."""
+    with _LOCK:
+        _MODELS.clear()
+        _LOADING.clear()
+        _RETRY_AFTER.clear()
+        _VECTORS.clear()
+
+
+def _normalize(vectors: np.ndarray) -> np.ndarray:
+    """L2-normalize row-wise; zero rows stay zero (they score 0, never NaN)."""
+    matrix = np.atleast_2d(np.asarray(vectors, dtype=np.float32))
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return matrix / norms
+
+
+class EmbeddingShortlister:
+    """Ranks tools by cosine similarity between query and tool documents."""
+
+    name: ClassVar[str] = "embedding"
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        provider: str = DEFAULT_PROVIDER,
+        query_weight: float = 0.7,
+        min_score: float = 0.15,
+    ) -> None:
+        self._model_name = model_name
+        self._provider = (provider or DEFAULT_PROVIDER).strip().lower()
+        self._query_weight = min(max(float(query_weight), 0.0), 1.0)
+        self._min_score = float(min_score)
+
+    @property
+    def _key(self) -> str:
+        return backend_key(self._provider, self._model_name)
+
+    # -- backend access ----------------------------------------------------
+
+    def _require_backend(self) -> Any:
+        """Return the ready backend, or start loading and signal unavailability."""
+        backend = _MODELS.get(self._key)
+        if backend is not None:
+            return backend
+        ensure_loading(self._provider, self._model_name)
+        raise ShortlisterUnavailableError(
+            f"embedding backend {self._key!r} is not ready yet; loading in the "
+            f"background and serving this call with the fallback strategy"
+        )
+
+    # -- vectors -----------------------------------------------------------
+
+    async def _document_matrix(self, backend: Any, tools: List[Any]) -> np.ndarray:
+        """Normalized document vectors for ``tools``, embedding only cache misses."""
+        from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+        fingerprints: List[str] = []
+        missing_texts: List[str] = []
+        missing_indexes: List[int] = []
+
+        for index, tool in enumerate(tools):
+            try:
+                _, response_doc = PromptUtils.get_tool_docs(tool)
+            except Exception:
+                response_doc = ""
+            document = tool_document(tool, app_name_for_tool(tool), response_doc)
+            # Keyed on the backend, not just the model: two providers serving the
+            # same model name still produce different vector spaces.
+            fingerprint = tool_fingerprint(document, self._key)
+            fingerprints.append(fingerprint)
+            if fingerprint not in _VECTORS:
+                missing_texts.append(document)
+                missing_indexes.append(index)
+
+        if missing_texts:
+            raw = await backend.aembed(missing_texts, as_query=False)
+            normalized = _normalize(raw)
+            for position, index in enumerate(missing_indexes):
+                _VECTORS[fingerprints[index]] = normalized[position]
+
+        return np.vstack([_VECTORS[f] for f in fingerprints])
+
+    async def _query_vector(self, backend: Any, request: ShortlistRequest) -> np.ndarray:
+        """Blend the step query and task context as weighted unit vectors.
+
+        String concatenation would let a long task context dominate a short step
+        query — the weighting would become an accident of relative length.
+        """
+        step = (request.query or "").strip()
+        context = (request.task_context or "").strip()
+
+        texts = [t for t in (step, context) if t]
+        if not texts:
+            raise ShortlisterUnavailableError("empty query — nothing to rank against")
+
+        normalized = _normalize(await backend.aembed(texts, as_query=True))
+        if len(texts) == 1:
+            return normalized[0]
+
+        alpha = self._query_weight
+        blended = alpha * normalized[0] + (1.0 - alpha) * normalized[1]
+        return _normalize(blended)[0]
+
+    # -- ranking -----------------------------------------------------------
+
+    def _select(
+        self,
+        scores: np.ndarray,
+        tools: List[Any],
+        request: ShortlistRequest,
+    ) -> List[Tuple[int, float]]:
+        """Apply ``top_k`` / ``min_score`` / ``max_results``, never returning empty."""
+        limit = request.top_k if request.top_k else len(tools)
+        if request.max_results:
+            limit = min(limit, request.max_results)
+        limit = max(1, min(limit, len(tools)))
+
+        order = np.argsort(-scores)[:limit]
+        kept = [(int(i), float(scores[i])) for i in order if float(scores[i]) >= self._min_score]
+
+        if not kept:
+            # Nothing cleared the floor. Returning nothing is worse than
+            # returning the best guesses: the agent has no next move, and the
+            # bind-time cap raises on an empty ranking.
+            fallback = min(_MIN_FALLBACK_RESULTS, limit, len(tools))
+            kept = [(int(i), float(scores[i])) for i in order[:fallback]]
+        return kept
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        if not request.tools or (request.top_k is not None and request.top_k <= 0):
+            return []
+
+        backend = self._require_backend()
+        document_matrix = await self._document_matrix(backend, request.tools)
+        query_vector = await self._query_vector(backend, request)
+
+        scores = document_matrix @ query_vector
+        selected = self._select(scores, request.tools, request)
+
+        return [
+            ShortlistCandidate(
+                name=request.tools[index].name,
+                score=score,
+                reasoning=f"Cosine similarity {score:.3f} to the query.",
+            )
+            for index, score in selected
+        ]

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/factory.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/factory.py
@@ -21,6 +21,8 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
     ShortlisterStrategy,
     ShortlisterUnavailableError,
 )
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.hybrid import HybridShortlister
 from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
 from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import BUILTIN_STRATEGIES, ShortlisterPlan
 
@@ -36,8 +38,24 @@ def _build_llm(plan: ShortlisterPlan) -> LLMShortlister:
     return LLMShortlister()
 
 
-#: Built-in strategies. Additional rankers register here.
-_BUILDERS: Dict[str, Callable[[ShortlisterPlan], Any]] = {"llm": _build_llm}
+def _build_embedding(plan: ShortlisterPlan) -> EmbeddingShortlister:
+    return EmbeddingShortlister(
+        model_name=plan.embedding_model,
+        provider=plan.embedding_provider,
+        query_weight=plan.query_weight,
+        min_score=plan.min_score,
+    )
+
+
+def _build_hybrid(plan: ShortlisterPlan) -> HybridShortlister:
+    return HybridShortlister(embedding=_build_embedding(plan), llm=_build_llm(plan))
+
+
+_BUILDERS: Dict[str, Callable[[ShortlisterPlan], Any]] = {
+    "llm": _build_llm,
+    "embedding": _build_embedding,
+    "hybrid": _build_hybrid,
+}
 
 
 def _build_from_dotted_path(path: str, plan: ShortlisterPlan) -> Any:

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/hybrid.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/hybrid.py
@@ -1,0 +1,68 @@
+"""Cosine prefilter, then LLM rerank.
+
+Cosine cuts a large catalogue down cheaply (high recall, poor precision on
+near-identical CRUD siblings); the LLM then makes the final selection with full
+schemas in front of it, on a pool small enough to be affordable.
+
+If the embedding leg is unavailable — model still downloading, fastembed
+missing — this degrades to plain LLM shortlisting, which is exactly today's
+behavior, so the degraded path is already well covered by existing tests.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, ClassVar, List
+
+from loguru import logger
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.base import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+
+
+class HybridShortlister:
+    """Embedding prefilter to ``top_k``, then :class:`LLMShortlister` ranks."""
+
+    name: ClassVar[str] = "hybrid"
+
+    def __init__(self, embedding: EmbeddingShortlister, llm: LLMShortlister) -> None:
+        self._embedding = embedding
+        self._llm = llm
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        if not request.tools:
+            return []
+
+        pool: List[Any] = request.tools
+
+        # Prefilter only when there is something to cut. At or below the cut
+        # width the LLM would see the same set either way.
+        width = request.top_k or 0
+        if width and len(pool) > width:
+            try:
+                prefiltered = await self._embedding.shortlist(
+                    dataclasses.replace(
+                        request,
+                        top_k=width,
+                        max_results=None,  # the cut width governs here, not the render cap
+                    )
+                )
+                by_name = {t.name: t for t in pool}
+                narrowed = [by_name[c.name] for c in prefiltered if c.name in by_name]
+                if narrowed:
+                    logger.debug("Hybrid shortlister: cosine cut {} tools to {}", len(pool), len(narrowed))
+                    pool = narrowed
+            except ShortlisterUnavailableError as e:
+                logger.warning(
+                    "Hybrid shortlister: embedding leg unavailable ({}); ranking all {} tools "
+                    "with the LLM for this call",
+                    e,
+                    len(pool),
+                )
+
+        return await self._llm.shortlist(dataclasses.replace(request, tools=pool))

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/plan.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/shortlister/plan.py
@@ -19,16 +19,28 @@ from pydantic import BaseModel, Field
 
 Seam = Literal["discovery", "bind_cap"]
 
-BUILTIN_STRATEGIES = ("llm",)
+BUILTIN_STRATEGIES = ("llm", "embedding", "hybrid")
 
 # Defaults live here, not in settings.toml, so a missing section can never break
 # resolution. settings.toml restates them for discoverability.
 DEFAULT_STRATEGY = "llm"
 DEFAULT_FALLBACK_STRATEGY = "llm"
+DEFAULT_THRESHOLD = 128
+DEFAULT_TOP_K = 128
+DEFAULT_MAX_RESULTS = 10
+DEFAULT_MIN_SCORE = 0.15
+DEFAULT_QUERY_WEIGHT = 0.7
+DEFAULT_EMBEDDING_PROVIDER = "local"
+DEFAULT_EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 
-_INT_FIELDS: tuple = ()
-_FLOAT_FIELDS: tuple = ()
-_STR_FIELDS = ("strategy", "fallback_strategy")
+_INT_FIELDS = ("threshold", "top_k", "max_results")
+_FLOAT_FIELDS = ("min_score", "query_weight")
+_STR_FIELDS = (
+    "strategy",
+    "fallback_strategy",
+    "embedding_provider",
+    "embedding_model",
+)
 ALL_FIELDS = _INT_FIELDS + _FLOAT_FIELDS + _STR_FIELDS
 
 #: ``configurable`` keys, e.g. ``shortlister_strategy``.
@@ -41,15 +53,35 @@ class ShortlisterPlan(BaseModel):
     seam: Seam = "discovery"
     strategy: str = DEFAULT_STRATEGY
     fallback_strategy: str = DEFAULT_FALLBACK_STRATEGY
+    threshold: int = DEFAULT_THRESHOLD
+    top_k: int = DEFAULT_TOP_K
+    max_results: int = DEFAULT_MAX_RESULTS
+    min_score: float = DEFAULT_MIN_SCORE
+    query_weight: float = DEFAULT_QUERY_WEIGHT
+    embedding_provider: str = DEFAULT_EMBEDDING_PROVIDER
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL
     #: Live strategy object injected via the SDK; bypasses ``strategy``.
     instance: Optional[Any] = Field(default=None, exclude=True)
     notes: List[str] = Field(default_factory=list)
 
     model_config = {"arbitrary_types_allowed": True}
 
+    @property
+    def is_llm_only(self) -> bool:
+        """True when no cosine stage can run — i.e. today's behavior exactly."""
+        return self.instance is None and self.strategy == "llm"
+
     def cache_key(self) -> str:
         """Identity for the strategy-instance cache (excludes per-call knobs)."""
-        return "|".join([self.strategy, self.fallback_strategy])
+        return "|".join(
+            [
+                self.strategy,
+                self.fallback_strategy,
+                self.embedding_provider,
+                self.embedding_model,
+                f"qw={self.query_weight}",
+            ]
+        )
 
 
 def _coerce(field_name: str, raw: Any) -> Any:
@@ -131,6 +163,10 @@ class ShortlisterRouter:
                 f"or a dotted class path)"
             )
             plan.strategy = DEFAULT_STRATEGY
+        if plan.top_k < 0:
+            plan.top_k = 0
+        if plan.max_results <= 0:
+            plan.max_results = DEFAULT_MAX_RESULTS
         return plan
 
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_defaults.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_defaults.py
@@ -1,0 +1,221 @@
+"""Defaults and the `threshold` contract.
+
+The load-bearing guarantee of this feature: with the default settings, or at or
+below `threshold` candidates, shortlisting behaves exactly as it did before the
+strategy seam existed — same prompt, same LLM call, no embedding work.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    ShortlisterRouter,
+    clear_instance_cache,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.plan import (
+    DEFAULT_MAX_RESULTS,
+    DEFAULT_THRESHOLD,
+    DEFAULT_TOP_K,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_instance_cache()
+    yield
+    clear_instance_cache()
+
+
+def _tool(name: str) -> StructuredTool:
+    def fn(**kwargs):
+        return name
+
+    fn.__name__ = name
+    return StructuredTool.from_function(func=fn, name=name, description=f"{name} description")
+
+
+def _tools(count: int):
+    return [_tool(f"tool_{i}") for i in range(count)]
+
+
+def _settings(**shortlister_overrides):
+    """Minimal settings stand-in exposing only what the router reads."""
+    return SimpleNamespace(shortlister=SimpleNamespace(**shortlister_overrides))
+
+
+# --- defaults ---------------------------------------------------------------
+
+
+def test_defaults_are_llm_and_128():
+    """Shipping defaults: LLM strategy, K=128, threshold=128, max_results=10."""
+    plan = ShortlisterRouter.resolve(SimpleNamespace())
+    assert plan.strategy == "llm"
+    assert plan.threshold == DEFAULT_THRESHOLD == 128
+    assert plan.top_k == DEFAULT_TOP_K == 128
+    assert plan.max_results == DEFAULT_MAX_RESULTS == 10
+    assert plan.is_llm_only is True
+
+
+def test_real_settings_defaults_match_plan_defaults():
+    """settings.toml and plan.py must not drift apart."""
+    from cuga.config import settings
+
+    plan = ShortlisterRouter.resolve(settings)
+    assert plan.strategy == "llm"
+    assert plan.threshold == 128
+    assert plan.top_k == 128
+    assert plan.max_results == 10
+
+
+def test_missing_shortlister_section_is_safe():
+    """A settings object with no [shortlister] must not raise."""
+    plan = ShortlisterRouter.resolve(SimpleNamespace())
+    assert plan.strategy == "llm"
+
+
+# --- the threshold contract -------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_count,expect_cosine",
+    [(128, False), (129, True)],
+    ids=["at-threshold-unchanged", "above-threshold-engages"],
+)
+async def test_threshold_gates_the_cosine_stage(tool_count, expect_cosine):
+    """At or below `threshold`, the cosine strategy must not run at all."""
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    tools = _tools(tool_count)
+    llm_result = AsyncMock(return_value=_empty_result())
+    embed_result = AsyncMock(return_value=_empty_result())
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm.LLMShortlister.shortlist",
+            llm_result,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding.EmbeddingShortlister.shortlist",
+            embed_result,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(strategy="embedding", threshold=128),
+        ),
+    ):
+        await PromptUtils.find_tools(query="q", all_tools=tools, all_apps=[])
+
+    assert embed_result.await_count == (1 if expect_cosine else 0)
+    assert llm_result.await_count == (0 if expect_cosine else 1)
+
+
+@pytest.mark.asyncio
+async def test_threshold_zero_always_engages():
+    """`threshold = 0` opts out of the gate entirely."""
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    embed_result = AsyncMock(return_value=_empty_result())
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding.EmbeddingShortlister.shortlist",
+            embed_result,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(strategy="embedding", threshold=0),
+        ),
+    ):
+        await PromptUtils.find_tools(query="q", all_tools=_tools(2), all_apps=[])
+
+    embed_result.assert_awaited_once()
+
+
+# --- K handling -------------------------------------------------------------
+
+
+def test_top_k_negative_clamps_to_zero():
+    plan = ShortlisterRouter.resolve(_settings(top_k=-5))
+    assert plan.top_k == 0
+
+
+def test_max_results_non_positive_falls_back_to_default():
+    plan = ShortlisterRouter.resolve(_settings(max_results=0))
+    assert plan.max_results == DEFAULT_MAX_RESULTS
+
+
+@pytest.mark.asyncio
+async def test_bind_cap_k_never_exceeds_caller_cap():
+    """A configured top_k may lower the bind cap, never raise it past the provider limit."""
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    tools = _tools(200)
+    captured = {}
+
+    async def _capture(self, request):
+        captured["top_k"] = request.top_k
+        return _empty_result()
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm.LLMShortlister.shortlist",
+            _capture,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(top_k=9999, threshold=0),
+        ),
+    ):
+        await PromptUtils.shortlist_tool_names(query="q", all_tools=tools, all_apps=[], top_k=16)
+
+    assert captured["top_k"] == 16, "caller cap must win over a larger configured top_k"
+
+
+@pytest.mark.asyncio
+async def test_configured_top_k_can_lower_bind_cap():
+    from cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils import PromptUtils
+
+    captured = {}
+
+    async def _capture(self, request):
+        captured["top_k"] = request.top_k
+        return _empty_result()
+
+    with (
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm.LLMShortlister.shortlist",
+            _capture,
+        ),
+        patch(
+            "cuga.backend.cuga_graph.nodes.cuga_lite.prompt_utils.settings",
+            _settings(top_k=4, threshold=0),
+        ),
+    ):
+        await PromptUtils.shortlist_tool_names(query="q", all_tools=_tools(50), all_apps=[], top_k=32)
+
+    assert captured["top_k"] == 4
+
+
+# --- distinct from the older threshold --------------------------------------
+
+
+def test_shortlister_threshold_is_not_shortlisting_tool_threshold():
+    """Two different settings, two different meanings — easy to confuse.
+
+    `advanced_features.shortlisting_tool_threshold` (35) decides when tools hide
+    behind find_tools in the prompt. `shortlister.threshold` (128) decides when
+    the cosine stage engages inside the shortlister.
+    """
+    from cuga.config import settings
+
+    assert settings.advanced_features.shortlisting_tool_threshold == 35
+    assert ShortlisterRouter.resolve(settings).threshold == 128
+
+
+def _empty_result():
+    return []

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_doc.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_doc.py
@@ -1,0 +1,106 @@
+"""Tool→text conversion for the cosine ranker.
+
+`split_identifier` is the single highest-leverage detail in the cosine path:
+real tool names are machine-generated (`crm_get_contacts_contacts_get`) and
+embed poorly until split back into words.
+"""
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.doc import (
+    app_name_for_tool,
+    split_identifier,
+    tool_document,
+    tool_fingerprint,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- split_identifier -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # The real shape CRM produces: path segments collide, so names fall
+        # back to FastAPI operationIds.
+        ("crm_get_contacts_contacts_get", "crm get contacts contacts get"),
+        ("crm_get_contacts_contacts__get", "crm get contacts contacts get"),
+        ("getAccountContacts", "get account contacts"),
+        ("crm-get.contacts", "crm get contacts"),
+        ("HTTPResponseCode", "http response code"),
+        ("tool_v2_lookup", "tool v2 lookup"),
+        ("", ""),
+        ("___", ""),
+    ],
+)
+def test_split_identifier(raw, expected):
+    assert split_identifier(raw) == expected
+
+
+# --- tool_document ----------------------------------------------------------
+
+
+class _ContactArgs(BaseModel):
+    email: str = Field(..., description="filter by email address")
+    limit: int = Field(default=10, description="")
+
+
+def _tool(name="crm_get_contacts_contacts_get", description="Get Contacts", args=_ContactArgs):
+    def fn(**kwargs):
+        return None
+
+    fn.__name__ = "fn"
+    return StructuredTool.from_function(func=fn, name=name, description=description, args_schema=args)
+
+
+def test_tool_document_includes_the_signal_bearing_fields():
+    document = tool_document(_tool(), app_name="crm", response_doc="- items (array): rows\n- total (int)")
+
+    assert "crm get contacts contacts get" in document
+    assert "Get Contacts" in document
+    assert "email: filter by email address" in document
+    assert "Returns: items, total" in document
+
+
+def test_tool_document_excludes_raw_schema_noise():
+    """args_schema JSON is what makes the LLM prompt expensive; in a fixed-size
+    vector it dilutes signal rather than adding to it."""
+    document = tool_document(_tool(), app_name="crm")
+    assert "properties" not in document
+    assert "$defs" not in document
+    assert "anyOf" not in document
+
+
+def test_tool_document_handles_missing_description_and_params():
+    def fn():
+        return None
+
+    fn.__name__ = "bare"
+    tool = StructuredTool.from_function(func=fn, name="bare_tool", description="")
+    assert "bare tool" in tool_document(tool, app_name="app")
+
+
+def test_tool_document_is_deterministic():
+    a, b = tool_document(_tool(), "crm"), tool_document(_tool(), "crm")
+    assert a == b
+
+
+# --- fingerprints -----------------------------------------------------------
+
+
+def test_fingerprint_changes_with_content_and_model():
+    base = tool_fingerprint("doc", "model")
+    assert tool_fingerprint("doc", "model") == base
+    assert tool_fingerprint("doc changed", "model") != base
+    assert tool_fingerprint("doc", "other-model") != base
+
+
+def test_app_name_from_registry_metadata():
+    tool = _tool()
+    tool.func._app_name = "crm"
+    assert app_name_for_tool(tool) == "crm"
+    assert app_name_for_tool(_tool(), fallback="fallback_app") == "fallback_app"

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_embedding.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_embedding.py
@@ -1,0 +1,335 @@
+"""EmbeddingShortlister: ranking, selection, query blending, cold start.
+
+Uses a deterministic bag-of-words fake embedder rather than a real model, so
+these run offline and assert exact ordering. Real-model behavior (does cosine
+actually pick the right tool) is a separate, slower concern — see the CRUD
+sibling harness.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import embedding as embedding_module
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import (
+    EmbeddingShortlister,
+    _is_asymmetric,
+    is_ready,
+    reset_caches,
+)
+
+pytestmark = pytest.mark.unit
+
+VOCAB = ["contact", "account", "email", "delete", "create", "list", "weather", "flight"]
+MODEL = "test-model"
+
+
+class FakeBackend:
+    """Bag-of-words backend: one dimension per vocabulary word."""
+
+    def __init__(self):
+        self.embed_calls = []
+        self.query_calls = []
+        self.passage_calls = []
+
+    async def aembed(self, texts, *, as_query):
+        items = list(texts)
+        self.embed_calls.append(items)
+        (self.query_calls if as_query else self.passage_calls).append(items)
+        return np.array(
+            [np.array([float((t or "").lower().count(w)) for w in VOCAB], dtype=np.float32) for t in items],
+            dtype=np.float32,
+        )
+
+
+class FakeTextEmbedding:
+    """Stand-in for fastembed's TextEmbedding, to test the local backend."""
+
+    def __init__(self):
+        self.embed_calls = []
+        self.query_calls = []
+        self.passage_calls = []
+
+    def _vectors(self, texts):
+        return [np.array([float((t or "").lower().count(w)) for w in VOCAB], dtype=np.float32) for t in texts]
+
+    def embed(self, texts):
+        self.embed_calls.append(list(texts))
+        return self._vectors(texts)
+
+    def query_embed(self, texts):
+        self.query_calls.append(list(texts))
+        return self._vectors(texts)
+
+    def passage_embed(self, texts):
+        self.passage_calls.append(list(texts))
+        return self._vectors(texts)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    reset_caches()
+    yield
+    reset_caches()
+
+
+@pytest.fixture
+def fake_model():
+    backend = FakeBackend()
+    embedding_module._MODELS[embedding_module.backend_key("local", MODEL)] = backend
+    return backend
+
+
+def _tool(name: str, description: str = "") -> StructuredTool:
+    def fn(**kwargs):
+        return name
+
+    fn.__name__ = name
+    return StructuredTool.from_function(func=fn, name=name, description=description)
+
+
+def _request(query: str, tools, **kwargs) -> ShortlistRequest:
+    return ShortlistRequest(query=query, tools=tools, apps=[], **kwargs)
+
+
+# --- ranking ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ranks_by_cosine_similarity(fake_model):
+    tools = [
+        _tool("weather_lookup", "weather forecast"),
+        _tool("contact_finder", "find a contact by email"),
+        _tool("flight_booker", "book a flight"),
+    ]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    result = await strategy.shortlist(_request("find the contact email", tools))
+
+    assert result[0].name == "contact_finder"
+    assert result[0].score > result[-1].score
+
+
+@pytest.mark.asyncio
+async def test_reasoning_is_populated_for_rendering(fake_model):
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    result = await strategy.shortlist(_request("contact", [_tool("contact_finder", "contact")]))
+    assert "Cosine similarity" in result[0].reasoning
+
+
+@pytest.mark.asyncio
+async def test_never_returns_empty_even_when_nothing_clears_min_score(fake_model):
+    """An empty result is a dead end for the agent and makes the bind cap raise."""
+    tools = [_tool("weather_lookup", "weather"), _tool("flight_booker", "flight")]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.99)
+    result = await strategy.shortlist(_request("contact email", tools))
+
+    assert result, "must fall back to best-guess rather than returning nothing"
+    assert len(result) <= 3
+
+
+@pytest.mark.asyncio
+async def test_min_score_filters_when_some_clear_it(fake_model):
+    tools = [_tool("contact_finder", "contact email"), _tool("weather_lookup", "weather")]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.5)
+    result = await strategy.shortlist(_request("contact email", tools))
+
+    assert [c.name for c in result] == ["contact_finder"]
+
+
+@pytest.mark.asyncio
+async def test_top_k_and_max_results_cap_the_result(fake_model):
+    tools = [_tool(f"contact_{i}", "contact email") for i in range(10)]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+
+    assert len(await strategy.shortlist(_request("contact", tools, top_k=3))) == 3
+    assert len(await strategy.shortlist(_request("contact", tools, max_results=2))) == 2
+    # The tighter of the two wins.
+    capped = await strategy.shortlist(_request("contact", tools, top_k=8, max_results=4))
+    assert len(capped) == 4
+
+
+@pytest.mark.asyncio
+async def test_top_k_zero_returns_nothing(fake_model):
+    strategy = EmbeddingShortlister(MODEL)
+    result = await strategy.shortlist(_request("contact", [_tool("contact_finder")], top_k=0))
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_empty_tools_returns_empty(fake_model):
+    strategy = EmbeddingShortlister(MODEL)
+    assert await strategy.shortlist(_request("contact", [])) == []
+
+
+# --- query blending ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_and_task_context_are_embedded_separately(fake_model):
+    """Not concatenated — a long context must not swamp a short step query."""
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    await strategy.shortlist(
+        _request("list contacts", [_tool("contact_finder", "contact")], task_context="book a flight")
+    )
+    assert fake_model.embed_calls[-1] == ["list contacts", "book a flight"]
+
+
+@pytest.mark.asyncio
+async def test_query_weight_shifts_ranking_toward_the_step_query(fake_model):
+    """The whole point of vector blending: the weighting is explicit, not a
+    side effect of how long each string happens to be."""
+    tools = [_tool("contact_finder", "contact"), _tool("flight_booker", "flight")]
+    request = dict(task_context="book a flight flight flight flight flight")
+
+    query_heavy = EmbeddingShortlister(MODEL, query_weight=1.0, min_score=0.0)
+    context_heavy = EmbeddingShortlister(MODEL, query_weight=0.0, min_score=0.0)
+
+    top_query = (await query_heavy.shortlist(_request("contact", tools, **request)))[0]
+    top_context = (await context_heavy.shortlist(_request("contact", tools, **request)))[0]
+
+    assert top_query.name == "contact_finder"
+    assert top_context.name == "flight_booker"
+
+
+@pytest.mark.asyncio
+async def test_missing_task_context_uses_query_alone(fake_model):
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    await strategy.shortlist(_request("list contacts", [_tool("contact_finder", "contact")]))
+    assert fake_model.embed_calls[-1] == ["list contacts"]
+
+
+@pytest.mark.asyncio
+async def test_blank_query_and_context_is_unavailable(fake_model):
+    strategy = EmbeddingShortlister(MODEL)
+    with pytest.raises(ShortlisterUnavailableError):
+        await strategy.shortlist(_request("   ", [_tool("contact_finder")], task_context="  "))
+
+
+# --- caching ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_vectors_are_cached_across_calls(fake_model):
+    tools = [_tool("contact_finder", "contact"), _tool("weather_lookup", "weather")]
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+
+    await strategy.shortlist(_request("contact", tools))
+    documents_embedded_first = sum(len(c) for c in fake_model.embed_calls[:-1])
+    calls_after_first = len(fake_model.embed_calls)
+
+    await strategy.shortlist(_request("weather", tools))
+
+    # Second run embeds only the query, not the two tool documents again.
+    assert documents_embedded_first == 2
+    assert len(fake_model.embed_calls) == calls_after_first + 1
+    assert fake_model.embed_calls[-1] == ["weather"]
+
+
+@pytest.mark.asyncio
+async def test_changed_description_reembeds(fake_model):
+    strategy = EmbeddingShortlister(MODEL, min_score=0.0)
+    await strategy.shortlist(_request("contact", [_tool("t", "contact")]))
+    before = len(fake_model.embed_calls)
+    await strategy.shortlist(_request("contact", [_tool("t", "totally different email text")]))
+    # One call for the new document + one for the query.
+    assert len(fake_model.embed_calls) == before + 2
+
+
+# --- cold start -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unloaded_model_raises_unavailable_and_starts_background_load():
+    """A user query must never block on a model download."""
+    strategy = EmbeddingShortlister("not-loaded-model")
+    with patch.object(embedding_module, "ensure_loading") as mock_loading:
+        with pytest.raises(ShortlisterUnavailableError):
+            await strategy.shortlist(_request("contact", [_tool("contact_finder")]))
+    mock_loading.assert_called_once_with("local", "not-loaded-model")
+
+
+def test_is_ready_reflects_residency(fake_model):
+    assert is_ready("local", MODEL) is True
+    assert is_ready("local", "some-other-model") is False
+
+
+def test_failed_load_sets_a_retry_cooldown():
+    """An airgapped deploy must not hammer the network on every call."""
+    with patch.object(embedding_module, "_build_backend", side_effect=OSError("offline")):
+        assert embedding_module.prewarm("local", "missing-model") is False
+    assert embedding_module.backend_key("local", "missing-model") in embedding_module._RETRY_AFTER
+
+    with patch.object(embedding_module, "_build_backend") as builder:
+        embedding_module.ensure_loading("local", "missing-model")
+        builder.assert_not_called()
+
+
+# --- symmetric vs asymmetric ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model_name,expected",
+    [
+        ("sentence-transformers/all-MiniLM-L6-v2", False),
+        ("all-MiniLM-L6-v2", False),
+        ("BAAI/bge-small-en-v1.5", True),
+        ("BAAI/bge-reranker-base", False),
+        ("some-unknown-model", False),
+    ],
+)
+def test_asymmetric_detection(model_name, expected):
+    """bge wants a query prefix; MiniLM does not, and applying one degrades it.
+    Unknown models default to symmetric."""
+    assert _is_asymmetric(model_name) is expected
+
+
+def _local_backend_with(model_name: str, fake: "FakeTextEmbedding"):
+    backend = embedding_module._LocalBackend.__new__(embedding_module._LocalBackend)
+    backend._model_name = model_name
+    backend._asymmetric = embedding_module._is_asymmetric(model_name)
+    backend._model = fake
+    return backend
+
+
+@pytest.mark.asyncio
+async def test_bge_backend_uses_query_and_passage_encoders():
+    fake = FakeTextEmbedding()
+    backend = _local_backend_with("BAAI/bge-small-en-v1.5", fake)
+
+    await backend.aembed(["a document"], as_query=False)
+    await backend.aembed(["a query"], as_query=True)
+
+    assert fake.passage_calls == [["a document"]]
+    assert fake.query_calls == [["a query"]]
+    assert not fake.embed_calls
+
+
+@pytest.mark.asyncio
+async def test_minilm_backend_uses_the_symmetric_encoder():
+    """Applying bge's query prefix to MiniLM degrades it, so it must not be used."""
+    fake = FakeTextEmbedding()
+    backend = _local_backend_with(MODEL, fake)
+
+    await backend.aembed(["a document"], as_query=False)
+    await backend.aembed(["a query"], as_query=True)
+
+    assert fake.embed_calls == [["a document"], ["a query"]]
+    assert not fake.query_calls and not fake.passage_calls
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_is_unavailable_not_silently_ignored():
+    """A provider typo must surface, not quietly fall back to local."""
+    with pytest.raises(ShortlisterUnavailableError, match="unknown shortlister.embedding_provider"):
+        embedding_module._build_backend("gpt4all", MODEL)
+
+
+def test_provider_is_part_of_the_backend_identity():
+    """Two providers serving the same model name are different vector spaces."""
+    assert embedding_module.backend_key("local", MODEL) != embedding_module.backend_key("openai", MODEL)

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_factory.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_factory.py
@@ -15,6 +15,8 @@ from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
     resolve_shortlister,
     run_shortlister,
 )
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.hybrid import HybridShortlister
 from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
 
 pytestmark = pytest.mark.unit
@@ -53,8 +55,12 @@ def _settings(**kwargs):
 # --- built-ins --------------------------------------------------------------
 
 
-def test_builtin_llm_strategy_resolves():
-    assert isinstance(resolve_shortlister(ShortlisterPlan(strategy="llm")), LLMShortlister)
+@pytest.mark.parametrize(
+    "name,expected",
+    [("llm", LLMShortlister), ("embedding", EmbeddingShortlister), ("hybrid", HybridShortlister)],
+)
+def test_builtin_strategies_resolve(name, expected):
+    assert isinstance(resolve_shortlister(ShortlisterPlan(strategy=name)), expected)
 
 
 def test_unknown_bare_name_is_rewritten_by_the_router():
@@ -79,6 +85,11 @@ def test_dotted_path_loads_a_custom_strategy():
     assert isinstance(strategy, CustomShortlister)
 
 
+def test_dotted_path_receives_the_plan():
+    plan = ShortlisterPlan(strategy=f"{__name__}.CustomShortlister", top_k=7)
+    assert resolve_shortlister(plan).plan.top_k == 7
+
+
 def test_broken_dotted_path_falls_back_rather_than_crashing():
     plan = ShortlisterPlan(strategy="does.not.Exist", fallback_strategy="llm")
     assert isinstance(resolve_shortlister(plan), LLMShortlister)
@@ -87,7 +98,74 @@ def test_broken_dotted_path_falls_back_rather_than_crashing():
 # --- precedence -------------------------------------------------------------
 
 
+def test_configurable_beats_settings():
+    plan = ShortlisterRouter.resolve(
+        _settings(strategy="llm", top_k=99),
+        configurable={"shortlister_strategy": "embedding", "shortlister_top_k": 12},
+    )
+    assert plan.strategy == "embedding"
+    assert plan.top_k == 12
+
+
+def test_per_seam_section_beats_global():
+    settings = SimpleNamespace(
+        shortlister=SimpleNamespace(
+            strategy="llm",
+            bind_cap=SimpleNamespace(strategy="embedding"),
+            discovery=SimpleNamespace(strategy="hybrid"),
+        )
+    )
+    assert ShortlisterRouter.resolve(settings, seam="bind_cap").strategy == "embedding"
+    assert ShortlisterRouter.resolve(settings, seam="discovery").strategy == "hybrid"
+
+
+def test_override_beats_configurable():
+    plan = ShortlisterRouter.resolve(
+        _settings(strategy="llm"),
+        configurable={"shortlister_strategy": "embedding"},
+        override=SimpleNamespace(strategy="hybrid"),
+    )
+    assert plan.strategy == "hybrid"
+
+
+def test_injected_instance_wins_over_named_strategy():
+    custom = CustomShortlister()
+    plan = ShortlisterRouter.resolve(_settings(strategy="embedding"), override=custom)
+    assert resolve_shortlister(plan) is custom
+
+
+def test_env_style_string_values_are_coerced():
+    """Env vars arrive as strings; ints/floats/bools must still land correctly."""
+    plan = ShortlisterRouter.resolve(_settings(top_k="64", min_score="0.42", threshold="256"))
+    assert plan.top_k == 64
+    assert plan.min_score == pytest.approx(0.42)
+    assert plan.threshold == 256
+
+
+def test_garbage_value_falls_through_to_the_default():
+    plan = ShortlisterRouter.resolve(_settings(top_k="not-a-number"))
+    assert plan.top_k == 128
+
+
 # --- caching ----------------------------------------------------------------
+
+
+def test_instances_are_cached_so_the_model_loads_once():
+    a = resolve_shortlister(ShortlisterPlan(strategy="embedding"))
+    b = resolve_shortlister(ShortlisterPlan(strategy="embedding"))
+    assert a is b
+
+
+def test_different_embedding_models_get_different_instances():
+    a = resolve_shortlister(ShortlisterPlan(strategy="embedding", embedding_model="model-a"))
+    b = resolve_shortlister(ShortlisterPlan(strategy="embedding", embedding_model="model-b"))
+    assert a is not b
+
+
+def test_per_call_knobs_do_not_fragment_the_cache():
+    a = resolve_shortlister(ShortlisterPlan(strategy="embedding", top_k=10))
+    b = resolve_shortlister(ShortlisterPlan(strategy="embedding", top_k=99))
+    assert a is b
 
 
 # --- fallback ---------------------------------------------------------------
@@ -132,29 +210,3 @@ async def test_ordinary_errors_are_not_swallowed():
     plan = ShortlisterPlan(strategy="embedding", instance=Boom())
     with pytest.raises(RuntimeError, match="ranking blew up"):
         await run_shortlister(plan, ShortlistRequest(query="q", tools=[], apps=[]))
-
-
-def test_configurable_beats_settings():
-    plan = ShortlisterRouter.resolve(
-        _settings(strategy="llm"), configurable={"shortlister_strategy": f"{__name__}.CustomShortlister"}
-    )
-    assert plan.strategy == f"{__name__}.CustomShortlister"
-
-
-def test_per_seam_section_beats_global():
-    dotted = f"{__name__}.CustomShortlister"
-    settings = SimpleNamespace(
-        shortlister=SimpleNamespace(strategy="llm", bind_cap=SimpleNamespace(strategy=dotted))
-    )
-    assert ShortlisterRouter.resolve(settings, seam="bind_cap").strategy == dotted
-    assert ShortlisterRouter.resolve(settings, seam="discovery").strategy == "llm"
-
-
-def test_injected_instance_wins_over_named_strategy():
-    custom = CustomShortlister()
-    plan = ShortlisterRouter.resolve(_settings(strategy="llm"), override=custom)
-    assert resolve_shortlister(plan) is custom
-
-
-def test_instances_are_cached():
-    assert resolve_shortlister(ShortlisterPlan()) is resolve_shortlister(ShortlisterPlan())

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_hybrid.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_hybrid.py
@@ -1,0 +1,105 @@
+"""HybridShortlister: cosine prefilters, the LLM decides."""
+
+from typing import Any, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import (
+    ShortlistCandidate,
+    ShortlistRequest,
+    ShortlisterUnavailableError,
+)
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import EmbeddingShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.hybrid import HybridShortlister
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.llm import LLMShortlister
+
+pytestmark = pytest.mark.unit
+
+
+def _tool(name: str) -> StructuredTool:
+    def fn(**kwargs):
+        return name
+
+    fn.__name__ = name
+    return StructuredTool.from_function(func=fn, name=name, description=name)
+
+
+def _tools(n: int) -> List[StructuredTool]:
+    return [_tool(f"tool_{i}") for i in range(n)]
+
+
+def _request(tools, **kwargs) -> ShortlistRequest:
+    return ShortlistRequest(query="find contacts", tools=tools, apps=[], **kwargs)
+
+
+class _RecordingLLM(LLMShortlister):
+    def __init__(self):
+        super().__init__()
+        self.seen: List[Any] = []
+
+    async def shortlist(self, request: ShortlistRequest) -> List[ShortlistCandidate]:
+        self.seen.append([t.name for t in request.tools])
+        return [ShortlistCandidate(name=request.tools[0].name)]
+
+
+def _hybrid(embedding=None, llm=None):
+    return HybridShortlister(embedding=embedding or EmbeddingShortlister("model"), llm=llm or _RecordingLLM())
+
+
+@pytest.mark.asyncio
+async def test_cosine_narrows_the_pool_before_the_llm_sees_it():
+    llm = _RecordingLLM()
+    prefiltered = [ShortlistCandidate(name=f"tool_{i}") for i in range(5)]
+
+    with patch.object(EmbeddingShortlister, "shortlist", AsyncMock(return_value=prefiltered)):
+        await _hybrid(llm=llm).shortlist(_request(_tools(100), top_k=5))
+
+    assert llm.seen == [[f"tool_{i}" for i in range(5)]]
+
+
+@pytest.mark.asyncio
+async def test_prefilter_is_skipped_when_the_pool_already_fits():
+    """Below the cut width the LLM would see the same set either way."""
+    llm = _RecordingLLM()
+    embed = AsyncMock()
+
+    with patch.object(EmbeddingShortlister, "shortlist", embed):
+        await _hybrid(llm=llm).shortlist(_request(_tools(4), top_k=10))
+
+    embed.assert_not_awaited()
+    assert llm.seen == [[f"tool_{i}" for i in range(4)]]
+
+
+@pytest.mark.asyncio
+async def test_llm_ordering_wins():
+    llm_result = [ShortlistCandidate(name="tool_9"), ShortlistCandidate(name="tool_1")]
+    prefiltered = [ShortlistCandidate(name=f"tool_{i}") for i in range(10)]
+
+    with (
+        patch.object(EmbeddingShortlister, "shortlist", AsyncMock(return_value=prefiltered)),
+        patch.object(LLMShortlister, "shortlist", AsyncMock(return_value=llm_result)),
+    ):
+        # A plain LLMShortlister, so the patch above actually applies.
+        result = await _hybrid(llm=LLMShortlister()).shortlist(_request(_tools(50), top_k=10))
+
+    assert [c.name for c in result] == ["tool_9", "tool_1"]
+
+
+@pytest.mark.asyncio
+async def test_degrades_to_plain_llm_when_embeddings_are_unavailable():
+    """Cold start must not break discovery — this path is exactly today's behavior."""
+    llm = _RecordingLLM()
+    unavailable = AsyncMock(side_effect=ShortlisterUnavailableError("still downloading"))
+
+    with patch.object(EmbeddingShortlister, "shortlist", unavailable):
+        result = await _hybrid(llm=llm).shortlist(_request(_tools(50), top_k=10))
+
+    assert llm.seen == [[f"tool_{i}" for i in range(50)]], "LLM must see the full pool"
+    assert result
+
+
+@pytest.mark.asyncio
+async def test_empty_tools_short_circuits():
+    assert await _hybrid().shortlist(_request([])) == []

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_real_model.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/tests/test_shortlister_real_model.py
@@ -1,0 +1,149 @@
+"""Real-embedding accuracy checks — no fake embedder.
+
+Marked ``stability``: excluded from the default run because a cold cache
+downloads ~90MB. Run with ``uv run pytest -m stability -k shortlister_real``.
+
+The tool names here are the real shapes CUGA produces, not idealized ones:
+CRM's ``/contacts/`` and ``/contacts/{contact_id}`` collide on path segment 1,
+so ``determine_operation_name_strategy`` falls back to FastAPI operationIds and
+the parser's description degrades to the auto-summary. If cosine works on
+these, it works on the real catalogue.
+"""
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister import ShortlistRequest
+from cuga.backend.cuga_graph.nodes.cuga_lite.shortlister.embedding import (
+    EmbeddingShortlister,
+    prewarm,
+    reset_caches,
+)
+
+pytestmark = [pytest.mark.stability, pytest.mark.slow]
+
+MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class _Args(BaseModel):
+    email: str = Field(default="", description="filter by email address")
+    limit: int = Field(default=10, description="max rows")
+
+
+def _tool(name: str, description: str) -> StructuredTool:
+    def fn(**kwargs):
+        return None
+
+    fn.__name__ = "fn"
+    return StructuredTool.from_function(func=fn, name=name, description=description, args_schema=_Args)
+
+
+CRM_TOOLS = [
+    _tool("crm_get_contacts_contacts_get", "Get Contacts"),
+    _tool("crm_get_contact_contacts_contact_id_get", "Get Contact"),
+    _tool("crm_create_contact_contacts_post", "Create Contact"),
+    _tool("crm_update_contact_contacts_contact_id_put", "Update Contact"),
+    _tool("crm_delete_contact_contacts_contact_id_delete", "Delete Contact"),
+    _tool("crm_get_accounts_accounts_get", "Get Accounts"),
+    _tool("crm_get_account_accounts_account_id_get", "Get Account"),
+    _tool("crm_create_account_accounts_post", "Create Account"),
+    _tool("crm_get_opportunities_opportunities_get", "Get Opportunities"),
+    _tool("crm_create_opportunity_opportunities_post", "Create Opportunity"),
+    _tool("crm_get_leads_leads_get", "Get Leads"),
+    _tool("crm_delete_lead_leads_lead_id_delete", "Delete Lead"),
+]
+NOISE_TOOLS = [_tool(f"other_app_operation_{i}_thing_get", f"Operation {i}") for i in range(200)]
+CATALOGUE = CRM_TOOLS + NOISE_TOOLS
+
+CASES = [
+    ("list all my contacts", "crm_get_contacts_contacts_get"),
+    ("add a new account", "crm_create_account_accounts_post"),
+    ("remove a lead from the system", "crm_delete_lead_leads_lead_id_delete"),
+    ("what sales opportunities are open", "crm_get_opportunities_opportunities_get"),
+]
+
+
+@pytest.fixture(scope="module")
+def strategy():
+    reset_caches()
+    if not prewarm("local", MODEL):
+        pytest.skip(f"embedding model {MODEL} unavailable (offline?)")
+    return EmbeddingShortlister(MODEL, provider="local", query_weight=0.7, min_score=0.15)
+
+
+async def _rank(strategy, query, top_k=5, task_context=None):
+    result = await strategy.shortlist(
+        ShortlistRequest(query=query, tools=CATALOGUE, apps=[], top_k=top_k, task_context=task_context)
+    )
+    return [c.name for c in result]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query,expected", CASES, ids=[c[0][:20] for c in CASES])
+async def test_expected_tool_survives_the_cosine_cut(strategy, query, expected):
+    """Recall is the property that matters — the hybrid prefilter and the bind
+    cap both only need "don't drop the needed tool"."""
+    assert expected in await _rank(strategy, query, top_k=5)
+
+
+@pytest.mark.asyncio
+async def test_recall_at_top_k_over_a_realistic_catalogue(strategy):
+    """Recall@k across k, so the default top_k is a measured choice."""
+    for k in (8, 32, 128):
+        hits = 0
+        for query, expected in CASES:
+            if expected in await _rank(strategy, query, top_k=k):
+                hits += 1
+        assert hits == len(CASES), f"recall@{k} was {hits}/{len(CASES)}"
+
+
+@pytest.mark.asyncio
+async def test_crud_siblings_are_barely_separated(strategy):
+    """Documents the limitation rather than asserting a score.
+
+    ``get_contacts`` (list) and ``get_contact`` (by id) are one character apart
+    and embed almost identically. If this margin is ever comfortably wide, the
+    assumption behind preferring `hybrid` for discovery has changed and the
+    defaults should be re-measured — so this test failing is a prompt to think,
+    not simply to bump a number.
+    """
+    result = await strategy.shortlist(
+        ShortlistRequest(query="list all my contacts", tools=CATALOGUE, apps=[], top_k=2)
+    )
+    scores = {c.name: c.score for c in result}
+    margin = abs(scores["crm_get_contacts_contacts_get"] - scores["crm_get_contact_contacts_contact_id_get"])
+    assert margin < 0.15, (
+        f"list-vs-get-by-id margin is {margin:.3f}; cosine now separates CRUD siblings "
+        f"better than assumed — re-measure before trusting it for final selection"
+    )
+
+
+@pytest.mark.asyncio
+async def test_steps_of_one_task_retrieve_different_tools(strategy):
+    """The vector-blend fix: a long task context must not swamp the step query.
+
+    With string concatenation both steps would embed nearly identically and
+    return the same tools, defeating per-step discovery entirely.
+    """
+    context = "I need a full CRM cleanup for the quarterly review across all our accounts"
+
+    contacts = await _rank(strategy, "list all contacts", top_k=3, task_context=context)
+    deletion = await _rank(strategy, "delete the stale lead", top_k=3, task_context=context)
+
+    assert contacts[0] == "crm_get_contacts_contacts_get"
+    assert deletion[0] == "crm_delete_lead_leads_lead_id_delete"
+    assert contacts[0] != deletion[0]
+
+
+@pytest.mark.asyncio
+async def test_repeated_queries_reuse_cached_vectors(strategy):
+    """Second call must not re-embed the catalogue."""
+    import time
+
+    await _rank(strategy, "list all my contacts")
+    start = time.time()
+    await _rank(strategy, "add a new account")
+    warm = time.time() - start
+
+    assert warm < 1.0, f"warm query took {warm:.2f}s — document vectors are not being cached"

--- a/src/cuga/config.py
+++ b/src/cuga/config.py
@@ -223,6 +223,13 @@ validators = [
     # Defaults mirror shortlister/plan.py so a missing [shortlister] section is safe.
     Validator("shortlister.strategy", default="llm"),
     Validator("shortlister.fallback_strategy", default="llm"),
+    Validator("shortlister.threshold", default=128, is_type_of=int),
+    Validator("shortlister.top_k", default=128, is_type_of=int),
+    Validator("shortlister.max_results", default=10, is_type_of=int),
+    Validator("shortlister.min_score", default=0.15),
+    Validator("shortlister.query_weight", default=0.7),
+    Validator("shortlister.embedding_provider", default="local"),
+    Validator("shortlister.embedding_model", default="sentence-transformers/all-MiniLM-L6-v2"),
     # Evolve integration
     Validator("evolve.enabled", default=False),
     Validator("evolve.url", default="http://127.0.0.1:8201/sse"),

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -81,13 +81,27 @@ sandbox_mode = "native"
 # Applies to both find_tools (runtime discovery) and the bind_tools provider cap.
 # See docs/design/pluggable-shortlister.md
 #
-# strategy: llm (default) or a dotted class path, e.g. "my.pkg.MyShortlister".
-# The default reproduces the pre-existing behavior exactly.
+# strategy: llm | embedding | hybrid | "my.pkg.MyShortlister" (dotted class path)
+#   llm       — ask the model (default; identical to pre-feature behavior)
+#   embedding — local cosine similarity, no LLM call
+#   hybrid    — cosine prefilter to top_k, then the LLM makes the final pick
 strategy = "llm"
-fallback_strategy = "llm"  # used when the chosen strategy cannot run
-# Per-seam overrides inherit the values above; add a [shortlister.discovery]
-# (find_tools) or [shortlister.bind_cap] (provider cap) section only when the
-# two seams need different settings.
+fallback_strategy = "llm"  # used when the chosen strategy can't run (e.g. model still downloading)
+# Engage the cosine stage only above this many candidates. At or below it, shortlisting
+# behaves exactly as it always has. NOTE: distinct from advanced_features.shortlisting_tool_threshold
+# (=35), which decides when tools are hidden behind find_tools in the prompt.
+threshold = 128
+top_k = 128        # how many candidates the cosine stage keeps (also the hybrid prefilter width)
+max_results = 10   # find_tools only: max tools rendered to the agent (128 would overflow output limits)
+min_score = 0.15   # cosine floor — deliberately LOW; this is a recall filter, not a precision knob
+query_weight = 0.7 # blend of step query vs initial user message when embedding the query
+# Embeddings are self-contained by default: always local, never a network call, never billed.
+# Deliberately does NOT inherit [storage.embedding], which may be set to "openai".
+embedding_provider = "local"
+embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+# Per-seam overrides are supported and inherit the values above; add a
+# [shortlister.discovery] (find_tools) or [shortlister.bind_cap] (provider cap)
+# section only when the two seams need different settings.
 
 [agent_spawn]
 # When false, sub-agent spawning via spawn_agent / get_agent_result is fully disabled.


### PR DESCRIPTION
## Feature

Refs #624 — part 2 of 3. **Stacked on the seam PR; review/merge that first.**

### Summary

Adds the two non-LLM rankers on top of the strategy seam. `embedding` ranks by cosine similarity with no LLM call; `hybrid` uses it to prefilter to `top_k` and lets the LLM make the final pick. Both opt-in — `strategy` stays `"llm"` by default.

Motivation is #150: AppWorld trace analysis rated shortlister mis-selection a **high-severity top cause of first divergence**, and it was closed with "review the prompt" — so accuracy has only ever been attacked prompt-side. `hybrid` attacks it from the retrieval side. Separately, the bind-cap shortlister runs on *the same model being bound*, which is why `BindToolsUnsupportedError` exists; a non-LLM ranker removes that coupling.

**Gated behind `threshold = 128`** — the existing `cuga_lite_bind_tools_max_count`, so one number means one thing. At or below that many candidates the cosine stage does not run and both seams behave exactly as before, whatever the strategy is set to.

No new dependencies: `fastembed` is already core. Embeddings default to local `all-MiniLM-L6-v2` — no network call, nothing billed.

<details>
<summary>What cosine compares, and its known limitation</summary>

One vector from the question against one per tool, built from **name + description + parameter names + return field names**. Tool names are machine-generated (`crm_get_contacts_contacts_get`) and embed poorly until split back into words; CRM-style endpoints often carry no description at all, so parameter text is frequently the only natural language available. `args_schema` JSON is excluded — it makes the LLM prompt expensive and dilutes a fixed-size vector.

Query and task context are blended as **weighted unit vectors**, not concatenated: a long first message would otherwise swamp a short per-step query and make every step of a task retrieve the same tools.

Cosine is a **recall** device, not a precision one — `get_contacts` (list) and `get_contact` (by id) embed almost identically, exactly the #150 failure class. A stability test measures recall and asserts the CRUD-sibling margin stays narrow, so promoting `embedding` to final selection requires re-measuring rather than assuming.
</details>

Two safety properties worth review: `top_k` is a ceiling the caller sets and config can lower but never raise (so the bind cap can't be pushed past what the provider accepts), and `find_tools` caps rendered results at `max_results` (10) because 128 fully-rendered tools would exceed `execution_output_max_length` and be silently truncated mid-render.

A query never waits on a model download: if the backend is not resident the call raises `ShortlisterUnavailableError`, the caller degrades to the LLM, and a background thread loads it — mirroring `knowledge/reranker.py`.

### Testing
- [x] Tested locally; tests pass — 286 passed, plus 8 stability tests against the real model

Real-model accuracy on a 212-tool catalogue using real machine-generated name shapes: precision@1 4/4, recall@5 4/4, ~67ms warm, 1.9s to embed 212 tools.
