### PR TITLE
fix(knowledge): tolerate missing file-task status in postgres recovery

### DIFF
--- a/src/cuga/backend/knowledge/metadata/postgres_store.py
+++ b/src/cuga/backend/knowledge/metadata/postgres_store.py
@@ -202,14 +202,20 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
         count = 0
         for row in rows:
             task_id = row["task_id"]
-            file_tasks = json.loads(row["file_tasks_json"])
-            for ft in file_tasks.values():
-                if ft["status"] in ("pending", "processing"):
-                    ft["status"] = "failed"
-                    ft["error"] = "interrupted by server restart"
+            try:
+                file_tasks = json.loads(row["file_tasks_json"]) or {}
+            except (TypeError, ValueError):
+                file_tasks = {}
+            if isinstance(file_tasks, dict):
+                for ft in file_tasks.values():
+                    if not isinstance(ft, dict):
+                        continue
+                    if ft.get("status", "pending") in ("pending", "processing"):
+                        ft["status"] = "failed"
+                        ft["error"] = ft.get("error") or "interrupted by server restart"
             await self.execute(
-                f"UPDATE {_TASK} SET status = 'failed', file_tasks_json = ?, updated_at = ? WHERE task_id = ?",
-                (json.dumps(file_tasks), now, task_id),
+                f"UPDATE {_TASK} SET status = ?, file_tasks_json = ?, updated_at = ? WHERE task_id = ?",
+                ("failed", json.dumps(file_tasks), now, task_id),
             )
             count += 1
         await self.commit()

--- a/tests/unit/test_knowledge_pgvector_metadata.py
+++ b/tests/unit/test_knowledge_pgvector_metadata.py
@@ -84,6 +84,12 @@ class _FakePostgresMetadata(PostgresKnowledgeMetadata):
         return None
 
     async def fetchall(self, sql: str, params: tuple = ()):  # type: ignore[override]
+        if "_tasks" in sql and "status IN" in sql:
+            return [
+                {"task_id": row["task_id"], "file_tasks_json": row["file_tasks_json"]}
+                for row in self._rows_by_task_id.values()
+                if row["status"] in ("running", "pending")
+            ]
         return []
 
     async def commit(self) -> None:  # type: ignore[override]
@@ -263,3 +269,43 @@ async def test_no_kwarg_silently_dropped_during_progress_emit():
     assert task["failed_files"] == 0
     assert task["total_files"] == 1
     assert task["file_tasks"]["f.pdf"]["status"] == "indexed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_recover_stale_tasks_handles_progress_entries_without_status():
+    """Progress emits replace file_tasks_json without a ``status`` key.
+
+    Postgres recovery used to KeyError on that shape and fail knowledge
+    warmup. Must match SQLite: close the parent task and not raise.
+    """
+    store = _FakePostgresMetadata()
+    await store.ensure_ready()
+    await store.create_task(
+        "t-progress",
+        "col1",
+        3,
+        {
+            "summary-plan-description.md": {
+                "filename": "summary-plan-description.md",
+                "stage": "parsed",
+                "progress": {"done": 182, "total": 182},
+            },
+            "bad_type.md": "not a dict",
+            "ok.pdf": {"filename": "ok.pdf", "status": "processing"},
+        },
+    )
+    await store.update_task("t-progress", status="running")
+
+    count = await store.recover_stale_tasks()
+    assert count == 1
+
+    task = await store.get_task("t-progress")
+    assert task is not None
+    assert task["status"] == "failed"
+    assert task["file_tasks"]["ok.pdf"]["status"] == "failed"
+    assert "restart" in task["file_tasks"]["ok.pdf"]["error"]
+    ms = task["file_tasks"]["summary-plan-description.md"]
+    assert isinstance(ms, dict)
+    assert ms["status"] == "failed"
+    assert "restart" in ms["error"]


### PR DESCRIPTION
## Bug fix

Fixes #683

### Summary

Postgres knowledge warmup crashes with `KeyError: 'status'` when recovering interrupted ingest tasks whose `file_tasks_json` entries have no `status` (progress emits write filename/stage/progress only). SQLite already defaults missing status; this ports that guard to `PostgresKnowledgeMetadata.recover_stale_tasks()`.

### Root cause

`recover_stale_tasks()` did `ft["status"]` on every nested file-task. Partial ingest rows look like `{'filename': '...', 'stage': 'parsed', 'progress': {...}}`. The exception is caught during warmup, so the process still starts, but knowledge is marked failed and OOBE PDF seed is skipped.

### Solution

Match SQLite: tolerate missing/corrupt `file_tasks_json`, skip non-dict entries, default missing `status` to `pending`, then mark those entries and the parent task failed.

### Testing

- [x] Verified fix locally; tests pass
- Added `test_recover_stale_tasks_handles_progress_entries_without_status` (reproduces the hosted payload)
- `uv run pytest tests/unit/test_knowledge_pgvector_metadata.py` — 6 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of stale tasks when task progress data is malformed or incomplete.
  * Invalid task entries are safely skipped, while valid tasks are marked as failed.
  * Existing error details are preserved when pending or processing tasks fail.
* **Tests**
  * Added coverage for missing status fields, invalid entries, and restart error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->