### PR TITLE
feat(llm): add wxo platform to LLMManager for watsonx Orchestrate routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,17 @@ AGENT_SETTING_CONFIG="settings.groq.toml"
 # AGENT_SETTING_CONFIG="settings.watsonx.toml"
 # MODEL_NAME="meta-llama/llama-4-maverick-17b-128e-instruct-fp8"
 
+# watsonx Orchestrate (wxO) — routes LLM calls through your Orchestrate tenant for
+# tracing, guardrails, and entitlement-based billing. Requires: pip install "cuga[wxo]"
+# (Python >= 3.11). Get the key and URL from Orchestrate: Settings -> API details ->
+# Generate API key, and the Service instance URL shown there.
+# WXO_API_KEY="your-wxo-api-key"
+# WXO_INSTANCE_URL="https://api.dl.watson-orchestrate.ibm.com/instances/your-instance-id"
+# AGENT_SETTING_CONFIG="settings.wxo.toml"
+# MODEL_NAME="watsonx/openai/gpt-oss-120b"
+# To target a local ADK dev server instead, omit WXO_API_KEY and set:
+# WXO_INSTANCE_URL="http://localhost:4321"
+
 # Optional: Langfuse tracing
 # LANGFUSE_SECRET_KEY="sk-lf-xxx"
 # LANGFUSE_PUBLIC_KEY="pk-lf-xxx"

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ CUGA supports multiple LLM providers with flexible configuration options. You ca
 - **Groq** - High-performance inference platform with fast LLM models
 - **RITS** - Internal IBM research platform
 - **OpenRouter** - LLM API gateway provider
+- **watsonx Orchestrate (wxO)** - Routes LLM calls through an Orchestrate tenant for tracing, guardrails, and entitlement-based billing
 
 ## Configuration Priority
 
@@ -383,6 +384,35 @@ To front RITS with a local LiteLLM proxy instead, use `AGENT_SETTING_CONFIG="set
 - Base URL: gemma-4-31B-it `/v1` endpoint on the RITS 3scale apicast host (direct preset)
 - Local proxy URL: `http://localhost:4000` (proxy preset)
 
+### Option 8: watsonx Orchestrate (wxO) Support
+
+Routes every agent role's LLM calls through your watsonx Orchestrate tenant instead of a
+provider directly — calls become traced/observable in the tenant, pass through its
+guardrails, and are billed against its entitlement.
+
+**Setup Instructions:**
+
+1. Install the optional SDK (requires Python >= 3.11): `pip install "cuga[wxo]"` or `uv sync --extra wxo`.
+2. In watsonx Orchestrate, go to **Settings -> API details** and click **Generate API key**; copy the **Service instance URL** shown on the same page.
+3. Add to your `.env` file:
+   ```env
+   # watsonx Orchestrate Configuration
+   WXO_API_KEY=your-wxo-api-key
+   WXO_INSTANCE_URL=https://api.dl.watson-orchestrate.ibm.com/instances/your-instance-id
+   AGENT_SETTING_CONFIG="settings.wxo.toml"
+
+   # Optional override — model ids are provider-prefixed per your tenant's Settings -> Models list
+   MODEL_NAME=groq/openai/gpt-oss-120b  # e.g. the Groq-hosted variant, ~25% faster than the Bedrock one
+   ```
+
+To target a local ADK dev server instead of a hosted tenant, set `WXO_INSTANCE_URL=http://localhost:4321`
+and omit `WXO_API_KEY` — local instances are auto-detected and don't require a key.
+
+**Default Values:**
+
+- Model: `watsonx/openai/gpt-oss-120b`
+- Instance URL: `http://localhost:4321` (local ADK dev server)
+
 
 ## Configuration Files
 
@@ -395,6 +425,7 @@ CUGA uses TOML configuration files located in `src/cuga/configurations/models/`:
 - `settings.openrouter.toml` - OpenRouter configuration
 - `settings.rits.toml` - RITS configuration (direct endpoint)
 - `settings.rits.proxy.toml` - RITS configuration (local LiteLLM proxy fronting RITS)
+- `settings.wxo.toml` - watsonx Orchestrate configuration
 
 Each file contains agent-specific model settings that can be overridden by environment variables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ knowledge = []  # knowledge is now built-in, no extra dependencies needed
 health = ["cuga-oak-health; python_version>='3.12'"]  # kept for backward compat, now also in core deps
 opensandbox = ["opensandbox", "opensandbox-code-interpreter"]
 evolve = ["altk-evolve>=1.1.0; python_version>='3.12'"]
+# wxO SDK requires Python >=3.11; keep it an extra so 3.10 installs are unaffected.
+wxo = ["ibm-watsonx-orchestrate-sdk>=2.15.0; python_version>='3.11'"]
 # OpenLit (PyPI) pins openai<2; litellm 1.83.x needs openai 2.x — cannot both be core deps for pip/uvx.
 # Note: When using observability extra, ensure python-dotenv>=1.1.0 is installed to avoid conflicts
 observability = ["openlit>=1.40.3"]

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 from cuga.backend.cuga_graph.utils.token_counter import ensure_model_context_profile
 from cuga.backend.llm.load_test_mock import clone_load_test_mock_chat_model, is_mock_llm_enabled
 from cuga.backend.secrets import resolve_secret
+from cuga.backend.utils.consts import LOCAL_ORCHESTRATE_URL
 from cuga.config import DEFAULT_LLM_HTTP_TIMEOUT, settings
 
 # weakref.ref(loop) on watsonx APIClient for the loop the async httpx client is for.
@@ -117,6 +118,30 @@ def _get_reasoning_chat_litellm():
 
 _get_reasoning_chat_litellm._loaded = False  # type: ignore[attr-defined]
 _get_reasoning_chat_litellm._cls = None  # type: ignore[attr-defined]
+
+
+def _get_chat_wxo():
+    """Lazy-load and return the ChatWxO class, or None if ibm_watsonx_orchestrate_sdk is missing.
+
+    No lock is needed: same reasoning as ``_get_reasoning_chat_openai`` — all callers
+    are on the asyncio event loop with no OS-thread exposure to this path.
+    """
+    if _get_chat_wxo._loaded:
+        return _get_chat_wxo._cls
+
+    try:
+        from ibm_watsonx_orchestrate_sdk.langchain import ChatWxO
+
+        _get_chat_wxo._cls = ChatWxO
+    except ImportError:
+        _get_chat_wxo._cls = None
+
+    _get_chat_wxo._loaded = True
+    return _get_chat_wxo._cls
+
+
+_get_chat_wxo._loaded = False  # type: ignore[attr-defined]
+_get_chat_wxo._cls = None  # type: ignore[attr-defined]
 
 _ENV_REF_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
 _DEFAULT_LLM_HTTP_TIMEOUT = DEFAULT_LLM_HTTP_TIMEOUT
@@ -647,6 +672,20 @@ class LLMManager:
                 default_model = "openai/gpt-oss-20b"
                 logger.info(f"No model_name specified, using default: {default_model}")
                 return default_model
+        elif platform == "wxo":
+            # For watsonx Orchestrate, check environment variables
+            env_model_name = os.environ.get('MODEL_NAME')
+            if env_model_name:
+                logger.info(f"Using MODEL_NAME from environment for wxO: {env_model_name}")
+                return env_model_name
+            elif toml_model_name:
+                logger.debug(f"Using model_name from TOML: {toml_model_name}")
+                return toml_model_name
+            else:
+                # Default fallback
+                default_model = "watsonx/openai/gpt-oss-120b"
+                logger.info(f"No model_name specified, using default: {default_model}")
+                return default_model
         elif platform == "watsonx":
             # For WatsonX, check environment variables
             env_model_name = os.environ.get('MODEL_NAME')
