### PR TITLE
fix(knowledge): tolerate status-less file-tasks in restart recovery

### DIFF
--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -2501,6 +2501,11 @@ class KnowledgeEngine:
             progress_futures: list[_cf.Future] = []
 
             async def _emit_progress(stage: str, done: int, total: int) -> None:
+                # Like the "parsed" emit above, this omits ``status`` on
+                # purpose, and ``update_task`` replaces the whole entry — so a
+                # task killed here leaves a status-less file-task behind.
+                # Readers must tolerate that; see ``normalize_file_tasks`` in
+                # knowledge/metadata/base.py (#683).
                 await self._metadata.update_task(
                     task_id,
                     file_tasks={

--- a/src/cuga/backend/knowledge/metadata/base.py
+++ b/src/cuga/backend/knowledge/metadata/base.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
+
+#: Error recorded on file-task entries that a restart interrupted mid-ingest.
+INTERRUPTED_ERROR = "interrupted by server restart"
+
+#: File-task statuses that a restart should re-mark as ``failed``. A missing
+#: ``status`` is treated as ``pending`` and therefore recovered too — see
+#: ``normalize_file_tasks`` for why the key can be absent.
+_RECOVERABLE_FILE_STATUSES = ("pending", "processing")
 
 
 def utc_now_iso() -> str:
@@ -12,6 +21,55 @@ def utc_now_iso() -> str:
 
 def iso_cutoff_days_ago(days: int) -> str:
     return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+def normalize_file_tasks(raw: Any) -> dict[str, Any]:
+    """Coerce a stored ``file_tasks_json`` value into a mapping.
+
+    Accepts the raw JSON text from the DB or an already-deserialized value,
+    and always returns a dict so callers can iterate and re-serialize without
+    guarding every access.
+
+    Two shapes on disk make this necessary:
+
+    1. **A file-task entry may legitimately have no ``status`` key.** The
+       ingest worker's progress emits replace the whole entry with
+       ``{filename, stage, progress}`` on purpose, so a late emit cannot
+       un-flip ``status="completed"`` back to ``"processing"``
+       (see ``_emit_progress`` in ``knowledge/engine.py``). Any task killed
+       mid-ingest therefore leaves a status-less entry behind. Readers must
+       treat a missing status as *non-terminal*, never assume the key exists
+       — assuming it crashed Postgres warmup with ``KeyError: 'status'``
+       (#683) while SQLite tolerated it, and the two backends silently
+       diverged for weeks.
+    2. **The payload may not be an object at all** — corrupt or truncated
+       JSON, ``null``, or a list written by an older build. Returning ``{}``
+       keeps the caller's re-serialization from persisting a non-object back
+       into a column the rest of the code reads as a mapping.
+    """
+    if isinstance(raw, (str, bytes, bytearray)):
+        try:
+            raw = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def mark_file_tasks_interrupted(file_tasks: dict[str, Any]) -> dict[str, Any]:
+    """Re-mark non-terminal file-task entries as failed, in place.
+
+    Shared by every backend's ``recover_stale_tasks`` so the tolerance rules
+    live in one place. Entries that are not dicts are skipped rather than
+    dropped, and an existing ``error`` is preserved because it is more
+    specific than the generic restart message.
+    """
+    for ft in file_tasks.values():
+        if not isinstance(ft, dict):
+            continue
+        if ft.get("status", "pending") in _RECOVERABLE_FILE_STATUSES:
+            ft["status"] = "failed"
+            ft["error"] = ft.get("error") or INTERRUPTED_ERROR
+    return file_tasks
 
 
 class KnowledgeMetadataStore(Protocol):

--- a/src/cuga/backend/knowledge/metadata/postgres_store.py
+++ b/src/cuga/backend/knowledge/metadata/postgres_store.py
@@ -8,7 +8,12 @@ from typing import Any
 
 import psycopg
 
-from cuga.backend.knowledge.metadata.base import iso_cutoff_days_ago, utc_now_iso
+from cuga.backend.knowledge.metadata.base import (
+    iso_cutoff_days_ago,
+    mark_file_tasks_interrupted,
+    normalize_file_tasks,
+    utc_now_iso,
+)
 from cuga.backend.storage.relational.prod import ProdRelationalStore
 
 _DOC = "cuga_knowledge_meta_documents"
@@ -202,14 +207,10 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
         count = 0
         for row in rows:
             task_id = row["task_id"]
-            file_tasks = json.loads(row["file_tasks_json"])
-            for ft in file_tasks.values():
-                if ft["status"] in ("pending", "processing"):
-                    ft["status"] = "failed"
-                    ft["error"] = "interrupted by server restart"
+            file_tasks = mark_file_tasks_interrupted(normalize_file_tasks(row["file_tasks_json"]))
             await self.execute(
-                f"UPDATE {_TASK} SET status = 'failed', file_tasks_json = ?, updated_at = ? WHERE task_id = ?",
-                (json.dumps(file_tasks), now, task_id),
+                f"UPDATE {_TASK} SET status = ?, file_tasks_json = ?, updated_at = ? WHERE task_id = ?",
+                ("failed", json.dumps(file_tasks), now, task_id),
             )
             count += 1
         await self.commit()

--- a/src/cuga/backend/knowledge/metadata/sqlite_store.py
+++ b/src/cuga/backend/knowledge/metadata/sqlite_store.py
@@ -11,7 +11,11 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from cuga.backend.knowledge.metadata.base import utc_now_iso
+from cuga.backend.knowledge.metadata.base import (
+    mark_file_tasks_interrupted,
+    normalize_file_tasks,
+    utc_now_iso,
+)
 from cuga.backend.storage.relational.local import LocalRelationalStore
 
 
@@ -180,25 +184,7 @@ class SqliteKnowledgeMetadata(LocalRelationalStore):
         count = 0
         for row in rows:
             task_id = row["task_id"]
-            try:
-                file_tasks = json.loads(row["file_tasks_json"]) or {}
-            except (TypeError, ValueError):
-                # Corrupted JSON — treat as empty so we still mark the
-                # parent task failed instead of 500-ing the entire engine
-                # startup health probe.
-                file_tasks = {}
-            if isinstance(file_tasks, dict):
-                for ft in file_tasks.values():
-                    # ``status`` is missing on rows written by older
-                    # builds / partial reindex tasks. Default to
-                    # ``pending`` so the recovery still re-marks them
-                    # ``failed`` rather than crashing the whole engine
-                    # health/list endpoints with a KeyError.
-                    if not isinstance(ft, dict):
-                        continue
-                    if ft.get("status", "pending") in ("pending", "processing"):
-                        ft["status"] = "failed"
-                        ft["error"] = ft.get("error") or "interrupted by server restart"
+            file_tasks = mark_file_tasks_interrupted(normalize_file_tasks(row["file_tasks_json"]))
             await self.execute(
                 "UPDATE tasks SET status='failed', file_tasks_json=?, updated_at=? WHERE task_id=?",
                 (json.dumps(file_tasks), now, task_id),

--- a/tests/unit/test_knowledge_recover_stale_tasks.py
+++ b/tests/unit/test_knowledge_recover_stale_tasks.py
@@ -1,0 +1,251 @@
+"""Restart recovery must tolerate every file-task shape that reaches the DB.
+
+``recover_stale_tasks`` runs from ``_ensure_metadata_ready`` on the first
+knowledge call after startup. It has no ``try/except`` around it and never
+latches ``_metadata_ready``, so anything it raises re-raises on *every*
+subsequent call — one poisoned row takes the whole knowledge surface down
+until the database is hand-edited.
+
+The shape that poisoned it (#683) is not corrupt data, it is normal steady
+state: the ingest worker's progress emits deliberately write a file-task entry
+with no ``status`` key, and ``update_task`` replaces the whole entry rather
+than merging, so any task killed mid-ingest leaves one behind. SQLite
+tolerated this; Postgres did ``ft["status"]`` and raised ``KeyError``. These
+tests pin the tolerance in the shared helper and assert both backends route
+through it, so the two cannot drift apart again.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from cuga.backend.knowledge.metadata.base import (
+    INTERRUPTED_ERROR,
+    mark_file_tasks_interrupted,
+    normalize_file_tasks,
+)
+from cuga.backend.knowledge.metadata.postgres_store import PostgresKnowledgeMetadata
+from cuga.backend.knowledge.metadata.sqlite_store import SqliteKnowledgeMetadata
+
+# The exact payload from the #683 report: a progress emit that landed after
+# Docling finished parsing, with no ``status`` key.
+PROGRESS_ENTRY: dict[str, Any] = {
+    "filename": "summary-plan-description.md",
+    "stage": "parsed",
+    "progress": {"done": 182, "total": 182},
+}
+
+
+class _RecoveryFakePostgres(PostgresKnowledgeMetadata):
+    """Run the real ``recover_stale_tasks`` against in-memory I/O.
+
+    Only the asyncpg boundary is replaced, so the store's own recovery logic
+    is what executes — not a mock of it. No live Postgres required, which
+    keeps this in the default unit shard.
+    """
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        super().__init__("postgresql://fake/test")
+        self._rows = rows
+        self.written: dict[str, dict[str, Any]] = {}
+
+    async def fetchall(self, sql: str, params: tuple = ()):  # type: ignore[override]
+        return list(self._rows)
+
+    async def execute(self, sql: str, params: tuple = ()) -> None:  # type: ignore[override]
+        status, file_tasks_json, _updated_at, task_id = params
+        self.written[task_id] = {"status": status, "file_tasks_json": file_tasks_json}
+
+    async def commit(self) -> None:  # type: ignore[override]
+        return None
+
+
+def _sqlite_store(tmp_path) -> SqliteKnowledgeMetadata:
+    return SqliteKnowledgeMetadata(tmp_path / "metadata.db")
+
+
+async def _stale_sqlite_row(store: SqliteKnowledgeMetadata, task_id: str, raw_json: str) -> None:
+    """Insert a running task whose file_tasks_json is exactly ``raw_json``.
+
+    Written through ``execute`` so we can plant payloads that ``create_task``
+    would never produce (corrupt JSON, non-object values).
+    """
+    await store.create_task(task_id, "kb_agent_test", 1, {})
+    await store.execute(
+        "UPDATE tasks SET status='running', file_tasks_json=? WHERE task_id=?",
+        (raw_json, task_id),
+    )
+    await store.commit()
+
+
+# --- the shared helper -------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_file_tasks_accepts_every_shape_on_disk():
+    assert normalize_file_tasks(json.dumps({"a.md": PROGRESS_ENTRY})) == {"a.md": PROGRESS_ENTRY}
+    # Already-deserialized input passes through (get_task hands us a dict).
+    assert normalize_file_tasks({"a.md": PROGRESS_ENTRY}) == {"a.md": PROGRESS_ENTRY}
+    # Everything that is not an object becomes one, so the caller's
+    # re-serialization can never persist a non-mapping back into the column.
+    for bad in ("not json", "", "null", "[1, 2]", '"a string"', "17", None, [1, 2], 17):
+        assert normalize_file_tasks(bad) == {}, bad
+
+
+@pytest.mark.unit
+def test_mark_file_tasks_interrupted_defaults_missing_status_to_recoverable():
+    """A status-less entry is mid-ingest, so it must be re-marked failed."""
+    out = mark_file_tasks_interrupted({"a.md": dict(PROGRESS_ENTRY)})
+    assert out["a.md"]["status"] == "failed"
+    assert out["a.md"]["error"] == INTERRUPTED_ERROR
+    # The progress fields survive — they are the audit trail of how far it got.
+    assert out["a.md"]["stage"] == "parsed"
+    assert out["a.md"]["progress"] == {"done": 182, "total": 182}
+
+
+@pytest.mark.unit
+def test_mark_file_tasks_interrupted_leaves_terminal_entries_alone():
+    out = mark_file_tasks_interrupted(
+        {
+            "done.md": {"filename": "done.md", "status": "indexed"},
+            "gone.md": {"filename": "gone.md", "status": "superseded"},
+            "live.md": {"filename": "live.md", "status": "processing"},
+            "junk.md": "not a dict",
+        }
+    )
+    assert out["done.md"]["status"] == "indexed"
+    assert out["gone.md"]["status"] == "superseded"
+    assert out["live.md"]["status"] == "failed"
+    # Non-dict entries are skipped, not dropped — we do not silently discard
+    # rows we failed to understand.
+    assert out["junk.md"] == "not a dict"
+
+
+@pytest.mark.unit
+def test_mark_file_tasks_interrupted_preserves_a_specific_error():
+    """The generic restart message must not clobber a real diagnosis."""
+    out = mark_file_tasks_interrupted(
+        {"a.md": {"filename": "a.md", "status": "processing", "error": "embedder OOM"}}
+    )
+    assert out["a.md"]["error"] == "embedder OOM"
+
+
+# --- Postgres (the backend that crashed) -------------------------------------
+
+
+@pytest.mark.unit
+async def test_postgres_recover_tolerates_missing_file_task_status():
+    """The #683 reproduction: warmup must not raise KeyError."""
+    store = _RecoveryFakePostgres(
+        [
+            {
+                "task_id": "task_f0f171881f6a",
+                "file_tasks_json": json.dumps({PROGRESS_ENTRY["filename"]: PROGRESS_ENTRY}),
+            }
+        ]
+    )
+
+    assert await store.recover_stale_tasks() == 1
+
+    written = store.written["task_f0f171881f6a"]
+    assert written["status"] == "failed"
+    entry = json.loads(written["file_tasks_json"])[PROGRESS_ENTRY["filename"]]
+    assert entry["status"] == "failed"
+    assert entry["error"] == INTERRUPTED_ERROR
+
+
+@pytest.mark.unit
+async def test_postgres_recover_always_persists_an_object():
+    """Corrupt or non-object payloads must not be written back as-is.
+
+    The guard added in #684 skipped the *loop* for non-dicts but still
+    re-serialized the original value, so a stale row could persist ``[1,2]``
+    into a column every other reader treats as a mapping.
+    """
+    rows = [
+        {"task_id": "t_corrupt", "file_tasks_json": "not json at all"},
+        {"task_id": "t_null", "file_tasks_json": "null"},
+        {"task_id": "t_list", "file_tasks_json": "[1, 2]"},
+        {"task_id": "t_scalar", "file_tasks_json": "17"},
+    ]
+    store = _RecoveryFakePostgres(rows)
+
+    assert await store.recover_stale_tasks() == len(rows)
+
+    for task_id in ("t_corrupt", "t_null", "t_list", "t_scalar"):
+        written = store.written[task_id]
+        assert written["status"] == "failed"
+        assert json.loads(written["file_tasks_json"]) == {}, task_id
+
+
+# --- SQLite (end-to-end against a real database) ------------------------------
+
+
+@pytest.mark.unit
+async def test_sqlite_recover_tolerates_missing_file_task_status(tmp_path):
+    store = _sqlite_store(tmp_path)
+    await _stale_sqlite_row(store, "task_sqlite_1", json.dumps({PROGRESS_ENTRY["filename"]: PROGRESS_ENTRY}))
+
+    assert await store.recover_stale_tasks() == 1
+
+    task = await store.get_task("task_sqlite_1")
+    assert task is not None
+    assert task["status"] == "failed"
+    entry = task["file_tasks"][PROGRESS_ENTRY["filename"]]
+    assert entry["status"] == "failed"
+    assert entry["error"] == INTERRUPTED_ERROR
+    await store.close()
+
+
+@pytest.mark.unit
+async def test_sqlite_recover_always_persists_an_object(tmp_path):
+    store = _sqlite_store(tmp_path)
+    await _stale_sqlite_row(store, "task_sqlite_bad", "[1, 2]")
+
+    assert await store.recover_stale_tasks() == 1
+
+    # get_task json.loads the column unguarded, so this read is itself the
+    # assertion that recovery left a mapping behind.
+    task = await store.get_task("task_sqlite_bad")
+    assert task is not None
+    assert task["file_tasks"] == {}
+    await store.close()
+
+
+# --- the two backends must not drift again ------------------------------------
+
+
+@pytest.mark.unit
+async def test_recover_stale_tasks_parity_between_sqlite_and_postgres(tmp_path):
+    """Same input, same output from both stores.
+
+    #683 existed because the SQLite guard landed in 92618226 and was never
+    back-ported to Postgres. This test fails if either backend stops routing
+    through the shared helper.
+    """
+    payload = {
+        "no-status.md": dict(PROGRESS_ENTRY),
+        "processing.md": {"filename": "processing.md", "status": "processing"},
+        "indexed.md": {"filename": "indexed.md", "status": "indexed"},
+        "with-error.md": {"filename": "with-error.md", "status": "pending", "error": "disk full"},
+    }
+    raw = json.dumps(payload)
+
+    pg = _RecoveryFakePostgres([{"task_id": "t_parity", "file_tasks_json": raw}])
+    await pg.recover_stale_tasks()
+    pg_out = json.loads(pg.written["t_parity"]["file_tasks_json"])
+
+    lite = _sqlite_store(tmp_path)
+    await _stale_sqlite_row(lite, "t_parity", raw)
+    await lite.recover_stale_tasks()
+    lite_task = await lite.get_task("t_parity")
+    assert lite_task is not None
+    lite_out = lite_task["file_tasks"]
+    await lite.close()
+
+    assert pg_out == lite_out
+    # And both agree with the helper that owns the rules.
+    assert pg_out == mark_file_tasks_interrupted(normalize_file_tasks(raw))


### PR DESCRIPTION
## Bug fix

Fixes #683

### Summary

Knowledge warmup on `storage.mode=prod` crashed with `KeyError: 'status'` while recovering interrupted ingest tasks, taking the whole knowledge subsystem down.

### Root cause

`PostgresKnowledgeMetadata.recover_stale_tasks()` did `ft["status"]` on every nested file-task entry. Those entries legitimately have no `status`:

- the ingest worker's progress emits write `{filename, stage, progress}` and **deliberately** omit `status`, so a late emit cannot un-flip `status="completed"` back to `"processing"` (`_emit_progress`, engine.py);
- `update_task` **replaces** the whole `file_tasks_json` blob rather than merging it.

So any task killed mid-ingest leaves a status-less entry behind. This is normal steady state, not corrupt or legacy data.

SQLite has defaulted the missing key since `92618226`; that guard was never applied to Postgres, so the two backends diverged silently for ~7 weeks.

**Blast radius is wider than the report suggests.** `_ensure_metadata_ready` has no `try/except` and never latches `_metadata_ready`, so the `KeyError` re-raises on *every* subsequent call — not just the skipped OOBE PDF seed, but 500s from `list_documents`, `get_tasks`, `ingest`, `delete_document` and `reindex` until the DB is hand-edited.

### Solution

Because the status-less write is intentional and race-preventing, the correct fix is a tolerant reader, not a changed writer. To stop the two backends drifting again, the rules now live in one place:

- `normalize_file_tasks()` and `mark_file_tasks_interrupted()` added to `metadata/base.py` — the only domain module both stores already import (there is deliberately no shared base class: `SqliteKnowledgeMetadata(LocalRelationalStore)` vs `PostgresKnowledgeMetadata(ProdRelationalStore)`).
- Both `recover_stale_tasks` implementations reduce to the same single line and route through it.
- Postgres now also preserves an existing `ft["error"]` instead of overwriting it with the generic restart message.
- A comment at `_emit_progress` points at the helper, so the next reader of a status-less entry knows it is by design.

**A second defect, present in both stores, is fixed by the same change:** a non-object payload (corrupt JSON, `null`, a list) skipped the marking loop via an `isinstance` guard but was still re-serialized back into the column — leaving a value that every other reader treats as a mapping. Normalizing on read means the `UPDATE` can only ever persist an object.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Verified fix locally; tests pass

New `tests/unit/test_knowledge_recover_stale_tasks.py` (9 tests, `@pytest.mark.unit`, lands in the `unit-b` shard). Postgres is exercised through a fake that replaces only the asyncpg boundary, so the store's real recovery logic runs with no live Postgres; SQLite is tested end-to-end against a real temp DB.

Verified to be genuine regression tests, not just green: against unfixed `main` three of them fail, including the exact `KeyError: 'status'` at `postgres_store.py:207` from the issue.

- `uv run pytest tests/unit/test_knowledge_recover_stale_tasks.py` — 9 passed
- `uv run pytest tests/unit/ -k knowledge` — 576 passed, no regressions
- `uv run ruff check` / `ruff format` — clean

Notable coverage: the `#683` payload verbatim; corrupt/`null`/list/scalar payloads; a pre-existing specific error surviving recovery; and a **parity test** asserting both backends produce identical output for the same input, which fails if either stops routing through the shared helper.

Also validated end to end against a real local Postgres deployment (`deployment/deploy-local-postgres.sh`, `storage.mode=prod`): planting the exact `#683` payload in `cuga_knowledge_meta_tasks` and restarting the server now recovers cleanly instead of failing warmup.

### Notes for the reviewer

- Deliberately **not** changing the progress emits or making `update_task` merge. The omission is load-bearing and the existing drain before the completion write already handles the race it guards against. Changing it is a bigger blast radius than an urgent prod fix should carry.
- `cancel_task` has the same unguarded `ft["status"]` subscript. Left alone here on purpose: it is unreachable today (a `pending` task always has `status` from `_create_task_entry_internal`), and the #685 fix rewrites that whole function. Flagging so it does not read as an oversight.
