### PR TITLE
fix(knowledge): stop loading Docling PDF models for markdown ingest

### DIFF
--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -4118,7 +4118,12 @@ class KnowledgeEngine:
             or old_use_gpu != self._config.use_gpu
         )
         if docling_changed:
-            self._docling_converters.clear()
+            lock = getattr(self, "_docling_converter_lock", None)
+            if lock is None:
+                lock = threading.Lock()
+                self._docling_converter_lock = lock
+            with lock:
+                self._docling_converters.clear()
             logger.info(
                 "Docling converter cache cleared (pdf_mode {!r}->{!r}, "
                 "layout_engine {!r}->{!r}, use_gpu {}->{})",

--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -5055,25 +5055,23 @@ class KnowledgeEngine:
                     packs (cuga's Docker images bundle a curated set; macOS
                     devs: ``brew install tesseract tesseract-lang``).
         """
-        mode = (self._config.docling_pdf_mode or "accurate").lower()
-        if mode not in ("fast", "balanced", "accurate"):
-            logger.warning("Unknown docling_pdf_mode={!r}; falling back to 'accurate'", mode)
-            mode = "accurate"
-
-        layout_engine_choice = (self._config.docling_layout_engine or "auto").lower()
-        device_label, _ = _detect_accelerator(self._config.use_gpu)
-        effective_layout_engine, _ = self._resolve_layout(layout_engine_choice, device_label)
-
-        # Cache by EFFECTIVE engine so explicit "transformers" and "auto"
-        # on a GPU host share one cached converter. Toggling use_gpu at
-        # runtime invalidates the cache in commit_knowledge_update, so
-        # auto re-resolves with the new device.
-        cache_key = f"{mode}|{effective_layout_engine}"
         lock = getattr(self, "_docling_converter_lock", None)
         if lock is None:
             lock = threading.Lock()
             self._docling_converter_lock = lock
         with lock:
+            # Read settings under the lock so a concurrent commit_knowledge_update
+            # cannot change use_gpu / pdf_mode, clear the cache, then have this
+            # thread store a converter built from the old device under the new key.
+            mode = (self._config.docling_pdf_mode or "accurate").lower()
+            if mode not in ("fast", "balanced", "accurate"):
+                logger.warning("Unknown docling_pdf_mode={!r}; falling back to 'accurate'", mode)
+                mode = "accurate"
+
+            layout_engine_choice = (self._config.docling_layout_engine or "auto").lower()
+            device_label, _ = _detect_accelerator(self._config.use_gpu)
+            effective_layout_engine, _ = self._resolve_layout(layout_engine_choice, device_label)
+            cache_key = f"{mode}|{effective_layout_engine}"
             cached = self._docling_converters.get(cache_key)
             if cached is not None:
                 return cached

--- a/src/cuga/backend/knowledge/engine.py
+++ b/src/cuga/backend/knowledge/engine.py
@@ -28,7 +28,6 @@ from pydantic import ConfigDict
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.indexing import InMemoryRecordManager
-from langchain_docling import DoclingLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from cuga.backend.knowledge.config import (
@@ -1813,6 +1812,10 @@ class KnowledgeEngine:
         # twice (duplicate ONNX session + download). HF file-locking protects the
         # blob, not a double load.
         self._embedder_init_lock = threading.Lock()
+        # Same race for DocumentConverter: warmup + parallel uploads can all
+        # miss the cache and each load layout/OCR weights (~1-4GB that ONNX/
+        # PyTorch will not return to the OS).
+        self._docling_converter_lock = threading.Lock()
 
         # Vector store LRU cache (bounded)
         self._vector_stores: collections.OrderedDict[str, VectorStoreAdapter] = collections.OrderedDict()
@@ -2104,61 +2107,20 @@ class KnowledgeEngine:
             )
 
     async def warmup(self) -> dict[str, Any]:
-        """Preload heavyweight resources so callers can gate on readiness.
+        """Preload embeddings (and an optional reranker). Docling stays lazy.
 
-        Three preloads, all in worker threads so we don't block the event loop:
-          1. metadata DB (sqlite/pg schema bootstrap)
-          2. embeddings (fastembed ONNX model load: ~100-300 MB)
-          3. Docling layout model (~22 s on first call; 770-weight load)
-
-        Doing these at startup means the user's FIRST ingest doesn't pay the
-        cold-start tax — important because the first ingest is also when the
-        user is most impatient.
+        Metadata + the configured embedder are needed for every ingest,
+        including markdown. The PDF layout/OCR/tableformer pipeline is not:
+        those weights are 1-4 GB and stay resident for the process lifetime
+        because ONNX/PyTorch do not return that RSS to the OS. Markdown and
+        other native-text uploads must not pay that tax. The first
+        PDF/office/image ingest builds the converter via
+        ``_get_docling_converter``.
         """
-        import time as _time
-
         await self._ensure_metadata_ready()
-        # Step 2: embeddings — same call existing code paths use.
         await asyncio.to_thread(self._ensure_embeddings)
+        logger.info("Knowledge prewarm complete: embeddings loaded (Docling PDF pipeline is lazy)")
 
-        # Step 3: Docling. Only build the converter for the *configured* mode
-        # — if the user later switches to a different mode it'll rebuild then.
-        # Loading the layout model is the single biggest cold-start cost on
-        # the parse stage, so this is where the user-visible win comes from.
-        docling_t0 = _time.monotonic()
-        docling_loaded = False
-        docling_error: str | None = None
-        try:
-            # Step A: build the converter (cheap — just registers options).
-            converter = await asyncio.to_thread(self._get_docling_converter)
-            # Step B: FORCE the pipeline + models to load right now. Without
-            # this, Docling lazy-loads the layout-model weights (~22s) on the
-            # first convert() call, defeating the whole point of prewarm.
-            try:
-                from docling.datamodel.base_models import InputFormat
-
-                await asyncio.to_thread(converter.initialize_pipeline, InputFormat.PDF)
-            except Exception as init_err:  # pragma: no cover - defensive
-                logger.warning(
-                    "Docling pipeline init during prewarm raised; weights will "
-                    "still lazy-load on first ingest: {}",
-                    init_err,
-                )
-            docling_loaded = True
-        except Exception as e:  # pragma: no cover - environmental
-            docling_error = str(e)
-            logger.warning("Docling prewarm failed (will lazy-load on first ingest): {}", e)
-        docling_dt = _time.monotonic() - docling_t0
-        if docling_loaded:
-            logger.info(
-                "Knowledge prewarm complete: embeddings + Docling (mode={!r}) loaded in {:.2f}s",
-                self._config.docling_pdf_mode,
-                docling_dt,
-            )
-
-        # Step 4: reranker — only when a profile has it enabled. Load the
-        # cross-encoder now so the first search doesn't pay the model load
-        # (~1-3s). Best-effort: on failure search degrades to fusion ranking.
         reranker_prewarmed = False
         if getattr(self._config, "rerank_enabled", False):
             try:
@@ -2175,9 +2137,9 @@ class KnowledgeEngine:
             "embedding_provider": self._config.embedding_provider,
             "embedding_model": self._config.embedding_model or "auto",
             "embeddings_initialized": self._default_embeddings is not None,
-            "docling_prewarmed": docling_loaded,
-            "docling_prewarm_seconds": round(docling_dt, 2),
-            "docling_prewarm_error": docling_error,
+            "docling_prewarmed": False,
+            "docling_prewarm_seconds": 0.0,
+            "docling_prewarm_error": None,
             "reranker_prewarmed": reranker_prewarmed,
         }
 
