### PR TITLE
fix(knowledge): fail the delete instead of reporting one the ingest will undo

### DIFF
--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -798,6 +798,22 @@ class ReindexInProgressError(Exception):
     pass
 
 
+class IngestStillFinishingError(Exception):
+    """A delete could not complete because an uncancellable ingest is still writing.
+
+    Retryable: the ingest is past its point of no return, so it cannot be
+    stopped and it will still call ``add_document``. Deleting now would report
+    success and then be undone by that write.
+    """
+
+    def __init__(self, filename: str, task_id: str):
+        self.filename = filename
+        self.task_id = task_id
+        super().__init__(
+            f"An ingest for {filename} is still finishing (task {task_id}); retry the delete shortly."
+        )
+
+
 class ReindexSupersededError(Exception):
     """Stale ingest worker: ``_apply_generation`` moved past the captured value."""
 
@@ -3103,10 +3119,17 @@ class KnowledgeEngine:
                     break
                 await asyncio.sleep(0.1)
             else:
+                # Do NOT delete anyway. That worker is past the point of no
+                # return, so it still has an add_document ahead of it: deleting
+                # now would report success and then be silently undone by that
+                # write — reintroducing the exact resurrection this method
+                # exists to prevent, just in the timeout window. Fail
+                # retryably instead of lying about the outcome.
                 logger.warning(
-                    f"Delete {filename}: ingest {task_id} still running after "
-                    f"{_DELETE_INGEST_WAIT_S}s; deleting anyway"
+                    f"Delete {filename}: ingest {task_id} still writing after "
+                    f"{_DELETE_INGEST_WAIT_S}s; refusing to report a delete it would undo"
                 )
+                raise IngestStillFinishingError(filename, task_id)
         return stopped
 
     async def delete_document(self, collection: str, filename: str) -> None:

