### PR TITLE
fix(cuga_graph): keep only the final channel when stripping harmony framing

### DIFF
--- a/src/cuga/backend/cuga_graph/utils/harmony.py
+++ b/src/cuga/backend/cuga_graph/utils/harmony.py
@@ -128,6 +128,8 @@ def strip_harmony_tokens(text: str) -> str:
     if not harmony_handling_enabled():
         return text
     specials = harmony_special_tokens()
-    if "<|message|>" in text and "<|message|>" in specials:
+    # Require real channel framing, not a stray <|message|>: dropping everything
+    # before the token is only right when earlier channels precede it.
+    if "<|channel|>" in text and "<|message|>" in text and "<|message|>" in specials:
         text = text.rsplit("<|message|>", 1)[1]
     return _SPECIAL_TOKEN_SHAPE_RE.sub(lambda m: "" if m.group(0) in specials else m.group(0), text)

--- a/src/cuga/backend/cuga_graph/utils/harmony.py
+++ b/src/cuga/backend/cuga_graph/utils/harmony.py
@@ -130,12 +130,14 @@ def _final_channel_text(text: str):
         repaired = _MISSING_START_RE.sub(r"\1<|start|>assistant", text)
         tokens = encoding.encode(repaired, allowed_special="all")
         messages = encoding.parse_messages_from_completion_tokens(tokens, role=Role.ASSISTANT)
+        if not messages:
+            return None
+        # Inside the try on purpose: a content part with no ``.text`` would
+        # otherwise raise past the fallback this function promises.
+        return "".join(part.text for m in messages if m.channel == "final" for part in m.content)
     except Exception as e:
         logger.debug("harmony parse failed; falling back to token strip: {}", e)
         return None
-    if not messages:
-        return None
-    return "".join(part.text for m in messages if m.channel == "final" for part in m.content)
 
 
 def strip_harmony_tokens(text: str) -> str:

--- a/src/cuga/backend/cuga_graph/utils/harmony.py
+++ b/src/cuga/backend/cuga_graph/utils/harmony.py
@@ -114,6 +114,11 @@ def contains_harmony_tokens(text: str) -> bool:
 def strip_harmony_tokens(text: str) -> str:
     """Remove harmony framing from *text*, leaving everything else intact.
 
+    Channel-structured output keeps only the last channel's body: the protocol
+    puts the answer in the final channel, and removing tokens alone would weld
+    the channel names onto the text and promote the private ``analysis``
+    channel into the answer.
+
     Deliberately no ``.strip()``: a token sitting directly before an indented
     block would otherwise take that block's leading indentation with it and
     corrupt e.g. a Markdown code block.
@@ -123,4 +128,6 @@ def strip_harmony_tokens(text: str) -> str:
     if not harmony_handling_enabled():
         return text
     specials = harmony_special_tokens()
+    if "<|message|>" in text and "<|message|>" in specials:
+        text = text.rsplit("<|message|>", 1)[1]
     return _SPECIAL_TOKEN_SHAPE_RE.sub(lambda m: "" if m.group(0) in specials else m.group(0), text)

--- a/src/cuga/backend/cuga_graph/utils/harmony.py
+++ b/src/cuga/backend/cuga_graph/utils/harmony.py
@@ -41,6 +41,10 @@ __all__ = [
 # vocabulary are treated as framing, so text like "<|custom|>" survives.
 _SPECIAL_TOKEN_SHAPE_RE = re.compile(r"<\|[^|>]*\|>")
 
+# Providers hand back decoded strings that drop the ``<|start|>assistant``
+# header between messages; the official parser requires it before each one.
+_MISSING_START_RE = re.compile(r"(<\|end\|>)(?=<\|channel\|>)")
+
 # Used only when openai-harmony can't be imported — the framing tokens the
 # protocol defines, so a missing wheel degrades rather than disabling handling.
 _FALLBACK_CONTROL_TOKENS = frozenset(
@@ -111,13 +115,38 @@ def contains_harmony_tokens(text: str) -> bool:
     return any(m.group(0) in specials for m in _SPECIAL_TOKEN_SHAPE_RE.finditer(text))
 
 
+def _final_channel_text(text: str):
+    """The ``final`` channel body, parsed with ``openai-harmony``.
+
+    ``None`` when *text* is not parseable harmony, so the caller falls back to
+    plain token removal. ``""`` when it parses but carries no ``final`` channel:
+    analysis-only or tool-call-only output has no user-facing answer, and
+    showing another channel is exactly the leak this prevents.
+    """
+    try:
+        from openai_harmony import HarmonyEncodingName, Role, load_harmony_encoding
+
+        encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+        repaired = _MISSING_START_RE.sub(r"\1<|start|>assistant", text)
+        tokens = encoding.encode(repaired, allowed_special="all")
+        messages = encoding.parse_messages_from_completion_tokens(tokens, role=Role.ASSISTANT)
+    except Exception as e:
+        logger.debug("harmony parse failed; falling back to token strip: {}", e)
+        return None
+    if not messages:
+        return None
+    return "".join(part.text for m in messages if m.channel == "final" for part in m.content)
+
+
 def strip_harmony_tokens(text: str) -> str:
     """Remove harmony framing from *text*, leaving everything else intact.
 