@@ -840,6 +879,25 @@ class LLMManager:
         # Groq SDK manages its own endpoint; any URL in config is ignored
         if platform == "groq":
             return None
+
+        # wxO: let WXO_INSTANCE_URL env override the TOML so the tenant instance can be
+        # swapped from .env without editing every per-role TOML block. Falls back to the
+        # local ADK dev server (same port CUGA already knows as LOCAL_ORCHESTRATE_URL).
+        if platform == "wxo":
+            env_instance_url = os.environ.get('WXO_INSTANCE_URL')
+            if env_instance_url and env_instance_url.strip():
+                logger.info(f"Using WXO_INSTANCE_URL from environment: {env_instance_url.strip()}")
+                return env_instance_url.strip()
+            toml_url = (
+                model_settings.get("instance_url")
+                or model_settings.get("base_url")
+                or model_settings.get("url")
+            )
+            if toml_url and str(toml_url).strip():
+                logger.debug(f"Using instance_url from TOML for wxO: {toml_url}")
+                return str(toml_url).strip()
+            logger.info(f"No instance_url specified for wxO, defaulting to local: {LOCAL_ORCHESTRATE_URL}")
+            return LOCAL_ORCHESTRATE_URL
 
         # RITS: let RITS_BASE_URL env override the TOML so model/endpoint can be
         # swapped from .env without editing every per-role TOML block.
@@ -1145,6 +1203,68 @@ class LLMManager:
                 include_extra=True,
             )
             llm = ChatGroq(**groq_params)
+        elif platform == "wxo":
+            ChatWxO = _get_chat_wxo()
+            if ChatWxO is None:
+                raise ImportError(
+                    "platform 'wxo' requires the watsonx Orchestrate SDK: "
+                    "pip install 'cuga[wxo]' (needs Python >= 3.11)"
+                )
+
+            api_key = None
+            apikey_ref = model_settings.get("api_key")
+            if apikey_ref:
+                api_key = _normalize_secret(resolve_secret(apikey_ref)) or os.environ.get(apikey_ref)
+            if not api_key:
+                api_key = _normalize_secret(resolve_secret("WXO_API_KEY")) or os.environ.get("WXO_API_KEY")
+
+            is_local = bool(base_url) and (
+                base_url.startswith("http://localhost")
+                or base_url.startswith("http://127.0.0.1")
+                or base_url.startswith("http://[::1]")
+                or base_url.startswith("http://0.0.0.0")
+            )
+            if not api_key and not is_local:
+                raise ValueError(
+                    "wxO requires an API key for a remote instance. Set WXO_API_KEY "
+                    "(Settings -> API details -> Generate API key in watsonx Orchestrate), "
+                    "or point WXO_INSTANCE_URL at a local ADK dev server."
+                )
+
+            logger.debug(f"Creating wxO model: {model_name} (instance_url={base_url})")
+            is_reasoning = self._is_reasoning_model(model_name)
+            wxo_params: Dict[str, Any] = {
+                "model": model_name,
+                "instance_url": base_url,
+                "api_key": api_key,
+                "max_tokens": max_tokens,
+                "timeout": http_timeout,
+            }
+            if not is_reasoning:
+                wxo_params["temperature"] = temperature
+                _merge_optional_sampling(
+                    wxo_params,
+                    model_settings,
+                    keys=("top_p", "frequency_penalty", "presence_penalty", "stop"),
+                )
+            else:
+                logger.debug(f"Skipping temperature for reasoning model: {model_name}")
+                _merge_optional_sampling(
+                    wxo_params,
+                    model_settings,
+                    keys=("stop",),
+                )
+
+            ssl_verify = self._get_ssl_verify(model_settings)
+            if ssl_verify is not True:
+                wxo_params["verify"] = ssl_verify
+                # ChatWxO only builds a *sync* httpx.Client for `verify`; without an
+                # explicit async client CUGA's async invoke/stream path would silently
+                # ignore a disabled/custom CA.
+                wxo_params["http_async_client"] = httpx.AsyncClient(verify=ssl_verify)
+
+            llm = ChatWxO(**wxo_params)
+            ensure_model_context_profile(llm, model_name)
         elif platform == "watsonx":
             from langchain_ibm import ChatWatsonx
 

--- a/src/cuga/backend/llm/models.py
+++ b/src/cuga/backend/llm/models.py
@@ -5,6 +5,7 @@ import threading
 import weakref
 from datetime import date
 from typing import Dict, Any, Optional, Mapping, TYPE_CHECKING
+from urllib.parse import urlsplit
 import hashlib
 import json
 import os
