### PR TITLE
ci: run the static-route path-containment test (#631)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,10 +120,13 @@ jobs:
             tests/unit/test_tool_guard_generation_route_sync.py \
             tests/unit/test_policy_frontend_dict_guards_enabled.py \
             tests/unit/test_toolguard_reuse_roundtrip.py
-          # Trajectory-write containment (#636) and the recording path it must not break.
+          # Path containment for the two attacker-reachable write/read sites:
+          # trajectory writes (#636) plus the recording path they must not break,
+          # and the static file routes (#631).
           uv run pytest \
             tests/unit/test_tracker_external_path_containment.py \
-            tests/unit/test_registry_trajectory_recording.py
+            tests/unit/test_registry_trajectory_recording.py \
+            tests/unit/test_static_route_path_containment.py
           uv run pytest tests/integration/a2a/ tests/unit/test_a2a_simple_runner_hitl.py
         env:
           PYTHONUNBUFFERED: "1"


### PR DESCRIPTION
## Chore

Closes #671

### Summary

`tests/unit/test_static_route_path_containment.py` was added by #632 to cover the
path-containment fix from #631, and merged to `main` in `3ce5ee68`. It was never added to
the unit-test allowlist in `.github/workflows/tests.yml`, so it has never run in CI.

The "Run unit tests" step names each `tests/unit/*.py` file explicitly rather than running
the directory — deliberate, per the comment above the step, because several suites rely on
module-level singletons that cannot share a pytest process. The side effect is that a new
file under `tests/unit/` is invisible to CI until it is listed. #637 hit the same gap and
fixed it for its own two files in `b6404b35`; #632's file was left behind.

This adds it to the invocation that already runs the #636 trajectory containment tests.
All three exercise the same `assert_resolved_path_under` guard on attacker-reachable
paths — the `trajectory_path` query parameter and the `serve_flows` / `serve_react` static
routes — so grouping them keeps related coverage together.

CI-only change. No source or test files are modified; the test being added already passes
on `main` as-is.

### Testing

```
$ uv run pytest tests/unit/test_static_route_path_containment.py -q
11 passed

$ uv run pytest tests/unit/test_tracker_external_path_containment.py \
    tests/unit/test_registry_trajectory_recording.py \
    tests/unit/test_static_route_path_containment.py -q
15 passed
```

Run in both file orders to confirm the three do not interfere when sharing one pytest
process — relevant because `ActivityTracker` is a singleton and `tracker_enabled` is
process-global. 15 passed either way. Workflow YAML parses.