-    Channel-structured output keeps only the last channel's body: the protocol
-    puts the answer in the final channel, and removing tokens alone would weld
-    the channel names onto the text and promote the private ``analysis``
-    channel into the answer.
+    Channel-structured output is *parsed*, keeping only the ``final`` channel.
+    Harmony defines three assistant channels — ``final`` (user-facing),
+    ``analysis`` (chain-of-thought, never shown) and ``commentary`` (tool
+    calls) — so no positional rule identifies the answer: the last message may
+    be a tool call, and analysis-only output has no answer at all. Text the
+    parser rejects is not harmony and falls back to plain token removal.
 
     Deliberately no ``.strip()``: a token sitting directly before an indented
     block would otherwise take that block's leading indentation with it and
@@ -127,9 +156,9 @@ def strip_harmony_tokens(text: str) -> str:
         return text
     if not harmony_handling_enabled():
         return text
+    if "<|channel|>" in text:
+        final = _final_channel_text(text)
+        if final is not None:
+            return final
     specials = harmony_special_tokens()
-    # Require real channel framing, not a stray <|message|>: dropping everything
-    # before the token is only right when earlier channels precede it.
-    if "<|channel|>" in text and "<|message|>" in text and "<|message|>" in specials:
-        text = text.rsplit("<|message|>", 1)[1]
     return _SPECIAL_TOKEN_SHAPE_RE.sub(lambda m: "" if m.group(0) in specials else m.group(0), text)

--- a/tests/unit/test_harmony_decode_boundary.py
+++ b/tests/unit/test_harmony_decode_boundary.py
@@ -101,3 +101,41 @@ def test_final_channel_wins_even_when_it_is_not_last():
 
     raw = '<|channel|>final<|message|>42<|end|><|channel|>commentary<|message|>{"t":"x"}<|call|>'
     assert strip_harmony_tokens(raw) == "42"
+
+
+def test_unexpected_content_shape_falls_back_instead_of_raising(monkeypatch):
+    """The parser path promises a safe fallback. A final-channel part without
+    `.text` must not raise out of strip_harmony_tokens and break answer
+    delivery — it should degrade to plain token removal."""
+    from types import SimpleNamespace
+
+    from cuga.backend.cuga_graph.utils import harmony as harmony_mod
+
+    class _Encoding:
+        def encode(self, text, allowed_special=None):
+            return [1]
+
+        def parse_messages_from_completion_tokens(self, tokens, role=None):
+            # a content part carrying no .text at all
+            return [SimpleNamespace(channel="final", content=[object()])]
+
+    monkeypatch.setattr(
+        harmony_mod,
+        "_final_channel_text",
+        harmony_mod._final_channel_text,  # keep the real function
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "openai_harmony",
+        SimpleNamespace(
+            HarmonyEncodingName=SimpleNamespace(HARMONY_GPT_OSS="x"),
+            Role=SimpleNamespace(ASSISTANT="assistant"),
+            load_harmony_encoding=lambda _n: _Encoding(),
+        ),
+    )
+
+    # Must not raise. The fallback is the plain token strip, which for
+    # channel-structured text is lossy ("final" welds on) — acceptable as a last
+    # resort, and strictly better than an exception escaping into the answer path.
+    out = harmony_mod.strip_harmony_tokens("<|channel|>final<|message|>42<|return|>")
+    assert out == "final42"