@@ -249,6 +250,32 @@ def _merge_optional_sampling(
             target[key] = model_settings[key]
     if include_extra and model_settings.get("extra_params") is not None:
         target.update(_safe_extra_params(model_settings.get("extra_params")))
+
+
+_WXO_LOCAL_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+def _is_local_wxo_url(url: Optional[str]) -> bool:
+    """True only for an exact loopback host on the canonical local ADK port.
+
+    Uses urllib.parse rather than string prefixes: "http://localhost.example.com"
+    starts with "http://localhost" but is a different, real, remote host that a
+    naive prefix check would misclassify as local — letting a keyless call
+    reach it. Requires an exact hostname match, http scheme, and the same port
+    as LOCAL_ORCHESTRATE_URL, not just "some port on a local-looking host".
+    """
+    if not url:
+        return False
+    try:
+        parsed = urlsplit(url)
+        canonical_port = urlsplit(LOCAL_ORCHESTRATE_URL).port
+        return (
+            parsed.scheme == "http"
+            and parsed.hostname in _WXO_LOCAL_HOSTNAMES
+            and parsed.port == canonical_port
+        )
+    except ValueError:
+        return False
 
 
 def _coerce_settings_dict(model_settings: Any) -> Dict[str, Any]:
@@ -1218,12 +1245,7 @@ class LLMManager:
             if not api_key:
                 api_key = _normalize_secret(resolve_secret("WXO_API_KEY")) or os.environ.get("WXO_API_KEY")
 
-            is_local = bool(base_url) and (
-                base_url.startswith("http://localhost")
-                or base_url.startswith("http://127.0.0.1")
-                or base_url.startswith("http://[::1]")
-                or base_url.startswith("http://0.0.0.0")
-            )
+            is_local = _is_local_wxo_url(base_url)
             if not api_key and not is_local:
                 raise ValueError(
                     "wxO requires an API key for a remote instance. Set WXO_API_KEY "

--- a/src/cuga/backend/secrets/seed.py
+++ b/src/cuga/backend/secrets/seed.py
@@ -15,6 +15,7 @@ _STATIC_ENV_SEED_MAP: dict[str, str] = {
     "MINIMAX_API_KEY": "minimax-api-key",
     "RITS_API_KEY_RESTRICT": "rits-api-key",
     "WATSONX_APIKEY": "watsonx-api-key",
+    "WXO_API_KEY": "wxo-api-key",
     "AZURE_OPENAI_API_KEY": "azure-openai-api-key",
     "LITELLM_API_KEY": "litellm-api-key",
 }
@@ -140,6 +141,7 @@ def resolve_llm_api_key_ref() -> str:
         "minimax": "minimax-api-key",
         "rits": "rits-api-key",
         "watsonx": "watsonx-api-key",
+        "wxo": "wxo-api-key",
         "azure": "azure-openai-api-key",
         "litellm": "litellm-api-key",
     }

--- a/src/cuga/backend/secrets/seed.py
+++ b/src/cuga/backend/secrets/seed.py
@@ -126,8 +126,57 @@ def seed_secrets_from_env_sync() -> None:
         asyncio.run(seed_secrets_from_env())
 
 
+_PLATFORM_API_KEY_SLUG: dict[str, str] = {
+    "groq": "groq-api-key",
+    "openai": "openai-api-key",
+    "anthropic": "anthropic-api-key",
+    "google-genai": "google-api-key",
+    "openrouter": "openrouter-api-key",
+    "minimax": "minimax-api-key",
+    "rits": "rits-api-key",
+    "watsonx": "watsonx-api-key",
+    "wxo": "wxo-api-key",
+    "azure": "azure-openai-api-key",
+    "litellm": "litellm-api-key",
+}
+
+
+def _active_platform() -> str | None:
+    """Return the platform configured for the `code` agent role, or None if unavailable.
+
+    Mirrors the local-mode platform resolution in ``create_llm_from_config``.
+    """
+    try:
+        from cuga.config import settings
+
+        code_model = settings.agent.code.model
+        if not code_model:
+            return None
+        platform = (
+            code_model.get("platform")
+            if hasattr(code_model, "get")
+            else getattr(code_model, "platform", None)
+        )
+        return str(platform).lower() if platform else None
+    except Exception:
+        return None
+
+
 def resolve_llm_api_key_ref() -> str:
-    """Return the db:// reference for the active LLM provider's API key, or ''."""
+    """Return the db:// reference for the active LLM provider's API key, or ''.
+
+    Checks the actively configured platform first (e.g. TOML `platform = "wxo"`), before
+    falling back to guessing from the MODEL_NAME env var. The guess is a substring match
+    that can misfire when one provider's model id embeds another provider's name (e.g. a
+    wxO model override like "groq/openai/gpt-oss-120b" contains "openai" as a substring),
+    so it is only a fallback for when the active platform can't be determined.
+    """
+    active_platform = _active_platform()
+    if active_platform:
+        slug = _PLATFORM_API_KEY_SLUG.get(active_platform)
+        if slug:
+            return f"db://{slug}"
+
     model_name = os.environ.get("MODEL_NAME", "").lower()
     provider_hints = {
         "groq": "groq-api-key",

--- a/src/cuga/configurations/models/settings.wxo.toml
+++ b/src/cuga/configurations/models/settings.wxo.toml
@@ -1,0 +1,59 @@
+[agent.task_decomposition.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.shortlister.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.planner.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.chat.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.plan_controller.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.final_answer.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 32000
+
+[agent.code.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.code_planner.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.qa.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 16000
+
+[agent.action.model]
+platform = "wxo"
+model_name = "watsonx/openai/gpt-oss-120b"
+temperature = 0.1
+max_tokens = 2000

--- a/tests/integration/test_llm_wxo_config_publish.py
+++ b/tests/integration/test_llm_wxo_config_publish.py
@@ -23,6 +23,11 @@ import pytest
 
 from cuga.backend.llm.models import LLMManager, set_current_llm_override
 
+# "integration" is not a registered marker in pyproject.toml (--strict-markers would
+# reject it); the provider and settings here are fully mocked, so "unit" is the
+# applicable registered marker despite this file's directory.
+pytestmark = pytest.mark.unit
+
 REMOTE_INSTANCE_URL = "https://api.dl.watson-orchestrate.ibm.com/instances/abc-123"
 
 
@@ -71,12 +76,17 @@ def vault_mode_settings():
 
 
 @pytest.fixture(autouse=True)
-def reset_llm_state():
+def reset_llm_state(monkeypatch):
     mgr = LLMManager()
     mgr._models.clear()
     mgr._pre_instantiated_model = None
     set_current_llm_override(None)
     FakeChatWxO.instances.clear()
+    # _get_base_url gives WXO_INSTANCE_URL env precedence over the configured
+    # base_url; clear it (and its siblings) so tests are deterministic
+    # regardless of what's ambient on a given machine or CI runner.
+    for key in ("WXO_API_KEY", "WXO_INSTANCE_URL", "MODEL_NAME"):
+        monkeypatch.delenv(key, raising=False)
     yield
     mgr._models.clear()
     mgr._pre_instantiated_model = None

--- a/tests/integration/test_llm_wxo_config_publish.py
+++ b/tests/integration/test_llm_wxo_config_publish.py
@@ -1,0 +1,123 @@
+"""Integration test for the Manage-UI publish path with a wxO provider config.
+
+``create_llm_from_config`` (models.py) is the function manage_routes calls after
+a config publish/draft-save. This pins that a "wxo" provider config flows
+through to the same ``_create_llm_instance`` wxo branch exercised in
+``tests/unit/test_llm_wxo_provider.py`` — in particular that the UI's
+``base_url`` field lands on ChatWxO's ``instance_url``, and that a missing key
+surfaces as the wxo branch's own ``ValueError`` (callers of
+``create_llm_from_config`` are documented to catch ``ValueError`` and fall back
+to env/TOML settings).
+
+Uses vault-mode settings (``force_env=False``) so the config's own
+``provider``/``model`` are honored — in local mode ``create_llm_from_config``
+overrides both from ``settings.agent.code.model`` (see
+``tests/integration/test_llm_config_publish.py`` for that path).
+"""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from cuga.backend.llm.models import LLMManager, set_current_llm_override
+
+REMOTE_INSTANCE_URL = "https://api.dl.watson-orchestrate.ibm.com/instances/abc-123"
+
+
+class FakeChatWxO:
+    """Minimal stand-in for ChatWxO that records constructor kwargs.
+
+    See ``tests/unit/test_llm_wxo_provider.py`` for the rationale (a bare
+    ``MagicMock`` would misleadingly satisfy attribute checks that
+    ``_update_model_parameters`` performs on the returned model).
+    """
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.model_kwargs = {}
+        self.model_name = kwargs.get("model", "")
+        self.temperature = kwargs.get("temperature")
+        self.max_tokens = kwargs.get("max_tokens")
+        self.profile = None
+        FakeChatWxO.instances.append(self)
+
+
+def _vault_settings_module_stub():
+    """Vault-mode settings so create_llm_from_config honors llm_cfg's own provider.
+
+    Mirrors tests/integration/test_llm_config_publish.py's stub: models.py
+    binds `settings` at import, so patch both `cuga.config.settings` and
+    `cuga.backend.llm.models.settings`.
+    """
+    return SimpleNamespace(
+        secrets=SimpleNamespace(mode="vault", force_env=False),
+        agent=SimpleNamespace(code=SimpleNamespace(model={"platform": "wxo", "max_tokens": 16000})),
+        connections=SimpleNamespace(ssl_ca_bundle=None, llm_http_timeout=None),
+    )
+
+
+@contextmanager
+def vault_mode_settings():
+    stub = _vault_settings_module_stub()
+    with (
+        patch("cuga.config.settings", stub),
+        patch("cuga.backend.llm.models.settings", stub),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def reset_llm_state():
+    mgr = LLMManager()
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+    FakeChatWxO.instances.clear()
+    yield
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+    FakeChatWxO.instances.clear()
+
+
+class TestCreateLlmFromConfigWxo:
+    def test_base_url_lands_on_instance_url(self, monkeypatch):
+        from cuga.backend.llm.models import create_llm_from_config
+
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with vault_mode_settings():
+            with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+                with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                    create_llm_from_config(
+                        {
+                            "provider": "wxo",
+                            "model": "watsonx/openai/gpt-oss-120b",
+                            "base_url": REMOTE_INSTANCE_URL,
+                            "api_key": "test-key",
+                        }
+                    )
+
+        assert len(FakeChatWxO.instances) == 1
+        kwargs = FakeChatWxO.instances[0].kwargs
+        assert kwargs["instance_url"] == REMOTE_INSTANCE_URL
+        assert kwargs["model"] == "watsonx/openai/gpt-oss-120b"
+
+    def test_missing_key_raises_value_error(self, monkeypatch):
+        from cuga.backend.llm.models import create_llm_from_config
+
+        monkeypatch.delenv("WXO_API_KEY", raising=False)
+        with vault_mode_settings():
+            with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+                with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                    with pytest.raises(ValueError, match="WXO_API_KEY"):
+                        create_llm_from_config(
+                            {
+                                "provider": "wxo",
+                                "model": "watsonx/openai/gpt-oss-120b",
+                                "base_url": REMOTE_INSTANCE_URL,
+                            }
+                        )

--- a/tests/unit/test_llm_wxo_provider.py
+++ b/tests/unit/test_llm_wxo_provider.py
@@ -13,13 +13,15 @@ local-dev vs remote API-key requirement, and the ``resolve_llm_api_key_ref``
 secret hint.
 """
 
-import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from cuga.backend.llm.models import LLMManager, set_current_llm_override
 from cuga.backend.utils.consts import LOCAL_ORCHESTRATE_URL
+
+pytestmark = pytest.mark.unit
 
 BASE_MODEL_SETTINGS = {
     "platform": "wxo",
@@ -77,21 +79,19 @@ class FakeChatWxO:
 
 
 @pytest.fixture(autouse=True)
-def reset_llm_state():
+def reset_llm_state(monkeypatch):
     mgr = LLMManager()
     mgr._models.clear()
     mgr._pre_instantiated_model = None
     set_current_llm_override(None)
     FakeChatWxO.instances.clear()
     for key in ("WXO_API_KEY", "WXO_INSTANCE_URL", "MODEL_NAME"):
-        os.environ.pop(key, None)
+        monkeypatch.delenv(key, raising=False)
     yield
     mgr._models.clear()
     mgr._pre_instantiated_model = None
     set_current_llm_override(None)
     FakeChatWxO.instances.clear()
-    for key in ("WXO_API_KEY", "WXO_INSTANCE_URL", "MODEL_NAME"):
-        os.environ.pop(key, None)
 
 
 class TestWxoModelName:
@@ -150,6 +150,42 @@ class TestWxoBaseUrl:
     def test_toml_url_strips_whitespace(self):
         mgr = LLMManager()
         assert mgr._get_base_url({"instance_url": f" {REMOTE_INSTANCE_URL} "}, "wxo") == (REMOTE_INSTANCE_URL)
+
+
+class TestIsLocalWxoUrl:
+    """Direct coverage of the exact-match parser, isolated from client construction."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:4321",
+            "http://127.0.0.1:4321",
+            "http://[::1]:4321",
+            "http://0.0.0.0:4321",
+        ],
+    )
+    def test_exact_local_urls_are_local(self, url):
+        from cuga.backend.llm.models import _is_local_wxo_url
+
+        assert _is_local_wxo_url(url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            None,
+            "",
+            REMOTE_INSTANCE_URL,
+            "http://localhost.example.com:4321",
+            "http://evil.com/localhost:4321",
+            "http://localhost:9999",
+            "https://localhost:4321",
+            "http://localhost:abc",
+        ],
+    )
+    def test_non_local_or_malformed_urls_are_not_local(self, url):
+        from cuga.backend.llm.models import _is_local_wxo_url
+
+        assert _is_local_wxo_url(url) is False
 
 
 class TestWxoCreateInstance:
@@ -271,6 +307,25 @@ class TestWxoCreateInstance:
                 mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "instance_url": local_url})
 
         assert FakeChatWxO.instances[0].kwargs["api_key"] is None