--- a/src/cuga/backend/knowledge/routes.py
+++ b/src/cuga/backend/knowledge/routes.py
@@ -25,6 +25,7 @@ from cuga.backend.knowledge.engine import (
     DocumentExistsError,
     DocumentNotFoundError,
     FileTooLargeError,
+    IngestStillFinishingError,
     IngestionQueueFullError,
     KnowledgeEngine,
     ReindexBusyError,
@@ -772,6 +773,10 @@ async def get_document_file(
         file_path = engine.get_document_file_path(collection, filename)
     except DocumentNotFoundError:
         raise HTTPException(status_code=404, detail="document not found")
+    except IngestStillFinishingError as e:
+        # Retryable: the ingest is past its point of no return and still has an
+        # add_document ahead of it, so a "deleted" answer here would be undone.
+        raise HTTPException(status_code=409, detail=str(e))
 
     media_type, _ = mimetypes.guess_type(str(file_path))
     # Let Starlette build Content-Disposition. It RFC 5987-encodes non-ASCII

--- a/src/cuga/backend/knowledge/routes.py
+++ b/src/cuga/backend/knowledge/routes.py
@@ -773,10 +773,6 @@ async def get_document_file(
         file_path = engine.get_document_file_path(collection, filename)
     except DocumentNotFoundError:
         raise HTTPException(status_code=404, detail="document not found")
-    except IngestStillFinishingError as e:
-        # Retryable: the ingest is past its point of no return and still has an
-        # add_document ahead of it, so a "deleted" answer here would be undone.
-        raise HTTPException(status_code=409, detail=str(e))
 
     media_type, _ = mimetypes.guess_type(str(file_path))
     # Let Starlette build Content-Disposition. It RFC 5987-encodes non-ASCII
@@ -813,6 +809,10 @@ async def delete_document(
         return {"status": "ok"}
     except DocumentNotFoundError:
         raise HTTPException(status_code=404, detail="document not found")
+    except IngestStillFinishingError as e:
+        # Retryable: the ingest is past its point of no return and still has an
+        # add_document ahead of it, so a "deleted" answer here would be undone.
+        raise HTTPException(status_code=409, detail=str(e))
     except ReindexInProgressError:
         # Delete is rejected while this collection is being reindexed —
         # otherwise the doc would be re-embedded into the in-flight target and

--- a/tests/unit/test_knowledge_delete_during_ingest.py
+++ b/tests/unit/test_knowledge_delete_during_ingest.py
@@ -20,7 +20,12 @@ import threading
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
 from langchain_core.documents import Document
+
+from cuga.backend.knowledge.auth import KnowledgeIdentity, require_internal_or_auth
+from cuga.backend.knowledge.routes import knowledge_router
 
 from cuga.backend.knowledge.config import KnowledgeConfig
 from cuga.backend.knowledge import engine as engine_mod
@@ -204,3 +209,46 @@ async def test_delete_refuses_rather_than_lying_when_the_ingest_outlives_the_dea
     # Once the ingest is done, the delete succeeds and sticks.
     await eng.delete_document(COLL, FNAME)
     assert not await eng._metadata.document_exists(COLL, FNAME)
+
+
+@pytest.mark.unit
+def test_delete_route_maps_ingest_still_finishing_to_409():
+    """The engine's retryable error must reach the client as 409, not 500.
+
+    The handler has to live on the route that actually calls
+    ``delete_document``. Attached to any other route it is dead code, and a
+    timed-out delete surfaces as an unhandled 500 — which tells the caller
+    "the server is broken" instead of "retry shortly".
+    """
+    from types import SimpleNamespace
+
+    class _Engine:
+        def __init__(self):
+            self._config = SimpleNamespace(enabled=True)
+
+        async def delete_document(self, collection, filename):
+            raise IngestStillFinishingError(filename, "task_abc123")
+
+    async def _identity(request: Request) -> KnowledgeIdentity:
+        return KnowledgeIdentity(
+            user_id=None,
+            tenant_id=None,
+            agent_id="cuga-default",
+            thread_id=None,
+            auth_mode="external",
+        )
+
+    app = FastAPI()
+    app.include_router(knowledge_router)
+    app.dependency_overrides[require_internal_or_auth] = _identity
+    app.state.app_state = SimpleNamespace(knowledge_engine=_Engine(), knowledge_provider=None)
+
+    resp = TestClient(app).request(
+        "DELETE",
+        "/api/knowledge/documents",
+        json={"scope": "agent", "filename": FNAME},
+    )
+
+    assert resp.status_code == 409, f"expected 409, got {resp.status_code}: {resp.text[:200]}"
+    detail = resp.json()["detail"]
+    assert "task_abc123" in detail and "retry" in detail.lower()

--- a/tests/unit/test_knowledge_delete_during_ingest.py
+++ b/tests/unit/test_knowledge_delete_during_ingest.py
@@ -23,7 +23,12 @@ import pytest
 from langchain_core.documents import Document
 
 from cuga.backend.knowledge.config import KnowledgeConfig
-from cuga.backend.knowledge.engine import DocumentNotFoundError, KnowledgeEngine
+from cuga.backend.knowledge import engine as engine_mod
+from cuga.backend.knowledge.engine import (
+    DocumentNotFoundError,
+    IngestStillFinishingError,
+    KnowledgeEngine,
+)
 
 COLL = "c"
 FNAME = "f.txt"
@@ -147,4 +152,55 @@ async def test_delete_of_an_indexed_document_still_works():
 
     await eng.delete_document(COLL, FNAME)
 
+    assert not await eng._metadata.document_exists(COLL, FNAME)
+
+
+@pytest.mark.unit
+async def test_delete_refuses_rather_than_lying_when_the_ingest_outlives_the_deadline(monkeypatch):
+    """An uncancellable ingest that finishes AFTER the wait must not be reported as deleted.
+
+    Past the point of no return the worker still has ``add_document`` ahead of
+    it. Deleting anyway would return success and then be silently undone by
+    that write — the exact resurrection this whole path exists to prevent,
+    just inside the timeout window. So the delete fails retryably instead.
+    """
+    # Collapse the deadline so the test does not actually wait 30s.
+    monkeypatch.setattr(engine_mod, "_DELETE_INGEST_WAIT_S", 0.3)
+
+    eng = _engine()
+    await eng._ensure_metadata_ready()
+    await eng._metadata.add_document(COLL, FNAME, 3, preview="hi")
+    await _new_task(eng, "t3")
+
+    # Park the worker inside the insert, i.e. past the point of no return, so
+    # the cancel is refused and it outlives the deadline.
+    entered, gate = asyncio.Event(), asyncio.Event()
+
+    async def fake_insert(*a, **k):
+        entered.set()
+        await gate.wait()
+        return {"num_added": 1, "num_skipped": 0}
+
+    eng._insert_documents_async = fake_insert
+    eng._load_document = lambda p: [Document(page_content="hi", metadata={"source": FNAME})]
+
+    cancel_event = asyncio.Event()
+    eng._active_tasks["t3"] = cancel_event
+    worker = asyncio.create_task(
+        eng._ingest_inner(COLL, MISSING, FNAME, "t3", True, cancel_event, skip_file_copy=True)
+    )
+    await asyncio.wait_for(entered.wait(), 5)
+    assert "t3" in eng._uncancellable_tasks, "worker should be past the point of no return"
+
+    with pytest.raises(IngestStillFinishingError):
+        await eng.delete_document(COLL, FNAME)
+
+    # And the document is still there — we did not half-delete it.
+    assert await eng._metadata.document_exists(COLL, FNAME)
+
+    gate.set()
+    await worker
+
+    # Once the ingest is done, the delete succeeds and sticks.
+    await eng.delete_document(COLL, FNAME)
     assert not await eng._metadata.document_exists(COLL, FNAME)


### PR DESCRIPTION
## Bug fix

Refs #691

> **Follow-up to #692**, which merged ~25 minutes before this commit was pushed, so this correction did not make it into `main`. Everything else from that PR did land. This is the one remaining piece — and it is the piece that keeps the timeout path from reintroducing the bug #692 set out to fix.

### Summary

`main` today still deletes a document while an uncancellable ingest is mid-write, and reports success for it.

### The hole

`_stop_ingest_for` waits for an ingest it could not cancel to terminalize. On deadline expiry it logged a warning and **deleted anyway**:

```python
else:
    logger.warning(f"... still running after {_DELETE_INGEST_WAIT_S}s; deleting anyway")
```

That worker is past its point of no return, so it still has an `add_document` ahead of it. The delete therefore returns success and is then silently undone by that write — **the exact resurrection #692 exists to prevent, relocated into the timeout window**. It is reachable by any ingest whose insert phase runs longer than the deadline, which a large PDF easily does.

Trading a bounded wait for a wrong answer was the wrong trade; the bound is right, the lie is not.

### Fix

Raise `IngestStillFinishingError` → **409 with a retry hint**. The delete genuinely did not happen, so reporting that is the honest answer, and the caller can retry once the ingest terminalizes. The 30s bound still holds, so a wedged embedding call cannot hang the request.

### Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

- [x] Verified fix locally; tests pass

New test parks a worker **past the point of no return** (asserting `task_id in _uncancellable_tasks`), collapses the deadline via `monkeypatch`, and asserts:

1. the delete **raises rather than half-completing**,
2. the document survives — no partial delete,
3. a retry after the ingest finishes succeeds and sticks.

- `uv run pytest tests/unit/ -k knowledge` — 612 passed
- `uv run ruff check` / `ruff format --check` — clean

**One honest caveat about that test:** against the old `delete anyway` code it does not fail cleanly, it *hangs* — the delete blocks on the collection lock the parked worker holds. So it is a valid guard for the new contract, but the failure mode it demonstrates on the old code is a stuck request rather than a resurrection. Both are bad; the resurrection is the one that bites in production, where `add_document` runs after the lock is released and so is not serialized against the delete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when deleting a document while ingestion is still in progress.
  * Deletion now returns a retryable conflict response with details when ingestion cannot be stopped in time.
  * Existing document content is preserved until ingestion finishes, preventing premature deletion.
  * Once ingestion completes, the document can be deleted successfully without data loss.
  * Retrieving a document is no longer incorrectly blocked by this ingestion state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->