@@ -4689,6 +4651,34 @@ class KnowledgeEngine:
 
     # --- Document loading ---
 
+    # Native-text formats skip Docling entirely. Routing .md/.csv/etc. through
+    # DoclingLoader used to import torch + build a PDF DocumentConverter
+    # (layout/OCR/tableformer) on first upload — several GB of RSS that the
+    # process never returns to the OS, even for a few 100 KB markdown files.
+    _TEXT_FORMATS = {
+        ".txt",
+        ".text",
+        ".log",
+        ".json",
+        ".xml",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".ini",
+        ".cfg",
+        ".conf",
+        ".md",
+        ".markdown",
+        ".rst",
+        ".csv",
+        ".tsv",
+        ".asciidoc",
+        ".adoc",
+        ".tex",
+        ".latex",
+    }
+
+    # Rich formats that actually need Docling (layout, tables, OCR, images).
     _DOCLING_FORMATS = {
         ".pdf",
         ".docx",
@@ -4696,12 +4686,6 @@ class KnowledgeEngine:
         ".xlsx",
         ".html",
         ".htm",
-        ".md",
-        ".csv",
-        ".asciidoc",
-        ".adoc",
-        ".tex",
-        ".latex",
         ".png",
         ".jpg",
         ".jpeg",
@@ -5066,14 +5050,6 @@ class KnowledgeEngine:
                     packs (cuga's Docker images bundle a curated set; macOS
                     devs: ``brew install tesseract tesseract-lang``).
         """
-        import os
-        from pathlib import Path
-
-        from docling.datamodel.base_models import InputFormat
-        from docling.datamodel.pipeline_options import PdfPipelineOptions
-        from docling.datamodel.accelerator_options import AcceleratorOptions, AcceleratorDevice
-        from docling.document_converter import DocumentConverter, PdfFormatOption
-
         mode = (self._config.docling_pdf_mode or "accurate").lower()
         if mode not in ("fast", "balanced", "accurate"):
             logger.warning("Unknown docling_pdf_mode={!r}; falling back to 'accurate'", mode)
@@ -5088,9 +5064,31 @@ class KnowledgeEngine:
         # runtime invalidates the cache in commit_knowledge_update, so
         # auto re-resolves with the new device.
         cache_key = f"{mode}|{effective_layout_engine}"
-        cached = self._docling_converters.get(cache_key)
-        if cached is not None:
-            return cached
+        lock = getattr(self, "_docling_converter_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._docling_converter_lock = lock
+        with lock:
+            cached = self._docling_converters.get(cache_key)
+            if cached is not None:
+                return cached
+            converter = self._build_docling_converter(mode, effective_layout_engine, device_label)
+            self._docling_converters[cache_key] = converter
+            return converter
+
+    def _build_docling_converter(
+        self,
+        mode: str,
+        effective_layout_engine: str,
+        device_label: str,
+    ):
+        import os
+        from pathlib import Path
+
+        from docling.datamodel.base_models import InputFormat
+        from docling.datamodel.pipeline_options import PdfPipelineOptions
+        from docling.datamodel.accelerator_options import AcceleratorOptions, AcceleratorDevice
+        from docling.document_converter import DocumentConverter, PdfFormatOption
 
         artifacts_path_str = os.environ.get("DOCLING_ARTIFACTS_PATH")
         artifacts_path = Path(artifacts_path_str) if artifacts_path_str else None
@@ -5285,7 +5283,6 @@ class KnowledgeEngine:
         converter = DocumentConverter(
             format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
         )
-        self._docling_converters[cache_key] = converter
         # Layout actually runs on `device_label` only via the transformers
         # engine; the ONNX engine is CPU-only regardless of device_label.
         layout_device = device_label if effective_layout_engine == "transformers" else "cpu"
@@ -5308,8 +5305,29 @@ class KnowledgeEngine:
         )
         return converter
 
+    def _load_plain_text_chunks(self, file_path: Path, chunk_size: int, chunk_overlap: int) -> list[Document]:
+        """Token-aware split for native-text files. Never imports Docling."""
+        text = file_path.read_text(errors="replace")
+        splitter = self._build_text_splitter(chunk_size, chunk_overlap)
+        chunks = splitter.split_text(text)
+        return [Document(page_content=chunk, metadata={"page": i + 1}) for i, chunk in enumerate(chunks)]
+
+    def _load_with_docling(self, file_path: Path, chunk_size: int) -> list[Document]:
+        from langchain_docling import DoclingLoader
+        from langchain_docling.loader import ExportType
+
+        chunker = self._build_docling_chunker(chunk_size)
+        loader_kwargs: dict = {
+            "file_path": str(file_path),
+            "export_type": ExportType.DOC_CHUNKS,
+            "converter": self._get_docling_converter(),
+        }
+        if chunker is not None:
+            loader_kwargs["chunker"] = chunker
+        return DoclingLoader(**loader_kwargs).load()
+
     def _load_document(self, file_path: Path) -> list[Document]:
-        """Load a document using Docling for supported formats, fallback for plain text."""
+        """Load a document: plain-text splitter for native text, Docling for rich formats."""
         suffix = file_path.suffix.lower()
         logger.info(
             f"Loading document: {file_path.name} (suffix={suffix}, size={file_path.stat().st_size} bytes)"
@@ -5317,61 +5335,20 @@ class KnowledgeEngine:
 
         chunk_size, chunk_overlap = self._get_effective_chunk_settings()
 
-        if suffix in self._DOCLING_FORMATS:
+        if suffix in self._TEXT_FORMATS:
+            docs = self._load_plain_text_chunks(file_path, chunk_size, chunk_overlap)
+        elif suffix in self._DOCLING_FORMATS:
             try:
-                from langchain_docling.loader import ExportType
-
-                chunker = self._build_docling_chunker(chunk_size)
-                loader_kwargs: dict = {
-                    "file_path": str(file_path),
-                    "export_type": ExportType.DOC_CHUNKS,
-                    "converter": self._get_docling_converter(),
-                }
-                if chunker is not None:
-                    loader_kwargs["chunker"] = chunker
-                loader = DoclingLoader(**loader_kwargs)
-                docs = loader.load()
+                docs = self._load_with_docling(file_path, chunk_size)
             except Exception as e:
                 translated = _translate_document_load_error(file_path, e)
                 logger.error(
                     f"Docling failed to parse {file_path.name}: {type(translated).__name__}: {translated}"
                 )
                 raise translated from e
-        elif suffix in (
-            ".txt",
-            ".text",
-            ".log",
-            ".json",
-            ".xml",
-            ".yaml",
-            ".yml",
-            ".toml",
-            ".ini",
-            ".cfg",
-            ".conf",
-        ):
-            text = file_path.read_text(errors="replace")
-            # Token-aware split when we have an HF tokenizer for the active
-            # embedder — guarantees no chunk exceeds the model's max_seq_length.
-            # Falls back to char-based for providers without an HF tokenizer
-            # (legacy fastembed default, cohere/voyage/gemini under cl100k).
-            splitter = self._build_text_splitter(chunk_size, chunk_overlap)
-            chunks = splitter.split_text(text)
-            docs = [Document(page_content=chunk, metadata={"page": i + 1}) for i, chunk in enumerate(chunks)]
         else:
             try:
-                from langchain_docling.loader import ExportType
-
-                chunker = self._build_docling_chunker(chunk_size)
-                loader_kwargs = {
-                    "file_path": str(file_path),
-                    "export_type": ExportType.DOC_CHUNKS,
-                    "converter": self._get_docling_converter(),
-                }
-                if chunker is not None:
-                    loader_kwargs["chunker"] = chunker
-                loader = DoclingLoader(**loader_kwargs)
-                docs = loader.load()
+                docs = self._load_with_docling(file_path, chunk_size)
             except Exception:
                 raise ValueError(f"Unsupported file format: {suffix}")
 

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -781,9 +781,7 @@ async def lifespan(app: FastAPI):
 
         async def _warm():
             try:
-                app_state.set_subsystem_status(
-                    "knowledge", "starting", "Loading knowledge embedding + parser models"
-                )
+                app_state.set_subsystem_status("knowledge", "starting", "Loading knowledge embedding models")
                 warmup_result = await app_state.knowledge_engine.warmup()
                 app_state.set_subsystem_status(
                     "knowledge", "ready", "Knowledge subsystem ready", warmup_result

--- a/tests/unit/test_knowledge_text_ingest_path.py
+++ b/tests/unit/test_knowledge_text_ingest_path.py
@@ -158,6 +158,26 @@ def test_config_update_during_converter_build_does_not_repopulate_stale_cache():
     getter_thread.start()
     assert started.wait(timeout=2.0)
 
+    commit_attempted_lock = threading.Event()
+    inner_lock = eng._docling_converter_lock
+
+    class _AcquireSignalLock:
+        def acquire(self, blocking: bool = True, timeout: float = -1):
+            commit_attempted_lock.set()
+            return inner_lock.acquire(blocking, timeout)
+
+        def release(self):
+            return inner_lock.release()
+
+        def __enter__(self):
+            self.acquire()
+            return self
+
+        def __exit__(self, *_exc):
+            self.release()
+
+    eng._docling_converter_lock = _AcquireSignalLock()
+
     commit_done = threading.Event()
 
     def commit() -> None:
@@ -167,7 +187,7 @@ def test_config_update_during_converter_build_does_not_repopulate_stale_cache():
 
     commit_thread = threading.Thread(target=commit)
     commit_thread.start()
-    time.sleep(0.05)
+    assert commit_attempted_lock.wait(timeout=2.0)
     release.set()
     getter_thread.join(timeout=3.0)
     commit_thread.join(timeout=3.0)

--- a/tests/unit/test_knowledge_text_ingest_path.py
+++ b/tests/unit/test_knowledge_text_ingest_path.py
@@ -1,0 +1,137 @@
+"""Markdown/text ingest must not load the Docling PDF/OCR stack.
+
+Uploading a few 100 KB .md files was jumping the agent server from ~2 GB to
+~6 GB RSS that never returned. Root cause: .md went through DoclingLoader,
+which imported torch and built a PDF DocumentConverter (layout + optional
+EasyOCR) on first ingest, and warmup() also initialized InputFormat.PDF.
+Native-text formats now use the token-aware splitter instead.
+"""
+
+from __future__ import annotations
+
+import inspect
+import tempfile
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from cuga.backend.knowledge.config import KnowledgeConfig
+from cuga.backend.knowledge.engine import KnowledgeEngine
+
+
+def _engine(tmp_path: Path) -> KnowledgeEngine:
+    return KnowledgeEngine(
+        KnowledgeConfig(
+            enabled=True,
+            persist_dir=tmp_path / "kb",
+            embedding_provider="openai",
+            embedding_model="text-embedding-3-small",
+            embedding_api_key="sk-test",
+            chunk_size=200,
+            chunk_overlap=20,
+        )
+    )
+
+
+@pytest.mark.unit
+def test_markdown_and_csv_are_plain_text_not_docling():
+    assert ".md" in KnowledgeEngine._TEXT_FORMATS
+    assert ".markdown" in KnowledgeEngine._TEXT_FORMATS
+    assert ".csv" in KnowledgeEngine._TEXT_FORMATS
+    assert ".md" not in KnowledgeEngine._DOCLING_FORMATS
+    assert ".csv" not in KnowledgeEngine._DOCLING_FORMATS
+    assert ".pdf" in KnowledgeEngine._DOCLING_FORMATS
+    assert ".docx" in KnowledgeEngine._DOCLING_FORMATS
+
+
+@pytest.mark.unit
+def test_engine_does_not_import_docling_loader_at_module_level():
+    import cuga.backend.knowledge.engine as engine_mod
+
+    assert not hasattr(engine_mod, "DoclingLoader")
+
+
+@pytest.mark.unit
+def test_markdown_load_never_calls_docling(tmp_path: Path):
+    eng = _engine(tmp_path)
+    md = tmp_path / "notes.md"
+    md.write_text("# Title\n\n" + ("paragraph of markdown text.\n\n" * 40))
+
+    eng._load_with_docling = MagicMock(side_effect=AssertionError("Docling must not run for .md"))
+    docs = eng._load_document(md)
+
+    eng._load_with_docling.assert_not_called()
+    assert docs
+    assert all(d.page_content.strip() for d in docs)
+    assert all(d.metadata.get("page") for d in docs)
+
+
+@pytest.mark.unit
+def test_csv_load_never_calls_docling(tmp_path: Path):
+    eng = _engine(tmp_path)
+    csv_path = tmp_path / "rows.csv"
+    csv_path.write_text("a,b\n1,2\n3,4\n")
+
+    eng._load_with_docling = MagicMock(side_effect=AssertionError("Docling must not run for .csv"))
+    docs = eng._load_document(csv_path)
+
+    eng._load_with_docling.assert_not_called()
+    assert docs
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_warmup_does_not_build_docling_converter(tmp_path: Path):
+    eng = _engine(tmp_path)
+    eng._ensure_embeddings = lambda: None
+    eng._default_embeddings = object()
+    eng._get_docling_converter = MagicMock(
+        side_effect=AssertionError("warmup must not build the Docling PDF pipeline")
+    )
+
+    result = await eng.warmup()
+
+    eng._get_docling_converter.assert_not_called()
+    assert result["docling_prewarmed"] is False
+    assert result["embeddings_initialized"] is True
+
+
+@pytest.mark.unit
+def test_docling_converter_construction_is_serialized():
+    tmp = Path(tempfile.mkdtemp(prefix="cuga-docling-lock-"))
+    eng = _engine(tmp)
+    builds: list[int] = []
+    release = threading.Event()
+    sentinel = object()
+
+    def slow_build(*_a, **_k):
+        builds.append(1)
+        assert release.wait(timeout=2.0)
+        return sentinel
+
+    eng._build_docling_converter = slow_build
+    results: list[object] = []
+
+    def worker() -> None:
+        results.append(eng._get_docling_converter())
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    time.sleep(0.05)
+    release.set()
+    for t in threads:
+        t.join(timeout=3.0)
+
+    assert builds == [1], f"expected one converter build under the lock, got {builds}"
+    assert results == [sentinel, sentinel]
+
+
+@pytest.mark.unit
+def test_get_docling_converter_uses_lock():
+    src = inspect.getsource(KnowledgeEngine._get_docling_converter)
+    assert "_docling_converter_lock" in src
+    assert "_build_docling_converter" in src

--- a/tests/unit/test_knowledge_text_ingest_path.py
+++ b/tests/unit/test_knowledge_text_ingest_path.py
@@ -131,7 +131,60 @@ def test_docling_converter_construction_is_serialized():
 
 
 @pytest.mark.unit
+def test_config_update_during_converter_build_does_not_repopulate_stale_cache():
+    """commit_knowledge_update must clear the converter cache under the same
+    lock as construction. Otherwise an in-flight build stores the old
+    converter after the clear (same cache key when only use_gpu flipped).
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="cuga-docling-invalidate-"))
+    eng = _engine(tmp)
+    started = threading.Event()
+    release = threading.Event()
+    stale = object()
+
+    def slow_build(*_a, **_k):
+        started.set()
+        assert release.wait(timeout=2.0)
+        return stale
+
+    eng._build_docling_converter = slow_build
+
+    getter_result: list[object] = []
+
+    def getter() -> None:
+        getter_result.append(eng._get_docling_converter())
+
+    getter_thread = threading.Thread(target=getter)
+    getter_thread.start()
+    assert started.wait(timeout=2.0)
+
+    commit_done = threading.Event()
+
+    def commit() -> None:
+        result = eng.apply_knowledge_config({"use_gpu": False})
+        assert result["docling_changed"] is True
+        commit_done.set()
+
+    commit_thread = threading.Thread(target=commit)
+    commit_thread.start()
+    time.sleep(0.05)
+    release.set()
+    getter_thread.join(timeout=3.0)
+    commit_thread.join(timeout=3.0)
+
+    assert getter_result == [stale]
+    assert commit_done.is_set()
+    assert eng._docling_converters == {}
+    rebuilt = object()
+    eng._build_docling_converter = lambda *_a, **_k: rebuilt
+    assert eng._get_docling_converter() is rebuilt
+    assert list(eng._docling_converters.values()) == [rebuilt]
+
+
+@pytest.mark.unit
 def test_get_docling_converter_uses_lock():
     src = inspect.getsource(KnowledgeEngine._get_docling_converter)
     assert "_docling_converter_lock" in src
     assert "_build_docling_converter" in src