+
+    @pytest.mark.parametrize(
+        "spoofed_url",
+        [
+            "http://localhost.example.com:4321",  # hostname suffix, not the loopback host
+            "http://localhost:9999",  # loopback host, but not the ADK dev port
+            "https://localhost:4321",  # loopback host, but not http
+        ],
+    )
+    def test_missing_api_key_on_local_looking_but_not_local_url_raises(self, monkeypatch, spoofed_url):
+        """A naive string-prefix check would misclassify these as local and skip
+        requiring a key, letting a keyless call reach a host that only looks
+        local. is_local must require an exact hostname/scheme/port match."""
+        monkeypatch.delenv("WXO_API_KEY", raising=False)
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                with pytest.raises(ValueError, match="WXO_API_KEY"):
+                    mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "instance_url": spoofed_url})
 
     def test_ssl_verify_default_true_no_async_client_override(self, monkeypatch):
         monkeypatch.setenv("WXO_API_KEY", "test-key")
@@ -395,30 +450,85 @@ class TestWxoContextProfile:
         assert llm.profile["max_input_tokens"] == DEFAULT_CONTEXT_SIZE
 
 
+def _stub_active_platform(platform):
+    """Settings stub exposing only what _active_platform reads: agent.code.model.platform."""
+    return SimpleNamespace(agent=SimpleNamespace(code=SimpleNamespace(model={"platform": platform})))
+
+
 class TestWxoSecretHint:
-    def test_env_var_present_resolves_to_wxo_key(self, monkeypatch):
+    """resolve_llm_api_key_ref must key off the *actively configured platform*
+    (settings.agent.code.model.platform), not guess from MODEL_NAME — a model
+    id string can embed another provider's name as a substring (the wxO
+    default id contains "watsonx/"; the documented groq-hosted override
+    contains "openai"), and an ambient sibling key (e.g. GROQ_API_KEY, present
+    in CI for other jobs) can otherwise win by dict-iteration order before
+    WXO_API_KEY is ever reached — this is the exact bug that broke CI.
+    """
+
+    def test_active_wxo_platform_wins_over_ambient_sibling_key(self, monkeypatch):
         from cuga.backend.secrets.seed import resolve_llm_api_key_ref
 
         monkeypatch.delenv("MODEL_NAME", raising=False)
+        monkeypatch.setenv("GROQ_API_KEY", "ambient-groq-key")
         monkeypatch.setenv("WXO_API_KEY", "test-key")
-        assert resolve_llm_api_key_ref() == "db://wxo-api-key"
+        with patch("cuga.config.settings", _stub_active_platform("wxo")):
+            assert resolve_llm_api_key_ref() == "db://wxo-api-key"
 
