### PR TITLE
chore(skills): assign linked issue before creating PR

### DIFF
--- a/.bob/skills/cuga-contributor-workflows/create-pr.md
+++ b/.bob/skills/cuga-contributor-workflows/create-pr.md
@@ -55,14 +55,26 @@ Only if the tree is clean and both counts are zero, continue.
 
 1. Pick the right template from `.github/PULL_REQUEST_TEMPLATE/` (typically `bugfix.md`, `feature.md`, `docs.md`, or `chore.md`).
 2. Ask which GitHub issue this PR closes or relates to. If the user skips / says none, leave Related Issue blank or note none — do not block.
-3. Fill the template from current commits and changes:
+3. **Assign linked issue (hard gate).** If an issue number was provided in step 2, assign it to the PR author before continuing. Skip if no issue was linked.
+
+   Add the author; do not remove existing assignees. `@me` resolves to the authenticated `gh` user.
+
+   ```bash
+   gh issue edit "$issue" --repo "$origin_repo" --add-assignee @me
+   gh issue view "$issue" --repo "$origin_repo" --json assignees \
+     --jq --arg me "$(gh api user -q .login)" 'any(.assignees[].login; . == $me)'
+   ```
+
+   If the verification prints `false`, **STOP**. Do not create the PR. Report the failure (permissions, not a collaborator, etc.) and let the user fix it.
+
+4. Fill the template from current commits and changes:
    - Related Issue
    - Description
    - Type of Changes
    - Root Cause / Solution (bugfixes)
    - Testing
    - Checklist
-4. Create (pass title via a variable; pass body via `--body-file` so shell does not interpolate the Markdown):
+5. Create (pass title via a variable; pass body via `--body-file` so shell does not interpolate the Markdown):
 
 ```bash
 title="<title in commit convention>"

--- a/.claude/skills/cuga-contributor-workflows/create-pr.md
+++ b/.claude/skills/cuga-contributor-workflows/create-pr.md
@@ -55,14 +55,26 @@ Only if the tree is clean and both counts are zero, continue.
 
 1. Pick the right template from `.github/PULL_REQUEST_TEMPLATE/` (typically `bugfix.md`, `feature.md`, `docs.md`, or `chore.md`).
 2. Ask which GitHub issue this PR closes or relates to. If the user skips / says none, leave Related Issue blank or note none — do not block.
-3. Fill the template from current commits and changes:
+3. **Assign linked issue (hard gate).** If an issue number was provided in step 2, assign it to the PR author before continuing. Skip if no issue was linked.
+
+   Add the author; do not remove existing assignees. `@me` resolves to the authenticated `gh` user.
+
+   ```bash
+   gh issue edit "$issue" --repo "$origin_repo" --add-assignee @me
+   gh issue view "$issue" --repo "$origin_repo" --json assignees \
+     --jq --arg me "$(gh api user -q .login)" 'any(.assignees[].login; . == $me)'
+   ```
+
+   If the verification prints `false`, **STOP**. Do not create the PR. Report the failure (permissions, not a collaborator, etc.) and let the user fix it.
+
+4. Fill the template from current commits and changes:
    - Related Issue
    - Description
    - Type of Changes
    - Root Cause / Solution (bugfixes)
    - Testing
    - Checklist
-4. Create (pass title via a variable; pass body via `--body-file` so shell does not interpolate the Markdown):
+5. Create (pass title via a variable; pass body via `--body-file` so shell does not interpolate the Markdown):
 
 ```bash
 title="<title in commit convention>"

--- a/.cursor/skills/cuga-contributor-workflows/create-pr.md
+++ b/.cursor/skills/cuga-contributor-workflows/create-pr.md
@@ -55,14 +55,26 @@ Only if the tree is clean and both counts are zero, continue.
 
 1. Pick the right template from `.github/PULL_REQUEST_TEMPLATE/` (typically `bugfix.md`, `feature.md`, `docs.md`, or `chore.md`).
 2. Ask which GitHub issue this PR closes or relates to. If the user skips / says none, leave Related Issue blank or note none — do not block.
-3. Fill the template from current commits and changes:
+3. **Assign linked issue (hard gate).** If an issue number was provided in step 2, assign it to the PR author before continuing. Skip if no issue was linked.
+
+   Add the author; do not remove existing assignees. `@me` resolves to the authenticated `gh` user.
+
+   ```bash
+   gh issue edit "$issue" --repo "$origin_repo" --add-assignee @me
+   gh issue view "$issue" --repo "$origin_repo" --json assignees \
+     --jq --arg me "$(gh api user -q .login)" 'any(.assignees[].login; . == $me)'
+   ```
+
+   If the verification prints `false`, **STOP**. Do not create the PR. Report the failure (permissions, not a collaborator, etc.) and let the user fix it.
+
+4. Fill the template from current commits and changes:
    - Related Issue
    - Description
    - Type of Changes
    - Root Cause / Solution (bugfixes)
    - Testing
    - Checklist
-4. Create (pass title via a variable; pass body via `--body-file` so shell does not interpolate the Markdown):
+5. Create (pass title via a variable; pass body via `--body-file` so shell does not interpolate the Markdown):
 
 ```bash
 title="<title in commit convention>"


### PR DESCRIPTION
## Chore

Related Issue: none

### Summary

Updates the `cuga-contributor-workflows` create-PR skill so that when a related GitHub issue is linked, the agent assigns that issue to the PR author and verifies the assignment before running `gh pr create`.

- Adds a hard gate in step 2.3 of `create-pr.md`
- Uses `gh issue edit --add-assignee @me` and verifies assignees
- Stops PR creation if assignment fails
- Keeps `.cursor`, `.claude`, and `.bob` skill mirrors in sync

### Testing

- [x] Verified all three mirrored `create-pr.md` files are identical
- [x] Commit includes `[skip ci]` as requested


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the pull request workflow to assign linked issues to the pull request author before creation.
  - Existing assignees are preserved, and the workflow verifies that the assignment succeeds.
  - Pull request creation now stops if verification fails.
  - This step is skipped when no issue is linked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->