+    commit_src = inspect.getsource(KnowledgeEngine.commit_knowledge_update)
+    assert "_docling_converter_lock" in commit_src


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug fix

Fixes n/a — static analysis of agent-server RSS jumping 2 GB → 6 GB after uploading five ~100–130 KB markdown files, then staying at 6 GB.

### Summary

Five markdown files (~650 KB total) cannot explain a **persistent +4 GB**. The bytes are not kept in LangGraph state. The jump is from **first-time load of the Docling PDF/OCR/layout stack** on `.md` ingest, plus native allocators that **never return RSS to the OS**.

This PR stops markdown (and other native-text formats) from touching that stack.

### Why RSS goes 2 GB → 6 GB and stays there

| Layer | What happens on 5× ~130 KB `.md` upload | Freed after ingest? |
|---|---|---|
| HTTP `UploadFile.read()` | ~650 KB in RAM | Yes |
| Temp files | Disk | Yes (unlinked) |
| **`_load_document` via DoclingLoader** | `.md` was in `_DOCLING_FORMATS`. First convert imports **torch + transformers + opencv**, builds a **PDF `DocumentConverter`** (layout / tableformer), and in `accurate` mode may `import easyocr` | **No — models stay for process life** |
| **`warmup()` `initialize_pipeline(InputFormat.PDF)`** | Forced PDF pipeline load at knowledge start, even if the user only uploads markdown | **No** |
| Parallel uploads (frontend `Promise.allSettled`, 5 POSTs) + warmup | `_get_docling_converter` had **no lock** — cache miss could load **duplicate** layout/OCR sessions | **No** (ONNX/PyTorch keep arenas) |
| Embeddings (`fastembed` bge-small) | ~100–300 MB on first embed | **No** (needed; not the 4 GB) |
| sqlite-vec + FTS `chunk_text` | Two on-disk copies of chunks | Disk + page cache, not GB-scale |
| Agent chat / LangGraph | Attachment snapshot is **filename + mime + size**, not file bytes | N/A for upload-only |