-    def test_default_wxo_model_name_hint_collides_with_watsonx(self, monkeypatch):
-        """Pins existing behavior: the default wxO model id embeds "watsonx/" as
-        a provider prefix, and the hint matcher's longest-substring-wins rule
-        picks "watsonx" over "wxo" for that string. This is a pre-existing
-        property of the substring-hint heuristic (shared by other providers
-        whose model ids embed another provider's name, e.g. groq's default
-        "openai/gpt-oss-20b"), not something introduced by the wxo platform.
-        Real wxO setups still resolve correctly because WXO_API_KEY, once set,
-        is found directly by resolve_llm_api_key_ref's second pass over actual
-        env vars — this hint pass only runs when MODEL_NAME is also exported.
-        """
+    def test_active_wxo_platform_ignores_default_model_id_hint(self, monkeypatch):
         from cuga.backend.secrets.seed import resolve_llm_api_key_ref
 
         monkeypatch.delenv("WXO_API_KEY", raising=False)
-        monkeypatch.setenv("MODEL_NAME", WXO_DEFAULT_MODEL_NAME)
-        assert resolve_llm_api_key_ref() == "db://watsonx-api-key"
+        monkeypatch.setenv("MODEL_NAME", WXO_DEFAULT_MODEL_NAME)  # contains "watsonx/"
+        with patch("cuga.config.settings", _stub_active_platform("wxo")):
+            assert resolve_llm_api_key_ref() == "db://wxo-api-key"
+
+    def test_active_wxo_platform_ignores_groq_override_hint(self, monkeypatch):
+        from cuga.backend.secrets.seed import resolve_llm_api_key_ref
+
+        monkeypatch.delenv("WXO_API_KEY", raising=False)
+        monkeypatch.setenv("MODEL_NAME", "groq/openai/gpt-oss-120b")  # contains "openai"
+        with patch("cuga.config.settings", _stub_active_platform("wxo")):
+            assert resolve_llm_api_key_ref() == "db://wxo-api-key"
+
+    def test_active_platform_other_than_wxo_still_resolves_correctly(self, monkeypatch):
+        """The fix is general: a stale MODEL_NAME hint never overrides the
+        actually-configured platform, for any provider — not just wxo."""
+        from cuga.backend.secrets.seed import resolve_llm_api_key_ref
+
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.setenv("MODEL_NAME", "openai/gpt-oss-120b")  # groq's own default id
+        with patch("cuga.config.settings", _stub_active_platform("groq")):
+            assert resolve_llm_api_key_ref() == "db://groq-api-key"
+
+    def test_unknown_active_platform_falls_back_to_model_name_hint(self, monkeypatch):
+        from cuga.backend.secrets.seed import resolve_llm_api_key_ref
+
+        monkeypatch.delenv("WXO_API_KEY", raising=False)
+        monkeypatch.setenv("MODEL_NAME", "claude-opus-4-6")
+        with patch("cuga.backend.secrets.seed._active_platform", return_value=None):
+            assert resolve_llm_api_key_ref() == "db://anthropic-api-key"
+
+    def test_unknown_active_platform_falls_back_to_ambient_env_scan(self, monkeypatch):
+        from cuga.backend.secrets.seed import resolve_llm_api_key_ref
+
+        monkeypatch.delenv("MODEL_NAME", raising=False)
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.secrets.seed._active_platform", return_value=None):
+            assert resolve_llm_api_key_ref() == "db://wxo-api-key"
+
+    def test_active_platform_lookup_failure_does_not_raise(self, monkeypatch):
+        """settings access is best-effort: any exception (e.g. cuga.config not
+        importable in some embedding) must fall back, not propagate."""
+        from cuga.backend.secrets.seed import resolve_llm_api_key_ref
+
+        monkeypatch.delenv("MODEL_NAME", raising=False)
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        # An object with no `.agent` attribute makes `settings.agent...` raise
+        # AttributeError, exercising the except-Exception fallback in _active_platform.
+        with patch("cuga.config.settings", object()):
+            assert resolve_llm_api_key_ref() == "db://wxo-api-key"
 
 
 class TestWxoUnsupportedPlatform:

--- a/tests/unit/test_llm_wxo_provider.py
+++ b/tests/unit/test_llm_wxo_provider.py
@@ -455,6 +455,23 @@ def _stub_active_platform(platform):
     return SimpleNamespace(agent=SimpleNamespace(code=SimpleNamespace(model={"platform": platform})))
 
 