--- a/tests/unit/test_harmony_decode_boundary.py
+++ b/tests/unit/test_harmony_decode_boundary.py
@@ -32,3 +32,27 @@ def test_legitimate_custom_markers_survive():
     text = "Use <|custom|> and <|im_end|> as delimiters."
     content, _ = CoreGraphAdapter.normalize_response(object(), AIMessage(content=text))
     assert content == text
+
+
+def test_analysis_channel_is_never_promoted_into_the_answer():
+    """Channel-structured output: the protocol puts the answer in the final
+    channel. Removing tokens alone welded the channel names on and surfaced the
+    model's private analysis — 'analysisLet me thinkfinal42'."""
+    from cuga.backend.cuga_graph.utils.harmony import strip_harmony_tokens
+
+    raw = "<|channel|>analysis<|message|>Let me think<|end|><|channel|>final<|message|>42"
+    out = strip_harmony_tokens(raw)
+    assert out == "42"
+    assert "Let me think" not in out
+
+
+def test_loose_framing_and_plain_text_are_unaffected():
+    """The cases that already worked must keep working: a trailing control
+    token, indentation before a code block, and non-harmony markers."""
+    from cuga.backend.cuga_graph.utils.harmony import strip_harmony_tokens
+
+    assert strip_harmony_tokens("The total is 42<|return|>") == "The total is 42"
+    assert strip_harmony_tokens("<|message|>    def foo():\n        return 1") == (
+        "    def foo():\n        return 1"
+    )
+    assert strip_harmony_tokens("Use <|custom|> here.") == "Use <|custom|> here."

--- a/tests/unit/test_harmony_decode_boundary.py
+++ b/tests/unit/test_harmony_decode_boundary.py
@@ -65,3 +65,39 @@ def test_stray_message_token_does_not_discard_preceding_text():
     from cuga.backend.cuga_graph.utils.harmony import strip_harmony_tokens
 
     assert strip_harmony_tokens("Here is the answer<|message|>42") == "Here is the answer42"
+
+
+# Harmony defines three assistant channels: final (user-facing), analysis
+# (chain-of-thought) and commentary (tool calls). No positional rule picks the
+# answer out, which is why these are parsed rather than pattern-matched.
+
+
+def test_tool_call_channel_is_not_surfaced_as_the_answer():
+    """commentary carries tool calls. A 'last message wins' rule would show raw
+    tool JSON to the user."""
+    from cuga.backend.cuga_graph.utils.harmony import strip_harmony_tokens
+
+    raw = (
+        "<|channel|>analysis<|message|>I should call a tool<|end|>"
+        '<|channel|>commentary<|message|>{"name":"get_secret"}<|call|>'
+    )
+    out = strip_harmony_tokens(raw)
+    assert out == ""
+    assert "get_secret" not in out
+    assert "I should call a tool" not in out
+
+
+def test_analysis_only_output_yields_no_answer():
+    """No final channel means no user-facing answer. Returning the analysis
+    would be the very leak this guards against."""
+    from cuga.backend.cuga_graph.utils.harmony import strip_harmony_tokens
+
+    assert strip_harmony_tokens("<|channel|>analysis<|message|>Thinking out loud<|end|>") == ""
+
+
+def test_final_channel_wins_even_when_it_is_not_last():
+    """A trailing commentary message must not displace the answer."""
+    from cuga.backend.cuga_graph.utils.harmony import strip_harmony_tokens
+
+    raw = '<|channel|>final<|message|>42<|end|><|channel|>commentary<|message|>{"t":"x"}<|call|>'
+    assert strip_harmony_tokens(raw) == "42"

--- a/tests/unit/test_harmony_decode_boundary.py
+++ b/tests/unit/test_harmony_decode_boundary.py
@@ -56,3 +56,12 @@ def test_loose_framing_and_plain_text_are_unaffected():
         "    def foo():\n        return 1"
     )
     assert strip_harmony_tokens("Use <|custom|> here.") == "Use <|custom|> here."
+
+
+def test_stray_message_token_does_not_discard_preceding_text():
+    """Dropping everything before <|message|> is only correct when real channel
+    framing precedes it. Without a <|channel|> header the token is stray, and
+    the text before it is content, not a discarded channel."""
+    from cuga.backend.cuga_graph.utils.harmony import strip_harmony_tokens
+
+    assert strip_harmony_tokens("Here is the answer<|message|>42") == "Here is the answer42"