Python/glibc/ONNX/PyTorch **do not give RSS back** after the peak. That is why it **stays at 6 GB**.

`layout_engine=auto` on CUDA/MPS resolves to **transformers** (full PyTorch layout). Combined with EasyOCR (no tesseract) this matches a **+2–4 GB** plateau.

Frontend session attach: `useSessionKnowledgeAttachments.ts` fires **one `wait=true` POST per file in parallel**. Backend `max_ingest_workers=2` bounds parse, but converter construction was unbounded.

### Other retainers (not this upload bug)

These can grow RAM later but are **not** what 650 KB of markdown does on upload:

- **`MemorySaver`** in `graph.py` (and a second draft graph in `main.py`) — all checkpoint versions in process memory, never evicted on `/api/reset`
- **`ActivityTracker` singleton** — `steps` / `images` / deepcopy’d `prompts`; `finish_task` does not clear them
- **Reranker** (`balanced` / `max_quality`) — extra ~1.1 GB, off on `standard`
- **`LLMManager._models`**, citation ledger (bounded 300 threads × 500 snippets)

### Root cause / Solution

**Root cause:** `.md` ingest used the same Docling PDF pipeline as scanned PDFs, and startup prewarmed that pipeline.

**Solution:**
1. Native-text formats (`.md`, `.markdown`, `.csv`, `.rst`, `.tex`, …) use the existing token-aware text splitter — **no Docling, no torch layout, no OCR**.
2. `warmup()` still loads **embeddings** (needed for every ingest). It no longer calls `initialize_pipeline(PDF)`.
3. `DocumentConverter` construction is serialized with `_docling_converter_lock` (same race as `_embedder_init_lock`).
4. `langchain_docling.DoclingLoader` is imported only on the rich-format path.