+def _clear_sibling_provider_keys(monkeypatch):
+    """Clear every static provider env var except WXO_API_KEY.
+
+    Tests that exercise the ambient-env-scan fallback in resolve_llm_api_key_ref
+    must not assume which sibling keys happen to be unset — CI runners carry
+    real keys (e.g. WATSONX_APIKEY, GROQ_API_KEY) for other jobs' sake, and any
+    of them sits earlier than WXO_API_KEY in _STATIC_ENV_SEED_MAP's iteration
+    order. This is the exact bug class #c1 fixed for the active-platform path;
+    it applies here too for the fallback path.
+    """
+    from cuga.backend.secrets.seed import _STATIC_ENV_SEED_MAP
+
+    for env_var in _STATIC_ENV_SEED_MAP:
+        if env_var != "WXO_API_KEY":
+            monkeypatch.delenv(env_var, raising=False)
+
+
 class TestWxoSecretHint:
     """resolve_llm_api_key_ref must key off the *actively configured platform*
     (settings.agent.code.model.platform), not guess from MODEL_NAME — a model
@@ -512,7 +529,7 @@ class TestWxoSecretHint:
         from cuga.backend.secrets.seed import resolve_llm_api_key_ref
 
         monkeypatch.delenv("MODEL_NAME", raising=False)
-        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        _clear_sibling_provider_keys(monkeypatch)
         monkeypatch.setenv("WXO_API_KEY", "test-key")
         with patch("cuga.backend.secrets.seed._active_platform", return_value=None):
             assert resolve_llm_api_key_ref() == "db://wxo-api-key"
@@ -523,7 +540,7 @@ class TestWxoSecretHint:
         from cuga.backend.secrets.seed import resolve_llm_api_key_ref
 
         monkeypatch.delenv("MODEL_NAME", raising=False)
-        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        _clear_sibling_provider_keys(monkeypatch)
         monkeypatch.setenv("WXO_API_KEY", "test-key")
         # An object with no `.agent` attribute makes `settings.agent...` raise
         # AttributeError, exercising the except-Exception fallback in _active_platform.

--- a/tests/unit/test_llm_wxo_provider.py
+++ b/tests/unit/test_llm_wxo_provider.py
@@ -1,0 +1,430 @@
+"""Tests for the watsonx Orchestrate (wxO) LLM provider branch in LLMManager.
+
+``ChatWxO`` (from the optional ``ibm-watsonx-orchestrate-sdk`` extra) is a
+``ChatOpenAI`` subclass that routes calls through an Orchestrate tenant's model
+gateway, exchanging an API key for a JWT it refreshes on every request. It is
+loaded lazily via ``_get_chat_wxo`` (mirroring ``_get_reasoning_chat_litellm``)
+so importing ``cuga.backend.llm.models`` never requires the SDK — it is an
+optional extra gated on Python >= 3.11.
+
+These tests lock: model-name/instance-url resolution, the client wiring in
+``_create_llm_instance`` (param names, key resolution, SSL, caching), the
+local-dev vs remote API-key requirement, and the ``resolve_llm_api_key_ref``
+secret hint.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cuga.backend.llm.models import LLMManager, set_current_llm_override
+from cuga.backend.utils.consts import LOCAL_ORCHESTRATE_URL
+
+BASE_MODEL_SETTINGS = {
+    "platform": "wxo",
+    "max_tokens": 100,
+    "temperature": 0.1,
+}
+
+WXO_DEFAULT_MODEL_NAME = "watsonx/openai/gpt-oss-120b"
+REMOTE_INSTANCE_URL = "https://api.dl.watson-orchestrate.ibm.com/instances/abc-123"
+
+
+def _self_signed_cert_pem() -> bytes:
+    """A throwaway self-signed cert, valid enough for SSLContext.load_verify_locations."""
+    import datetime
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "cuga-test-ca")])
+    epoch = datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(epoch)
+        .not_valid_after(epoch + datetime.timedelta(days=36500))
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+class FakeChatWxO:
+    """Minimal stand-in for ChatWxO that records constructor kwargs.
+
+    A bare ``MagicMock`` would satisfy ``hasattr(model, 'model_kwargs')``
+    misleadingly for callers that inspect the returned model (e.g.
+    ``_update_model_parameters``), so use a small real object instead.
+    """
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.model_kwargs = {}
+        self.model_name = kwargs.get("model", "")
+        self.temperature = kwargs.get("temperature")
+        self.max_tokens = kwargs.get("max_tokens")
+        self.profile = None
+        FakeChatWxO.instances.append(self)
+
+
+@pytest.fixture(autouse=True)
+def reset_llm_state():
+    mgr = LLMManager()
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+    FakeChatWxO.instances.clear()
+    for key in ("WXO_API_KEY", "WXO_INSTANCE_URL", "MODEL_NAME"):
+        os.environ.pop(key, None)
+    yield
+    mgr._models.clear()
+    mgr._pre_instantiated_model = None
+    set_current_llm_override(None)
+    FakeChatWxO.instances.clear()
+    for key in ("WXO_API_KEY", "WXO_INSTANCE_URL", "MODEL_NAME"):
+        os.environ.pop(key, None)
+
+
+class TestWxoModelName:
+    def test_default_model_name(self):
+        mgr = LLMManager()
+        assert mgr._get_model_name({}, "wxo") == WXO_DEFAULT_MODEL_NAME
+
+    def test_toml_model_name_wins_over_default(self):
+        mgr = LLMManager()
+        assert mgr._get_model_name({"model_name": "groq/openai/gpt-oss-120b"}, "wxo") == (
+            "groq/openai/gpt-oss-120b"
+        )
+
+    def test_config_model_wins_over_toml(self):
+        mgr = LLMManager()
+        settings = {"model": "groq/openai/gpt-oss-120b", "model_name": "watsonx/openai/gpt-oss-120b"}
+        assert mgr._get_model_name(settings, "wxo") == "groq/openai/gpt-oss-120b"
+
+    def test_env_model_name_wins_over_toml(self, monkeypatch):
+        monkeypatch.setenv("MODEL_NAME", "groq/openai/gpt-oss-120b")
+        mgr = LLMManager()
+        assert mgr._get_model_name({"model_name": "watsonx/openai/gpt-oss-120b"}, "wxo") == (
+            "groq/openai/gpt-oss-120b"
+        )
+
+
+class TestWxoBaseUrl:
+    def test_default_is_local_orchestrate_url(self):
+        mgr = LLMManager()
+        assert mgr._get_base_url({}, "wxo") == LOCAL_ORCHESTRATE_URL
+
+    def test_toml_instance_url_wins_over_default(self):
+        mgr = LLMManager()
+        assert mgr._get_base_url({"instance_url": REMOTE_INSTANCE_URL}, "wxo") == REMOTE_INSTANCE_URL
+
+    def test_toml_base_url_alias(self):
+        mgr = LLMManager()
+        assert mgr._get_base_url({"base_url": REMOTE_INSTANCE_URL}, "wxo") == REMOTE_INSTANCE_URL
+
+    def test_toml_url_alias(self):
+        mgr = LLMManager()
+        assert mgr._get_base_url({"url": REMOTE_INSTANCE_URL}, "wxo") == REMOTE_INSTANCE_URL
+
+    def test_env_instance_url_wins_over_toml(self, monkeypatch):
+        monkeypatch.setenv("WXO_INSTANCE_URL", REMOTE_INSTANCE_URL)
+        mgr = LLMManager()
+        assert mgr._get_base_url({"instance_url": "https://ignored/instances/x"}, "wxo") == (
+            REMOTE_INSTANCE_URL
+        )
+
+    def test_env_instance_url_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("WXO_INSTANCE_URL", f"  {REMOTE_INSTANCE_URL}  ")
+        mgr = LLMManager()
+        assert mgr._get_base_url({}, "wxo") == REMOTE_INSTANCE_URL
+
+    def test_toml_url_strips_whitespace(self):
+        mgr = LLMManager()
+        assert mgr._get_base_url({"instance_url": f" {REMOTE_INSTANCE_URL} "}, "wxo") == (REMOTE_INSTANCE_URL)
+
+
+class TestWxoCreateInstance:
+    def test_client_receives_expected_param_names(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL, "timeout": 200}
+                )
+
+        assert len(FakeChatWxO.instances) == 1
+        kwargs = FakeChatWxO.instances[0].kwargs
+        assert kwargs["model"] == WXO_DEFAULT_MODEL_NAME
+        assert kwargs["instance_url"] == REMOTE_INSTANCE_URL
+        assert kwargs["api_key"] == "test-key"
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["timeout"] == 200.0
+        # ChatWxO manages its own OpenAI-side wiring — never pass these directly.
+        assert "openai_api_key" not in kwargs
+        assert "openai_api_base" not in kwargs
+        assert "model_name" not in kwargs
+
+    def test_key_from_settings_ref_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "env-key")
+        with patch(
+            "cuga.backend.llm.models.resolve_secret",
+            side_effect=lambda ref: "ref-key" if ref == "MY_WXO_REF" else None,
+        ):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {
+                        **BASE_MODEL_SETTINGS,
+                        "instance_url": REMOTE_INSTANCE_URL,
+                        "api_key": "MY_WXO_REF",
+                    }
+                )
+
+        assert FakeChatWxO.instances[0].kwargs["api_key"] == "ref-key"
+
+    def test_temperature_present_for_non_reasoning_model(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL, "temperature": 0.3}
+                )
+
+        assert FakeChatWxO.instances[0].kwargs["temperature"] == 0.3
+
+    def test_temperature_dropped_for_reasoning_model(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {
+                        **BASE_MODEL_SETTINGS,
+                        "instance_url": REMOTE_INSTANCE_URL,
+                        "model": "watsonx/openai/gpt-5",
+                    }
+                )
+
+        assert "temperature" not in FakeChatWxO.instances[0].kwargs
+
+    def test_optional_sampling_forwarded_only_when_set(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {
+                        **BASE_MODEL_SETTINGS,
+                        "instance_url": REMOTE_INSTANCE_URL,
+                        "top_p": 0.9,
+                    }
+                )
+
+        kwargs = FakeChatWxO.instances[0].kwargs
+        assert kwargs["top_p"] == 0.9
+        assert "frequency_penalty" not in kwargs
+        assert "presence_penalty" not in kwargs
+        assert "stop" not in kwargs
+
+    def test_default_headers_never_passed(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL})
+
+        assert "default_headers" not in FakeChatWxO.instances[0].kwargs
+
+    def test_missing_api_key_on_remote_instance_raises(self, monkeypatch):
+        monkeypatch.delenv("WXO_API_KEY", raising=False)
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                with pytest.raises(ValueError, match="WXO_API_KEY"):
+                    mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL})
+
+    @pytest.mark.parametrize(
+        "local_url",
+        [
+            "http://localhost:4321",
+            "http://127.0.0.1:4321",
+            "http://[::1]:4321",
+            "http://0.0.0.0:4321",
+        ],
+    )
+    def test_missing_api_key_on_local_instance_does_not_raise(self, monkeypatch, local_url):
+        monkeypatch.delenv("WXO_API_KEY", raising=False)
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "instance_url": local_url})
+
+        assert FakeChatWxO.instances[0].kwargs["api_key"] is None
+
+    def test_ssl_verify_default_true_no_async_client_override(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL})
+
+        kwargs = FakeChatWxO.instances[0].kwargs
+        assert "verify" not in kwargs
+        assert "http_async_client" not in kwargs
+
+    def test_ssl_disabled_passes_verify_false_and_async_client(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL, "disable_ssl": True}
+                )
+
+        kwargs = FakeChatWxO.instances[0].kwargs
+        assert kwargs["verify"] is False
+        assert kwargs["http_async_client"] is not None
+
+    def test_custom_ca_bundle_passes_verify_path_and_async_client(self, monkeypatch, tmp_path):
+        # httpx.AsyncClient(verify=<path>) eagerly loads the file into an SSLContext,
+        # so the bundle must be a real, parseable certificate.
+        ca_bundle = tmp_path / "ca.pem"
+        ca_bundle.write_bytes(_self_signed_cert_pem())
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {
+                        **BASE_MODEL_SETTINGS,
+                        "instance_url": REMOTE_INSTANCE_URL,
+                        "ssl_ca_bundle": str(ca_bundle),
+                    }
+                )
+
+        kwargs = FakeChatWxO.instances[0].kwargs
+        assert kwargs["verify"] == str(ca_bundle)
+        assert kwargs["http_async_client"] is not None
+
+    def test_sdk_missing_raises_actionable_import_error(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=None):
+                mgr = LLMManager()
+                with pytest.raises(ImportError, match=r"cuga\[wxo\]"):
+                    mgr._create_llm_instance({**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL})
+
+
+class TestWxoCaching:
+    def test_same_settings_reuse_cached_instance(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                model_settings = {**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL}
+                first = mgr.get_model(model_settings)
+                second = mgr.get_model(model_settings)
+
+        assert len(FakeChatWxO.instances) == 1
+        assert first is second
+
+    def test_different_instance_url_creates_distinct_instances(self, monkeypatch):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr.get_model({**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL})
+                mgr.get_model(
+                    {
+                        **BASE_MODEL_SETTINGS,
+                        "instance_url": "https://api.dl.watson-orchestrate.ibm.com/instances/other",
+                    }
+                )
+
+        assert len(FakeChatWxO.instances) == 2
+
+
+class TestWxoContextProfile:
+    @pytest.mark.parametrize(
+        "model_name,expected",
+        [
+            ("watsonx/openai/gpt-oss-120b", 131072),
+            ("groq/openai/gpt-oss-120b", 131072),
+            ("watsonx/meta-llama/llama-3.3-70b-instruct", 128000),
+        ],
+    )
+    def test_known_model_sets_context_profile(self, monkeypatch, model_name, expected):
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {**BASE_MODEL_SETTINGS, "instance_url": REMOTE_INSTANCE_URL, "model": model_name}
+                )
+
+        llm = FakeChatWxO.instances[0]
+        assert llm.profile["max_input_tokens"] == expected
+
+    def test_unknown_model_falls_back_to_default_context_size(self, monkeypatch):
+        from cuga.backend.cuga_graph.utils.token_counter import DEFAULT_CONTEXT_SIZE
+
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        with patch("cuga.backend.llm.models.resolve_secret", return_value=None):
+            with patch("cuga.backend.llm.models._get_chat_wxo", return_value=FakeChatWxO):
+                mgr = LLMManager()
+                mgr._create_llm_instance(
+                    {
+                        **BASE_MODEL_SETTINGS,
+                        "instance_url": REMOTE_INSTANCE_URL,
+                        "model": "watsonx/ibm/granite-3-8b-instruct",
+                    }
+                )
+
+        llm = FakeChatWxO.instances[0]
+        assert llm.profile["max_input_tokens"] == DEFAULT_CONTEXT_SIZE
+
+
+class TestWxoSecretHint:
+    def test_env_var_present_resolves_to_wxo_key(self, monkeypatch):
+        from cuga.backend.secrets.seed import resolve_llm_api_key_ref
+
+        monkeypatch.delenv("MODEL_NAME", raising=False)
+        monkeypatch.setenv("WXO_API_KEY", "test-key")
+        assert resolve_llm_api_key_ref() == "db://wxo-api-key"
+
+    def test_default_wxo_model_name_hint_collides_with_watsonx(self, monkeypatch):
+        """Pins existing behavior: the default wxO model id embeds "watsonx/" as
+        a provider prefix, and the hint matcher's longest-substring-wins rule
+        picks "watsonx" over "wxo" for that string. This is a pre-existing
+        property of the substring-hint heuristic (shared by other providers
+        whose model ids embed another provider's name, e.g. groq's default
+        "openai/gpt-oss-20b"), not something introduced by the wxo platform.
+        Real wxO setups still resolve correctly because WXO_API_KEY, once set,
+        is found directly by resolve_llm_api_key_ref's second pass over actual
+        env vars — this hint pass only runs when MODEL_NAME is also exported.
+        """
+        from cuga.backend.secrets.seed import resolve_llm_api_key_ref
+
+        monkeypatch.delenv("WXO_API_KEY", raising=False)
+        monkeypatch.setenv("MODEL_NAME", WXO_DEFAULT_MODEL_NAME)
+        assert resolve_llm_api_key_ref() == "db://watsonx-api-key"
+
+
+class TestWxoUnsupportedPlatform:
+    def test_typo_platform_still_raises(self):
+        mgr = LLMManager()
+        with pytest.raises(ValueError, match="Unsupported platform"):
+            mgr._create_llm_instance(
+                {**BASE_MODEL_SETTINGS, "platform": "wxo-typo", "model_name": "some-model"}
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1323,6 +1323,9 @@ opensandbox = [
 profiling = [
     { name = "memray", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
 ]
+wxo = [
+    { name = "ibm-watsonx-orchestrate-sdk", marker = "python_full_version >= '3.11'" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1372,6 +1375,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "hvac", specifier = ">=2.0.0" },
     { name = "ibm-watsonx-ai", marker = "python_full_version >= '3.14'", specifier = ">=1.5.13" },
+    { name = "ibm-watsonx-orchestrate-sdk", marker = "python_full_version >= '3.11' and extra == 'wxo'", specifier = ">=2.15.0" },
     { name = "langchain", specifier = ">=1.3.9,<1.3.15" },
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-docling", specifier = ">=2.0,<3.0" },
@@ -1410,7 +1414,7 @@ requires-dist = [
     { name = "typer-slim", specifier = ">=0.15.3" },
     { name = "uvicorn" },
 ]
-provides-extras = ["evaluation", "e2b", "knowledge", "health", "opensandbox", "evolve", "observability", "profiling"]
+provides-extras = ["evaluation", "e2b", "knowledge", "health", "opensandbox", "evolve", "wxo", "observability", "profiling"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3003,6 +3007,21 @@ wheels = [
 ]
 
 [[package]]
+name = "ibm-cloud-sdk-core"
+version = "3.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "urllib3", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/d3/92cdfedfeb2154478fbd72db414ad41402f361da2c0107c29f7f326bc5df/ibm_cloud_sdk_core-3.26.0.tar.gz", hash = "sha256:80f427f2413c9eef536169bddbba60301692831b6bcdfccc5b790dba26862d06", size = 83808, upload-time = "2026-07-16T10:04:29.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/ce/8efbda90d7d253aea0f1ff6b830aa0b9d0869b1311c007efc6dfe73b7e83/ibm_cloud_sdk_core-3.26.0-py3-none-any.whl", hash = "sha256:e96098cbd7abce67ad856bccf3696443b5ae497dde644cd532d7fc6040db4240", size = 76595, upload-time = "2026-07-16T10:04:28.49Z" },
+]
+
+[[package]]
 name = "ibm-cos-sdk"
 version = "2.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3111,6 +3130,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0e/93/b31b517a83f47fd4b3e4958f86201fb0a6d5a771fb54d4136ee0d0c16ff6/ibm_watsonx_ai-1.6.3.tar.gz", hash = "sha256:7ad6daa509a971a7ebbb073cca56e6cf471cce611f8a4dfc89de28ed80ce992d", size = 739812, upload-time = "2026-08-11T19:16:11.038Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/c9/4823fc4d6e6d91f9a127faff5293987a4b8a4267ab5ca3f4ce870a837e37/ibm_watsonx_ai-1.6.3-py3-none-any.whl", hash = "sha256:1cb16ac61b92bd76468c145fd04543008078487bf23aac0d1b8655cd6876ad6f", size = 1126955, upload-time = "2026-08-11T19:16:09.395Z" },
+]
+
+[[package]]
+name = "ibm-watsonx-orchestrate-clients"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ibm-cloud-sdk-core", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
+    { name = "websocket-client", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/8f/b62484c466238690224368111efa8735f6205994ae2045f12b91fb7f623e/ibm_watsonx_orchestrate_clients-2.15.0.tar.gz", hash = "sha256:3a4d7e5ed117ccbeb9bb33561460c3a3822e495a2137fe41906433a438e05944", size = 1891, upload-time = "2026-08-17T22:09:12.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/09/ad5f4645d2b8971cbaabb0034a8f26f175666516322f5a697480c2a828b0/ibm_watsonx_orchestrate_clients-2.15.0-py3-none-any.whl", hash = "sha256:02ab68d35b59a378f9ea33f8370f95fa3ce381548d35cb3d1f1bb9f6aa9d8eec", size = 59135, upload-time = "2026-08-17T22:09:06.853Z" },
+]
+
+[[package]]
+name = "ibm-watsonx-orchestrate-core"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/38/cb428f9a69c17a5ebb2be6c58717c596ba40658484d6d08857f35454620b/ibm_watsonx_orchestrate_core-2.15.0.tar.gz", hash = "sha256:73b1b7a036ba71f2a1e081c758575c5d6daa24a1bcf4d35de10e0af47c40fb99", size = 1226, upload-time = "2026-08-17T22:09:13.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/cd/d8ec5c7dc9f8a061e1755b0a5e4c9b04ac1fea4036c5bde81afc3a2bc43d/ibm_watsonx_orchestrate_core-2.15.0-py3-none-any.whl", hash = "sha256:e4a6c67b5f3a4d2fa937d6460b48958e8e7fcf3ce5ae7fc181b823a1c82f514d", size = 46816, upload-time = "2026-08-17T22:09:07.693Z" },
+]
+
+[[package]]
+name = "ibm-watsonx-orchestrate-sdk"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ibm-watsonx-orchestrate-clients", marker = "python_full_version >= '3.11'" },
+    { name = "ibm-watsonx-orchestrate-core", marker = "python_full_version >= '3.11'" },
+    { name = "langchain-openai", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/d9/8da95350a0a61df8876bdeab55a533a12e9a67c2af3dd28498e8a524a0fc/ibm_watsonx_orchestrate_sdk-2.15.0.tar.gz", hash = "sha256:378b285c5091ec95fbe895c35c6c3e55f0988f2ddfd6684a47febb639d109d42", size = 2048, upload-time = "2026-08-17T22:09:14.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/a5/aa5dc5d9970ed102f7c797027fcdcb545a03ef5ef588c23d900f05e6019b/ibm_watsonx_orchestrate_sdk-2.15.0-py3-none-any.whl", hash = "sha256:9971b0926a5479a937ee577e019513abd5e380ea9cf0bbd5e53e1a4eb14c7f61", size = 46740, upload-time = "2026-08-17T22:09:10.383Z" },
 ]
 
 [[package]]
