### PR TITLE
fix(knowledge): make delete stop an in-flight ingest of the same file

### DIFF
--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -63,6 +63,11 @@ _BACKGROUND_REINDEX_TASKS: set[Any] = set()
 # terminal: doing so would let a second ingest race a live insert.
 _TERMINAL_FILE_STATUSES = frozenset({"indexed", "failed", "skipped", "cancelled", "superseded"})
 
+# How long a delete waits for an ingest it could not cancel (already past the
+# point of no return) to finish writing. Bounded so a wedged provider call
+# cannot hang the delete request; on expiry the delete proceeds anyway.
+_DELETE_INGEST_WAIT_S = 30
+
 
 # Docling's plugin factory emits a WARNING every time it scans for plugins:
 #   "The plugin langchain_docling will not be loaded because Docling is being
@@ -3048,6 +3053,47 @@ class KnowledgeEngine:
 
     # --- Delete (5-step compensating flow per plan) ---
 
+    async def _stop_ingest_for(self, collection: str, filename: str) -> bool:
+        """Stop any in-flight ingest that owns ``filename``. Returns whether one was.
+
+        Delete used to ignore active tasks entirely (#691), which made the
+        button do nothing in two different ways:
+
+        * during a first upload the documents row does not exist yet — it is
+          written near the END of ingest — so ``mark_deleting`` found nothing
+          and the delete 404'd while the ingest carried on and indexed it;
+        * during a re-upload the delete succeeded, then the ingest reached
+          ``add_document`` and wrote the document straight back.
+
+        Must be called BEFORE taking the collection lock: waiting on a worker
+        while holding that lock would deadlock, since the worker needs it to
+        insert.
+        """
+        stopped = False
+        for task in await self._metadata.list_tasks(collection):
+            if not self._blocks_reupload(task, filename):
+                continue
+            task_id = task["task_id"]
+            logger.info(f"Delete {filename}: stopping in-flight ingest {task_id}")
+            await self.cancel_task(task_id)
+            stopped = True
+            # A cancel past the point of no return is refused, and that worker
+            # WILL write the document. Wait for it to reach a terminal status —
+            # which it only does after add_document — so our delete runs last
+            # instead of being resurrected by it.
+            deadline = time.monotonic() + _DELETE_INGEST_WAIT_S
+            while time.monotonic() < deadline:
+                current = await self._metadata.get_task(task_id)
+                if not current or current.get("status") in ("completed", "failed", "cancelled"):
+                    break
+                await asyncio.sleep(0.1)
+            else:
+                logger.warning(
+                    f"Delete {filename}: ingest {task_id} still running after "
+                    f"{_DELETE_INGEST_WAIT_S}s; deleting anyway"
+                )
+        return stopped
+
     async def delete_document(self, collection: str, filename: str) -> None:
         """Delete a document. Idempotent compensating flow across stores."""
         await self._ensure_metadata_ready()
@@ -3069,6 +3115,9 @@ class KnowledgeEngine:
                 f"Reindex in progress for {collection}; deletes are rejected until it completes."
             )
 
+        # Outside the lock on purpose — see _stop_ingest_for.
+        stopped_ingest = await self._stop_ingest_for(collection, filename)
+
         async with self._get_collection_lock(collection):
             # Re-check under the lock: reindex() flags the collection AND
             # snapshots its file_list under this same lock, so a delete that
@@ -3079,6 +3128,13 @@ class KnowledgeEngine:
                     f"Reindex in progress for {collection}; deletes are rejected until it completes."
                 )
             if not await self._metadata.mark_deleting(collection, filename):
+                if stopped_ingest:
+                    # There is no documents row because the ingest never got
+                    # far enough to write one — but we did stop it, so the
+                    # user's intent ("make this not be here") is satisfied.
+                    # 404 here would be a lie about work we actually did.
+                    logger.info(f"Delete {filename}: ingest stopped before it indexed anything")
+                    return
                 raise DocumentNotFoundError(filename)
             await self._ensure_vector_store_cached(collection)
             try:

