### PR TITLE
fix(knowledge): serialize terminal task writes so a row cannot lie

### DIFF
--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -1835,6 +1835,15 @@ class KnowledgeEngine:
         # head on, so a terminal write here would corrupt data.
         self._uncancellable_tasks: set[str] = set()
 
+        # Serializes "read a task's status, decide, write a terminal status".
+        # update_task is last-write-wins with no CAS, so without this a
+        # worker's status="completed" could land between cancel_task's read
+        # and its UPDATE — leaving the row "cancelled" while the document is
+        # actually indexed. Holding this across read+decide+write makes the
+        # check-then-act atomic: whichever side goes second re-reads, sees the
+        # terminal status the other just wrote, and declines to overwrite it.
+        self._task_write_lock = asyncio.Lock()
+
         # Reindex coordination flags (in-memory, single-process only — flock ensures this)
         self._reindex_in_progress: set[str] = set()
         self._reindex_deferred: set[str] = set()
@@ -2794,20 +2803,23 @@ class KnowledgeEngine:
             stage_timings["finalize_s"] = round(time.monotonic() - t_finalize, 3)
             stage_timings["total_s"] = round(time.monotonic() - start, 3)
 
-            await self._metadata.update_task(
-                task_id,
-                status="completed",
-                processed_files=1,
-                successful_files=1,
-                file_tasks={
-                    filename: {
-                        "filename": filename,
-                        "status": "indexed",
-                        "duration_seconds": round(duration, 2),
-                        "timings": dict(stage_timings),
-                    }
-                },
-            )
+            # Locked so this cannot land between cancel_task's read and its
+            # write. Whichever side goes second re-reads and stands down.
+            async with self._task_write_lock:
+                await self._metadata.update_task(
+                    task_id,
+                    status="completed",
+                    processed_files=1,
+                    successful_files=1,
+                    file_tasks={
+                        filename: {
+                            "filename": filename,
+                            "status": "indexed",
+                            "duration_seconds": round(duration, 2),
+                            "timings": dict(stage_timings),
+                        }
+                    },
+                )
             logger.info(
                 f"Ingested {filename} -> {len(docs)} chunks in {collection} "
                 f"(added={result.get('num_added', 0)}, skipped={result.get('num_skipped', 0)})"
@@ -2861,54 +2873,57 @@ class KnowledgeEngine:
             # (e.g. cancel arrived while the worker was queued on _ingest_sem).
             duration = time.monotonic() - start
             logger.info(f"Task {task_id} cancelled by user for {filename} after {duration:.1f}s")
-            await self._metadata.update_task(
-                task_id,
-                status="cancelled",
-                processed_files=1,
-                file_tasks={
-                    filename: {
-                        "filename": filename,
-                        "status": "cancelled",
-                        "reason": "cancelled by user",
-                        "duration_seconds": round(duration, 2),
-                    }
-                },
-            )
+            async with self._task_write_lock:
+                await self._metadata.update_task(
+                    task_id,
+                    status="cancelled",
+                    processed_files=1,
+                    file_tasks={
+                        filename: {
+                            "filename": filename,
+                            "status": "cancelled",
+                            "reason": "cancelled by user",
+                            "duration_seconds": round(duration, 2),
+                        }
+                    },
+                )
         except ReindexSupersededError as e:
             # SQL status "cancelled" (CHECK admits no new value); supersede
             # audit lives in file_tasks[filename].
             duration = time.monotonic() - start
             logger.info(f"Task {task_id} superseded for {filename} after {duration:.1f}s ({e})")
-            await self._metadata.update_task(
-                task_id,
-                status="cancelled",
-                processed_files=1,
-                file_tasks={
-                    filename: {
-                        "filename": filename,
-                        "status": "superseded",
-                        "reason": f"config changed mid-ingest (gen {e.worker_gen} -> {e.current_gen})",
-                        "duration_seconds": round(duration, 2),
-                    }
-                },
-            )
+            async with self._task_write_lock:
+                await self._metadata.update_task(
+                    task_id,
+                    status="cancelled",
+                    processed_files=1,
+                    file_tasks={
+                        filename: {
+                            "filename": filename,
+                            "status": "superseded",
+                            "reason": f"config changed mid-ingest (gen {e.worker_gen} -> {e.current_gen})",
+                            "duration_seconds": round(duration, 2),
+                        }
+                    },
+                )
         except Exception as e:
             duration = time.monotonic() - start
             logger.error(f"Failed to ingest {filename}: {e}")
-            await self._metadata.update_task(
-                task_id,
-                status="failed",
-                processed_files=1,
-                failed_files=1,
-                file_tasks={
-                    filename: {
-                        "filename": filename,
-                        "status": "failed",
-                        "error": str(e),
-                        "duration_seconds": round(duration, 2),
-                    }
-                },
-            )
+            async with self._task_write_lock:
+                await self._metadata.update_task(
+                    task_id,
+                    status="failed",
+                    processed_files=1,
+                    failed_files=1,
+                    file_tasks={
+                        filename: {
+                            "filename": filename,
+                            "status": "failed",
+                            "error": str(e),
+                            "duration_seconds": round(duration, 2),
+                        }
+                    },
+                )
         finally:
             self._active_tasks.pop(task_id, None)
             self._uncancellable_tasks.discard(task_id)
@@ -3834,16 +3849,29 @@ class KnowledgeEngine:
         reindex, all three of which read the same status filter.
         """
         await self._ensure_metadata_ready()
-        task = await self._metadata.get_task(task_id)
-        if not task:
-            return None
-        if task["status"] in ("completed", "failed", "cancelled"):
-            return task
 
+        # Set the event BEFORE taking the write lock. The worker's checkpoints
+        # are synchronous reads of this event, so setting it first means a
+        # worker that runs while we wait for the lock still sees the cancel.
         cancel_event = self._active_tasks.get(task_id)
         if cancel_event:
             cancel_event.set()
 
+        # Read, decide and write under one lock. Without it the worker's
+        # status="completed" could land between our read and our UPDATE,
+        # leaving the row "cancelled" while the document is really indexed.
+        async with self._task_write_lock:
+            task = await self._metadata.get_task(task_id)
+            if not task:
+                return None
+            # Re-read inside the lock: if the worker reached a terminal status
+            # while we were waiting, that is the truth — do not overwrite it.
+            if task["status"] in ("completed", "failed", "cancelled"):
+                return task
+            return await self._cancel_task_locked(task_id, task)
+
+    async def _cancel_task_locked(self, task_id: str, task: dict[str, Any]) -> dict[str, Any] | None:
+        """Write the cancellation. Caller must hold ``_task_write_lock``."""
         if task_id in self._uncancellable_tasks:
             # Past the point of no return: the insert is in flight and the
             # document WILL land. Persisting "cancelled" would both lie and

--- a/tests/unit/test_knowledge_cancel_task.py
+++ b/tests/unit/test_knowledge_cancel_task.py
@@ -408,3 +408,46 @@ async def test_cancel_before_worker_registers_its_event_is_still_honoured():
     task = await eng._metadata.get_task("t1")
     assert task["status"] == "cancelled", f"cancelled row was resurrected to {task['status']}"
     assert not await eng._metadata.document_exists(COLL, FNAME)
+
+
+@pytest.mark.unit
+async def test_row_and_document_never_disagree_when_cancel_races_completion():
+    """Close the last interleaving: a "cancelled" row over an indexed document.
+
+    ``update_task`` is last-write-wins with no CAS. Without a lock around
+    read-decide-write, the worker's ``status="completed"`` could land between
+    ``cancel_task``'s read (which saw ``running``) and its UPDATE, leaving the
+    row ``cancelled`` while the document really is indexed.
+
+    Asserted as an invariant rather than a fixed outcome, because either side
+    may legitimately win the race. What must never happen is the two
+    disagreeing.
+    """
+    eng = _engine()
+    await _new_task(eng)
+    entered, gate = _park_at_insert(eng)
+
+    cancel_event = asyncio.Event()
+    eng._active_tasks["t1"] = cancel_event
+    worker = asyncio.create_task(
+        eng._ingest_inner(COLL, MISSING, FNAME, "t1", True, cancel_event, skip_file_copy=True)
+    )
+    await asyncio.wait_for(entered.wait(), 5)
+
+    # Release the insert and cancel in the same tick so the terminal write and
+    # the cancel write contend for the task write lock.
+    gate.set()
+    cancelled, _ = await asyncio.gather(eng.cancel_task("t1"), worker)
+
+    task = await eng._metadata.get_task("t1")
+    indexed = await eng._metadata.document_exists(COLL, FNAME)
+    assert task["status"] in ("completed", "cancelled")
+    if task["status"] == "cancelled":
+        assert not indexed, "row says cancelled but the document is indexed"
+    else:
+        assert indexed, "row says completed but no document was indexed"
+    # The returned row may legitimately be the pre-read snapshot: when the
+    # cancel is refused past the point of no return we hand back the live row
+    # so the caller keeps polling to the real terminal status. What it must
+    # never do is claim "cancelled" for a task that indexed its document.
+    assert cancelled["status"] != "cancelled" or not indexed


### PR DESCRIPTION
## Bug fix

Refs #685

> **Follow-up to #688**, which was merged ~7 minutes before this commit was pushed, so this hardening did not make it into `main`. Everything else from that PR (including the pre-registration cancel guard) did land — verified against `main`. This is the one remaining piece.

### Summary

Closes the last known interleaving in the cancel path: a task row could read `cancelled` while its document was actually indexed.

### Root cause

`update_task` is last-write-wins with no CAS. So the worker's `status="completed"` could land **between** `cancel_task`'s read (which saw `running`) and its own `UPDATE`. The row then said `cancelled` over an indexed document.

It is a stale *label* rather than data loss — the vector store and the documents table still agree with each other, and the next `loadDocuments()` shows the truth — but it is the label the UI puts in front of the user, so it is worth closing.

### Solution

- `_task_write_lock` held across **read → decide → write** in `cancel_task`, and around each of the worker's four terminal writes (`completed`, `cancelled`, `superseded`, `failed`).
- Whichever side goes second re-reads inside the lock, sees the terminal status the other just wrote, and declines to overwrite it.
- **The cancel event is still set _before_ the lock is taken.** The worker's checkpoints are synchronous reads of that event, so a worker that runs while cancel is waiting on the lock still observes the cancel and aborts. Setting it after would reintroduce a window — worth a look in review, since it reads like something to "tidy up".

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Verified fix locally; tests pass

The test asserts the **invariant** rather than a fixed winner: either side may legitimately win the race, and what must never happen is the task row and the document disagreeing.

- `uv run pytest tests/unit/ -k knowledge` — 607 passed
- `uv run ruff check` / `ruff format` — clean
- Re-validated on a real Postgres deployment (both a native PG17 and the helm `deployment/deploy-local-postgres.sh` chart on Kubernetes): 29/29 stress checks, plus kill-mid-ingest → restart → clean recovery.

An aside worth recording: my first attempt at this test held the lock by hand and deadlocked against the worker's terminal write. That is itself reasonable evidence the serialization is real.

### Remaining known limits (unchanged, neither a correctness hole)

- Cancel during a Docling parse does not *stop* the parse — `asyncio.to_thread` is not interruptible, so it burns CPU until it returns, then aborts. Harmless: that worker writes nothing.
- The point-of-no-return handoff is safe **because** there is no `await` between the check and the flag set. It is commented, but a future edit could silently break it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cancellation and completion handling to prevent inconsistent final statuses.
  * Ensured cancelled tasks do not retain indexed documents, while completed tasks remain properly indexed.
  * Prevented cancellation from overriding successful ingestion results.

* **Tests**
  * Added coverage for race conditions between task cancellation and ingestion completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->