@@ -9590,6 +9653,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Feature

Closes #715

### Summary

Adds `platform = "wxo"` to `LLMManager` so CUGA's LLM calls can be routed through a watsonx Orchestrate (wxO) tenant instead of calling a provider directly — calls become traced/observable in the tenant and are billed against its entitlement rather than a separate provider key (see #715 for full context, including live verification against a real tenant).

- `ChatWxO` (from the optional `ibm-watsonx-orchestrate-sdk` package, a `ChatOpenAI` subclass) is loaded lazily via a new `_get_chat_wxo()` helper, mirroring the existing `_get_reasoning_chat_litellm` pattern — the SDK needs Python >= 3.11, above CUGA's own >= 3.10 floor, so it ships as an optional `cuga[wxo]` extra, never a core dependency.
- `_get_model_name` / `_get_base_url` resolve `WXO_API_KEY` / `WXO_INSTANCE_URL` (env -> TOML -> default), with the instance URL folded into the LLMManager cache key so two tenants never share a cached client.
- A local ADK dev server (`http://localhost:4321`, auto-detected) runs keyless; only a remote instance requires an API key.
- New `settings.wxo.toml` covering all ten agent roles.
- `WXO_API_KEY` added to the secrets seed map and the `resolve_llm_api_key_ref` provider hint.
- `.env.example` and `README.md` updated with setup instructions.