--- a/tests/unit/test_knowledge_delete_during_ingest.py
+++ b/tests/unit/test_knowledge_delete_during_ingest.py
@@ -1,0 +1,152 @@
+"""Deleting a document must make it not be there, even mid-upload.
+
+Delete used to ignore in-flight ingests entirely (#691), so the button did
+nothing in two different ways:
+
+* during a FIRST upload the documents row does not exist yet — it is written
+  near the end of ingest — so ``mark_deleting`` matched nothing, the request
+  404'd, and the ingest carried on and indexed the file anyway;
+* during a RE-UPLOAD the delete succeeded and the row vanished, then the
+  in-flight ingest reached ``add_document`` and wrote it straight back.
+
+Both are "I clicked delete and the file is still there".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+from langchain_core.documents import Document
+
+from cuga.backend.knowledge.config import KnowledgeConfig
+from cuga.backend.knowledge.engine import DocumentNotFoundError, KnowledgeEngine
+
+COLL = "c"
+FNAME = "f.txt"
+MISSING = Path("/tmp/f.txt-does-not-exist")
+
+
+def _cfg(**over):
+    d = dict(
+        enabled=True,
+        persist_dir=Path(tempfile.mkdtemp(prefix="cuga-del-")),
+        embedding_provider="fastembed",
+    )
+    d.update(over)
+    return KnowledgeConfig(**d)
+
+
+def _engine() -> KnowledgeEngine:
+    eng = KnowledgeEngine(_cfg())
+
+    async def _noop(*a, **k):
+        return None
+
+    async def _fake_insert(*a, **k):
+        return {"num_added": 1, "num_skipped": 0}
+
+    eng._ensure_collection_config = _noop
+    eng._ensure_vector_store_cached = _noop
+    eng._insert_documents_async = _fake_insert
+    # The vector/file removal is real I/O against a store we never built.
+    eng._delete_vector_and_file = lambda collection, filename: None
+    return eng
+
+
+async def _new_task(eng: KnowledgeEngine, task_id: str = "t1") -> None:
+    await eng._ensure_metadata_ready()
+    await eng._metadata.create_task(
+        task_id, COLL, 1, {FNAME: {"filename": FNAME, "status": "pending"}}
+    )
+
+
+def _blocking_parse(started: threading.Event, release: threading.Event):
+    def fake_load(path):
+        started.set()
+        assert release.wait(5), "test deadlock: parse never released"
+        return [Document(page_content="hi", metadata={"source": FNAME})]
+
+    return fake_load
+
+
+@pytest.mark.unit
+async def test_delete_during_first_upload_stops_the_ingest(eng=None):
+    """Variant A: nothing indexed yet, so delete must cancel rather than 404."""
+    eng = _engine()
+    await _new_task(eng)
+    started, release = threading.Event(), threading.Event()
+    eng._load_document = _blocking_parse(started, release)
+
+    cancel_event = asyncio.Event()
+    eng._active_tasks["t1"] = cancel_event
+    worker = asyncio.create_task(
+        eng._ingest_inner(COLL, MISSING, FNAME, "t1", True, cancel_event, skip_file_copy=True)
+    )
+    await asyncio.to_thread(started.wait, 5)
+
+    # Must NOT raise DocumentNotFoundError: there is no row yet, but there is
+    # an ingest to stop, and stopping it is real work.
+    await eng.delete_document(COLL, FNAME)
+
+    release.set()
+    await worker
+
+    assert (await eng._metadata.get_task("t1"))["status"] == "cancelled"
+    assert not await eng._metadata.document_exists(COLL, FNAME), (
+        "the ingest indexed the document after it was deleted"
+    )
+
+
+@pytest.mark.unit
+async def test_delete_during_reupload_is_not_resurrected():
+    """Variant B: the ingest must not write the document back after the delete."""
+    eng = _engine()
+    await eng._ensure_metadata_ready()
+    # Seed an already-indexed document.
+    await eng._metadata.add_document(COLL, FNAME, 3, preview="hi")
+    assert await eng._metadata.document_exists(COLL, FNAME)
+
+    # A re-upload of the same name is now in flight.
+    await _new_task(eng, "t2")
+    started, release = threading.Event(), threading.Event()
+    eng._load_document = _blocking_parse(started, release)
+    cancel_event = asyncio.Event()
+    eng._active_tasks["t2"] = cancel_event
+    worker = asyncio.create_task(
+        eng._ingest_inner(COLL, MISSING, FNAME, "t2", True, cancel_event, skip_file_copy=True)
+    )
+    await asyncio.to_thread(started.wait, 5)
+
+    await eng.delete_document(COLL, FNAME)
+
+    release.set()
+    await worker
+
+    assert not await eng._metadata.document_exists(COLL, FNAME), (
+        "deleted document was resurrected by the in-flight ingest"
+    )
+
+
+@pytest.mark.unit
+async def test_delete_with_no_document_and_no_ingest_still_404s():
+    """The stop-the-ingest path must not turn a genuine miss into a success."""
+    eng = _engine()
+    await eng._ensure_metadata_ready()
+    with pytest.raises(DocumentNotFoundError):
+        await eng.delete_document(COLL, "never-existed.txt")
+
+
+@pytest.mark.unit
+async def test_delete_of_an_indexed_document_still_works():
+    """The ordinary path is unchanged when nothing is in flight."""
+    eng = _engine()
+    await eng._ensure_metadata_ready()
+    await eng._metadata.add_document(COLL, FNAME, 3, preview="hi")
+
+    await eng.delete_document(COLL, FNAME)
+
+    assert not await eng._metadata.document_exists(COLL, FNAME)

--- a/tests/unit/test_knowledge_delete_during_ingest.py
+++ b/tests/unit/test_knowledge_delete_during_ingest.py
@@ -59,9 +59,7 @@ def _engine() -> KnowledgeEngine:
 
 async def _new_task(eng: KnowledgeEngine, task_id: str = "t1") -> None:
     await eng._ensure_metadata_ready()
-    await eng._metadata.create_task(
-        task_id, COLL, 1, {FNAME: {"filename": FNAME, "status": "pending"}}
-    )
+    await eng._metadata.create_task(task_id, COLL, 1, {FNAME: {"filename": FNAME, "status": "pending"}})
 
 
 def _blocking_parse(started: threading.Event, release: threading.Event):


### PR DESCRIPTION
## Bug fix

Fixes #691

> **Stacked on #688** (base branch `fix/685-knowledge-cancel-running-ingest`). It depends on that PR making `cancel_task` actually stop a running ingest — before it, there was nothing for delete to call. Review #688 first; this diff is only the two files listed below.

### Summary

Clicking **Delete** on a knowledge document while an upload of that filename is in flight did nothing. Found by hand-testing the UI against a local Postgres (`storage.mode=prod`) deployment.

### Root cause

Delete and an in-flight ingest were not coordinated at all:

- `delete_document` → `mark_deleting()` only matches a **documents row**, and that row is written by `add_document` near the *end* of ingest. So during a first upload the row does not exist, the request 404s, nothing is cancelled, and the ingest indexes the file anyway.
- During a re-upload the row does exist, so the delete succeeds and the document disappears — then the ingest reaches `add_document` and writes it straight back. `add_document` runs **outside** the per-collection lock that `delete_document` takes, so even a delete that wins the lock is overwritten moments later.

Measured on `main` (156 KB `.md`, `replace_duplicates=true`):

| variant | delete during ingest | present after ingest finishes |
|---|---|---|
| A — first upload, delete at +0.0 / +0.05 / +0.2 / +0.5s | **404** | **yes** (no-op) |
| B — existing doc + re-upload, delete at +0.0 / +0.1 / +0.3s | **200** | **yes** (resurrected) |

### Solution

`_stop_ingest_for()` cancels any active task owning that filename, then the normal delete flow runs.

Three details that matter:

- **Called before the collection lock is taken.** Waiting on a worker while holding that lock would deadlock — the worker needs it to insert.
- **If the cancel is refused** because the ingest is past its point of no return, wait for the task to terminalize. The terminal status is written *after* `add_document`, so waiting guarantees the delete runs last rather than being resurrected. Bounded at 30s so a wedged embedding call cannot hang the request; on expiry the delete proceeds anyway.
- **A missing documents row is no longer a 404 when an ingest was actually stopped.** The user's intent — "make this not be here" — is satisfied, and 404 would misreport work that really happened. A genuine miss (no document, no ingest) still 404s.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Verified fix locally; tests pass

New `tests/unit/test_knowledge_delete_during_ingest.py` (4 tests, `@pytest.mark.unit`): both bug variants, plus two guards that the ordinary paths are unchanged (a genuine miss still raises `DocumentNotFoundError`; deleting an indexed document with nothing in flight still works).

Verified as real regression tests: **the two behaviour tests fail without the fix**, and the two unchanged-behaviour tests pass either way — so the fix is doing something and not breaking the normal path.

Re-verified end to end against real Postgres 17 + pgvector, driving the same HTTP surface the UI uses:

| variant | before | after |
|---|---|---|
| A, delete at +0.0 / +0.2 / +0.5s | 404, document present | **200, ingest `cancelled`, document absent** |
| B, delete at +0.0 / +0.2s | 200 then resurrected | **200, ingest `cancelled`, not resurrected** |

- `uv run pytest tests/unit/ -k knowledge` — 582 passed
- `uv run ruff check` / `ruff format` — clean

### Note on the UI

No frontend change needed. `handleDelete` already checks `res.ok` and surfaces the error; the problem was entirely server-side — it was returning 404 (variant A) or succeeding and then being undone (variant B).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a document now stops any active upload or re-upload in progress.
  * Prevents cancelled uploads from recreating deleted documents.
  * Deletion completes safely even when an upload has not yet created a document record.
  * Preserves the expected not-found response when neither a document nor upload exists.

* **Tests**
  * Added coverage for deleting documents during initial uploads, re-uploads, and normal indexed-document deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->