PDF / DOCX / PPTX / XLSX / HTML / images still use Docling; first of those pays the cold start.

### Testing
- [x] `uv run pytest tests/unit/test_knowledge_text_ingest_path.py tests/unit/test_knowledge_resplit_unit_mismatch.py tests/unit/test_knowledge_ocr_language_detect.py tests/unit/test_preload_models.py tests/unit/test_knowledge_ingest_concurrency.py tests/unit/test_knowledge_publish_import_pipeline.py tests/unit/test_knowledge_rag_scope_failure_fix.py tests/unit/test_knowledge_engine.py tests/unit/test_knowledge_chunker_tokenizer.py` — 115 passed
- [x] Did not start the agent server or any live CUGA service (static analysis + unit tests only)

### Checklist
- [x] Markdown ingest no longer constructs a Docling PDF converter
- [x] Warmup does not prewarm `InputFormat.PDF`
- [x] Converter builds are serialized
- [x] DCO sign-off on commit

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c5f1d0b-54fd-4a8a-9041-2f9757f06a26?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c5f1d0b-54fd-4a8a-9041-2f9757f06a26&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster knowledge-service startup by deferring rich-document processing components until needed.
  * Markdown, CSV, and other plain-text formats now use streamlined text ingestion.
  * Rich document formats continue to support document conversion with clearer parsing errors.
  * Improved reliability when multiple documents are processed concurrently.
* **Bug Fixes**
  * Warmup no longer initializes unnecessary document-conversion components.
  * Knowledge warmup status now accurately reports embedding-model loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->