### Testing
- [x] Tested locally; tests pass
- New unit coverage: `tests/unit/test_llm_wxo_provider.py` (model-name/base-url resolution, client wiring, SSL, caching, context-profile lookup, the secrets hint)
- New integration coverage: `tests/integration/test_llm_wxo_config_publish.py` (Manage-UI publish path via `create_llm_from_config`)
- Full shared-path regression set re-run with zero regressions: `test_llm_advanced_params`, `test_llm_override`, `test_llm_http_timeout`, `test_llm_minimax_provider`, `test_llm_reasoning_model_temperature`, `test_llm_watsonx_loop_rebind`, `test_token_counter`, `test_llm_config_publish`
- Live-tested end-to-end against a real wxO tenant: `invoke`/`ainvoke`/`stream`/`astream`/`bind_tools`/`with_structured_output`, both the `watsonx/` and tenant-recommended `groq/`-hosted model variants, plus a bad-key case failing with a clear auth error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added watsonx Orchestrate as a supported LLM platform.
  * Added local and hosted configuration options, including model, URL, API key, timeout, SSL, and sampling settings.
  * Added default agent model configurations and secure API key handling.
  * Added Python 3.11+ installation support for the watsonx Orchestrate SDK.

* **Documentation**
  * Added setup instructions, environment variables, configuration details, and model override guidance.

* **Tests**
  * Added coverage for configuration, authentication, local and remote endpoints, and provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->