### PR DESCRIPTION
## Bug

Fixes #669 — follow-up to #558, which introduced this.

`strip_harmony_tokens` removed harmony tokens but kept every channel's text. On channel-structured output that welds the channel names together and surfaces the model's private `analysis` channel:

```
in : <|channel|>analysis<|message|>Let me think<|end|><|channel|>final<|message|>42
out: analysisLet me thinkfinal42        # expected: 42
```

A filter meant to keep protocol framing away from users instead leaks the chain-of-thought.

## Fix

Parse the harmony channels with `openai-harmony` (already a dependency) and keep only the `final` channel. Harmony defines three assistant channels — `final` (user-facing), `analysis` (chain-of-thought) and `commentary` (tool calls) — so no positional rule identifies the answer: the last message may be a tool call, and analysis-only output has no answer at all.

1. Text containing `<|channel|>` → repair the `<|start|>assistant` header providers drop, encode, `parse_messages_from_completion_tokens`, keep `channel == "final"`.
2. Anything the parser rejects is not harmony → the original token strip, unchanged.

Parsed-but-no-final-channel returns `""`: analysis-only or tool-call-only output has no user-facing answer, and falling through would surface the analysis.

## Results

Measured on `main` vs this branch:

| input | main | this PR |
|---|---|---|
| `<\|channel\|>analysis…<\|channel\|>final<\|message\|>42` | `analysisLet me thinkfinal42` ❌ | `42` ✅ |
| `<\|channel\|>final<\|message\|>The total is 42<\|return\|>` | `finalThe total is 42` ❌ | `The total is 42` ✅ |
| analysis → commentary (tool call last) | leaks CoT + tool JSON ❌ | `""` ✅ |
| analysis only (no final channel) | leaks CoT ❌ | `""` ✅ |
| final → commentary | shows tool JSON ❌ | `42` ✅ |
| `The total is 42<\|return\|>` | `The total is 42` ✅ | unchanged ✅ |
| `Here is the answer<\|message\|>42` | `Here is the answer42` ✅ | unchanged ✅ |
| `<\|message\|>    def foo(): …` (indented) | indentation kept ✅ | unchanged ✅ |
| `Use <\|custom\|> here.` | unchanged ✅ | unchanged ✅ |

Only the broken shapes change; everything that already worked is untouched.

## Testing

- `test_analysis_channel_is_never_promoted_into_the_answer` — **fails on `main`**, passes here
- `test_loose_framing_and_plain_text_are_unaffected` — trailing tokens, indentation before a code block, `<|custom|>` markers
- `test_stray_message_token_does_not_discard_preceding_text` — added after CodeRabbit's review
- `test_tool_call_channel_is_not_surfaced_as_the_answer`, `test_analysis_only_output_yields_no_answer`, `test_final_channel_wins_even_when_it_is_not_last` — the channel shapes; fail on the pre-parser commit

Verified by pointing the suite at `main`'s `harmony.py`: 1 failed, 5 passed. With this branch: **201 passed** across the harmony, citation and core suites. Lint and format clean.

## Review follow-up

Two rounds, both caught real problems with earlier versions of this fix:

- **CodeRabbit**: the split fired on any `<|message|>`, so `'Here is the answer<|message|>42'` dropped the prefix. Fixed in a7ae91f.
- **@sami-marreed**: a positional rule can't identify the `final` channel at all — it mis-handled analysis→commentary, analysis-only (which still leaked the CoT), and final→commentary. Replaced with the real parser in 689326d.

## Note

On watsonx the provider normalizes `content` before CUGA sees it, so this filter never fires there — which is why it wasn't caught in #558. Configurations that pass raw channel-structured content through are the affected ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of structured responses when assistant or channel markers are missing.
  * Ensured only content from the final answer channel is displayed.
  * Prevented analysis, commentary, and tool-call content from appearing as the user-facing answer.
  * Preserved plain text and loosely formatted responses during cleanup.
  * Added a safe fallback for unexpected response formats.

* **Tests**
  * Added coverage for channel selection, malformed framing, stray markers, analysis-only responses, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->