### PR TITLE
fix(storage): scope all Postgres records by tenant and instance

### DIFF
--- a/src/cuga/backend/cuga_graph/policy/configurable.py
+++ b/src/cuga/backend/cuga_graph/policy/configurable.py
@@ -14,6 +14,36 @@ from cuga.backend.llm.models import LLMManager
 from cuga.config import settings, DBS_DIR
 
 
+def resolve_local_policy_db_path(
+    explicit_path: Optional[str],
+    settings_path: Optional[str],
+    storage_mode: str,
+) -> Optional[str]:
+    """Return a local sqlite path for policies, or None to use the storage facade.
+
+    An explicit ``initialize(policy_db_path=...)`` argument always wins (tests).
+    ``[policy].policy_db_path`` applies only when ``storage.mode`` is not ``prod``.
+    """
+    explicit = (explicit_path or "").strip()
+    from_settings = (settings_path or "").strip()
+    mode = (storage_mode or "local").lower()
+    if explicit:
+        configured = explicit
+    elif from_settings and mode != "prod":
+        configured = from_settings
+    else:
+        if from_settings and mode == "prod":
+            logger.warning(
+                "Ignoring [policy].policy_db_path because storage.mode=prod; "
+                "policies are stored on storage.postgres_url"
+            )
+        return None
+    if not os.path.isabs(configured):
+        os.makedirs(DBS_DIR, exist_ok=True)
+        return os.path.join(DBS_DIR, configured)
+    return configured
+
+
 class PolicyConfigurable:
     """
     Configurable policy system for LangGraph integration.
@@ -119,15 +149,12 @@ class PolicyConfigurable:
                 policy_config.collection_name if policy_config else "cuga_policies"
             )
 
-            configured_path = (policy_db_path or getattr(policy_config, "policy_db_path", None) or "").strip()
-            if configured_path:
-                if not os.path.isabs(configured_path):
-                    os.makedirs(DBS_DIR, exist_ok=True)
-                    final_policy_db_path = os.path.join(DBS_DIR, configured_path)
-                else:
-                    final_policy_db_path = configured_path
-            else:
-                final_policy_db_path = None
+            explicit_path = (policy_db_path or "").strip()
+            settings_path = (getattr(policy_config, "policy_db_path", None) or "").strip()
+            from cuga.backend.storage.facade import get_storage_connection_params
+
+            storage_mode = get_storage_connection_params()[0]
+            final_policy_db_path = resolve_local_policy_db_path(explicit_path, settings_path, storage_mode)
             from cuga.backend.storage.embedding import get_embedding_config
 
             emb_cfg = get_embedding_config()

--- a/src/cuga/backend/knowledge/metadata/base.py
+++ b/src/cuga/backend/knowledge/metadata/base.py
@@ -6,6 +6,14 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 
+from cuga.config import get_service_instance_id, get_tenant_id
+
+
+def current_scope() -> tuple[str, str]:
+    """Return ``(tenant_id, instance_id)`` for row-level metadata isolation."""
+    return get_tenant_id(), get_service_instance_id()
+
+
 #: Error recorded on file-task entries that a restart interrupted mid-ingest.
 INTERRUPTED_ERROR = "interrupted by server restart"
 

--- a/src/cuga/backend/knowledge/metadata/postgres_store.py
+++ b/src/cuga/backend/knowledge/metadata/postgres_store.py
@@ -9,6 +9,7 @@ from typing import Any
 import psycopg
 
 from cuga.backend.knowledge.metadata.base import (
+    current_scope,
     iso_cutoff_days_ago,
     mark_file_tasks_interrupted,
     normalize_file_tasks,
@@ -33,21 +34,32 @@ _TASK_UPDATE_COLS = frozenset(
     }
 )
 
+_TABLE_PKS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (_DOC, ("tenant_id", "instance_id", "collection", "filename")),
+    (_TASK, ("tenant_id", "instance_id", "task_id")),
+    (_COLL, ("tenant_id", "instance_id", "collection")),
+    (_SET, ("tenant_id", "instance_id", "key")),
+)
+
 _SCHEMA_STATEMENTS = (
     f"""
             CREATE TABLE IF NOT EXISTS {_DOC} (
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
                 collection TEXT NOT NULL,
                 filename TEXT NOT NULL,
                 chunk_count BIGINT NOT NULL DEFAULT 0,
                 status TEXT NOT NULL DEFAULT 'indexed',
                 ingested_at TEXT NOT NULL,
                 preview TEXT NOT NULL DEFAULT '',
-                PRIMARY KEY (collection, filename)
+                PRIMARY KEY (tenant_id, instance_id, collection, filename)
             )
             """,
     f"""
             CREATE TABLE IF NOT EXISTS {_TASK} (
-                task_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL,
                 collection TEXT NOT NULL,
                 status TEXT NOT NULL DEFAULT 'pending'
                     CHECK (status IN ('pending','running','completed','failed','cancelled')),
@@ -57,26 +69,38 @@ _SCHEMA_STATEMENTS = (
                 failed_files BIGINT NOT NULL DEFAULT 0,
                 file_tasks_json TEXT NOT NULL DEFAULT '{{}}',
                 created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, task_id)
             )
             """,
     f"""
             CREATE TABLE IF NOT EXISTS {_COLL} (
-                collection TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                collection TEXT NOT NULL,
                 embedding_provider TEXT NOT NULL,
                 embedding_model TEXT NOT NULL,
                 embedding_dim BIGINT NOT NULL,
-                created_at TEXT NOT NULL
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, collection)
             )
             """,
     f"""
             CREATE TABLE IF NOT EXISTS {_SET} (
-                key TEXT PRIMARY KEY,
-                value TEXT NOT NULL
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, key)
             )
             """,
-    f"CREATE INDEX IF NOT EXISTS idx_cuga_kn_meta_task_cs ON {_TASK}(collection, status, updated_at)",
-    f"CREATE INDEX IF NOT EXISTS idx_cuga_kn_meta_doc_cs ON {_DOC}(collection, status)",
+)
+
+_INDEX_STATEMENTS = (
+    "DROP INDEX IF EXISTS idx_cuga_kn_meta_task_cs",
+    "DROP INDEX IF EXISTS idx_cuga_kn_meta_doc_cs",
+    f"CREATE INDEX IF NOT EXISTS idx_cuga_kn_meta_task_cs ON {_TASK}(tenant_id, instance_id, collection, status, updated_at)",
+    f"CREATE INDEX IF NOT EXISTS idx_cuga_kn_meta_doc_cs ON {_DOC}(tenant_id, instance_id, collection, status)",
 )
 
 
@@ -86,6 +110,9 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
         self._schema_initialized = False
         self._schema_lock = asyncio.Lock()
 
+    def _scope(self) -> tuple[str, str]:
+        return current_scope()
+
     async def ensure_ready(self) -> None:
         if self._schema_initialized:
             return
@@ -94,56 +121,97 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
                 return
             for stmt in _SCHEMA_STATEMENTS:
                 await self.execute(stmt.strip())
+            await self._migrate_scope_columns()
+            for stmt in _INDEX_STATEMENTS:
+                await self.execute(stmt.strip())
             await self.commit()
             self._schema_initialized = True
 
+    async def _migrate_scope_columns(self) -> None:
+        """Add tenant/instance columns and composite PKs on tables created before isolation."""
+        for table, pk_cols in _TABLE_PKS:
+            await self.execute(
+                f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS tenant_id TEXT NOT NULL DEFAULT ''"
+            )
+            await self.execute(
+                f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS instance_id TEXT NOT NULL DEFAULT ''"
+            )
+            current = await self.fetchall(
+                """
+                SELECT a.attname AS attname
+                FROM pg_index i
+                JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+                WHERE i.indrelid = to_regclass(?) AND i.indisprimary
+                ORDER BY array_position(i.indkey, a.attnum)
+                """,
+                (table,),
+            )
+            current_pk = tuple(r["attname"] for r in current)
+            if current_pk == pk_cols:
+                continue
+            await self.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_pkey")
+            await self.execute(f"ALTER TABLE {table} ADD PRIMARY KEY ({', '.join(pk_cols)})")
+
     async def add_document(self, collection: str, filename: str, chunk_count: int, preview: str = "") -> None:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         await self.execute(
             f"""
-            INSERT INTO {_DOC} (collection, filename, chunk_count, status, ingested_at, preview)
-            VALUES (?, ?, ?, 'indexed', ?, ?)
-            ON CONFLICT (collection, filename) DO UPDATE SET
+            INSERT INTO {_DOC} (tenant_id, instance_id, collection, filename, chunk_count, status, ingested_at, preview)
+            VALUES (?, ?, ?, ?, ?, 'indexed', ?, ?)
+            ON CONFLICT (tenant_id, instance_id, collection, filename) DO UPDATE SET
                 chunk_count = EXCLUDED.chunk_count,
                 status = EXCLUDED.status,
                 ingested_at = EXCLUDED.ingested_at,
                 preview = EXCLUDED.preview
             """,
-            (collection, filename, chunk_count, now, preview),
+            (tenant_id, inst_id, collection, filename, chunk_count, now, preview),
         )
         await self.commit()
 
     async def mark_deleting(self, collection: str, filename: str) -> bool:
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            f"UPDATE {_DOC} SET status = 'deleting' WHERE collection = ? AND filename = ?",
-            (collection, filename),
+            f"UPDATE {_DOC} SET status = 'deleting' "
+            f"WHERE tenant_id = ? AND instance_id = ? AND collection = ? AND filename = ?",
+            (tenant_id, inst_id, collection, filename),
         )
         ok = self._last_rowcount > 0
         await self.commit()
         return ok
 
     async def remove_document(self, collection: str, filename: str) -> None:
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            f"DELETE FROM {_DOC} WHERE collection = ? AND filename = ?",
-            (collection, filename),
+            f"DELETE FROM {_DOC} WHERE tenant_id = ? AND instance_id = ? AND collection = ? AND filename = ?",
+            (tenant_id, inst_id, collection, filename),
         )
         await self.commit()
 
     async def list_documents(self, collection: str) -> list[dict[str, Any]]:
+        tenant_id, inst_id = self._scope()
         return await self.fetchall(
             f"SELECT filename, chunk_count, status, ingested_at, preview FROM {_DOC} "
-            f"WHERE collection = ? AND status != 'deleting' ORDER BY ingested_at DESC",
-            (collection,),
+            f"WHERE tenant_id = ? AND instance_id = ? AND collection = ? AND status != 'deleting' "
+            f"ORDER BY ingested_at DESC",
+            (tenant_id, inst_id, collection),
         )
 
     async def get_deleting_documents(self) -> list[dict[str, Any]]:
-        return await self.fetchall(f"SELECT collection, filename FROM {_DOC} WHERE status = 'deleting'")
+        tenant_id, inst_id = self._scope()
+        return await self.fetchall(
+            f"SELECT collection, filename FROM {_DOC} "
+            f"WHERE tenant_id = ? AND instance_id = ? AND status = 'deleting'",
+            (tenant_id, inst_id),
+        )
 
     async def document_exists(self, collection: str, filename: str) -> bool:
+        tenant_id, inst_id = self._scope()
         row = await self.fetchone(
             f"SELECT 1 AS one FROM {_DOC} "
-            f"WHERE collection = ? AND filename = ? AND status != 'deleting' LIMIT 1",
-            (collection, filename),
+            f"WHERE tenant_id = ? AND instance_id = ? AND collection = ? AND filename = ? "
+            f"AND status != 'deleting' LIMIT 1",
+            (tenant_id, inst_id, collection, filename),
         )
         return row is not None
 
@@ -151,20 +219,25 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
         self, task_id: str, collection: str, total_files: int, file_tasks: dict[str, dict]
     ) -> dict[str, Any]:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         await self.execute(
             f"""
             INSERT INTO {_TASK} (
-                task_id, collection, status, total_files, processed_files,
+                tenant_id, instance_id, task_id, collection, status, total_files, processed_files,
                 successful_files, failed_files, file_tasks_json, created_at, updated_at
-            ) VALUES (?, ?, 'pending', ?, 0, 0, 0, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, 'pending', ?, 0, 0, 0, ?, ?, ?)
             """,
-            (task_id, collection, total_files, json.dumps(file_tasks), now, now),
+            (tenant_id, inst_id, task_id, collection, total_files, json.dumps(file_tasks), now, now),
         )
         await self.commit()
         return await self.get_task(task_id)
 
     async def get_task(self, task_id: str) -> dict[str, Any] | None:
-        row = await self.fetchone(f"SELECT * FROM {_TASK} WHERE task_id = ?", (task_id,))
+        tenant_id, inst_id = self._scope()
+        row = await self.fetchone(
+            f"SELECT * FROM {_TASK} WHERE tenant_id = ? AND instance_id = ? AND task_id = ?",
+            (tenant_id, inst_id, task_id),
+        )
         if not row:
             return None
         task = dict(row)
@@ -173,6 +246,7 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
 
     async def update_task(self, task_id: str, **kwargs: Any) -> None:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         if "file_tasks" in kwargs:
             kwargs["file_tasks_json"] = json.dumps(kwargs.pop("file_tasks"))
         kwargs["updated_at"] = now
@@ -180,18 +254,26 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
         if not cols:
             return
         set_clause = ", ".join(f"{k} = ?" for k in cols)
-        values = [kwargs[k] for k in cols] + [task_id]
-        await self.execute(f"UPDATE {_TASK} SET {set_clause} WHERE task_id = ?", values)
+        values = [kwargs[k] for k in cols] + [tenant_id, inst_id, task_id]
+        await self.execute(
+            f"UPDATE {_TASK} SET {set_clause} WHERE tenant_id = ? AND instance_id = ? AND task_id = ?",
+            values,
+        )
         await self.commit()
 
     async def list_tasks(self, collection: str | None = None) -> list[dict[str, Any]]:
+        tenant_id, inst_id = self._scope()
         if collection:
             rows = await self.fetchall(
-                f"SELECT * FROM {_TASK} WHERE collection = ? ORDER BY created_at DESC",
-                (collection,),
+                f"SELECT * FROM {_TASK} WHERE tenant_id = ? AND instance_id = ? AND collection = ? "
+                f"ORDER BY created_at DESC",
+                (tenant_id, inst_id, collection),
             )
         else:
-            rows = await self.fetchall(f"SELECT * FROM {_TASK} ORDER BY created_at DESC")
+            rows = await self.fetchall(
+                f"SELECT * FROM {_TASK} WHERE tenant_id = ? AND instance_id = ? ORDER BY created_at DESC",
+                (tenant_id, inst_id),
+            )
         out: list[dict[str, Any]] = []
         for r in rows:
             task = dict(r)
@@ -201,16 +283,20 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
 
     async def recover_stale_tasks(self) -> int:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         rows = await self.fetchall(
-            f"SELECT task_id, file_tasks_json FROM {_TASK} WHERE status IN ('running', 'pending')",
+            f"SELECT task_id, file_tasks_json FROM {_TASK} "
+            f"WHERE tenant_id = ? AND instance_id = ? AND status IN ('running', 'pending')",
+            (tenant_id, inst_id),
         )
         count = 0
         for row in rows:
             task_id = row["task_id"]
             file_tasks = mark_file_tasks_interrupted(normalize_file_tasks(row["file_tasks_json"]))
             await self.execute(
-                f"UPDATE {_TASK} SET status = ?, file_tasks_json = ?, updated_at = ? WHERE task_id = ?",
-                ("failed", json.dumps(file_tasks), now, task_id),
+                f"UPDATE {_TASK} SET status = ?, file_tasks_json = ?, updated_at = ? "
+                f"WHERE tenant_id = ? AND instance_id = ? AND task_id = ?",
+                ("failed", json.dumps(file_tasks), now, tenant_id, inst_id, task_id),
             )
             count += 1
         await self.commit()
@@ -218,54 +304,88 @@ class PostgresKnowledgeMetadata(ProdRelationalStore):
 
     async def purge_old_tasks(self, max_age_days: int = 7) -> int:
         cutoff = iso_cutoff_days_ago(max_age_days)
-        await self.execute(f"DELETE FROM {_TASK} WHERE updated_at < ?", (cutoff,))
+        tenant_id, inst_id = self._scope()
+        await self.execute(
+            f"DELETE FROM {_TASK} WHERE tenant_id = ? AND instance_id = ? AND updated_at < ?",
+            (tenant_id, inst_id, cutoff),
+        )
         n = self._last_rowcount
         await self.commit()
         return n
 
     async def get_collection_config(self, collection: str) -> dict[str, Any] | None:
-        return await self.fetchone(f"SELECT * FROM {_COLL} WHERE collection = ?", (collection,))
+        tenant_id, inst_id = self._scope()
+        return await self.fetchone(
+            f"SELECT * FROM {_COLL} WHERE tenant_id = ? AND instance_id = ? AND collection = ?",
+            (tenant_id, inst_id, collection),
+        )
 
     async def set_collection_config(
         self, collection: str, embedding_provider: str, embedding_model: str, embedding_dim: int
     ) -> None:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         await self.execute(
             f"""
-            INSERT INTO {_COLL} (collection, embedding_provider, embedding_model, embedding_dim, created_at)
-            VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT (collection) DO NOTHING
+            INSERT INTO {_COLL} (
+                tenant_id, instance_id, collection, embedding_provider, embedding_model, embedding_dim, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (tenant_id, instance_id, collection) DO NOTHING
             """,
-            (collection, embedding_provider, embedding_model, embedding_dim, now),
+            (tenant_id, inst_id, collection, embedding_provider, embedding_model, embedding_dim, now),
         )
         await self.commit()
 
     async def list_all_collection_configs(self) -> list[str]:
-        rows = await self.fetchall(f"SELECT collection FROM {_COLL}")
+        tenant_id, inst_id = self._scope()
+        rows = await self.fetchall(
+            f"SELECT collection FROM {_COLL} WHERE tenant_id = ? AND instance_id = ?",
+            (tenant_id, inst_id),
+        )
         return [r["collection"] for r in rows]
 
     async def delete_collection_metadata(self, collection: str) -> None:
-        await self.execute(f"DELETE FROM {_DOC} WHERE collection = ?", (collection,))
-        await self.execute(f"DELETE FROM {_TASK} WHERE collection = ?", (collection,))
-        await self.execute(f"DELETE FROM {_COLL} WHERE collection = ?", (collection,))
+        tenant_id, inst_id = self._scope()
+        await self.execute(
+            f"DELETE FROM {_DOC} WHERE tenant_id = ? AND instance_id = ? AND collection = ?",
+            (tenant_id, inst_id, collection),
+        )
+        await self.execute(
+            f"DELETE FROM {_TASK} WHERE tenant_id = ? AND instance_id = ? AND collection = ?",
+            (tenant_id, inst_id, collection),
+        )
+        await self.execute(
+            f"DELETE FROM {_COLL} WHERE tenant_id = ? AND instance_id = ? AND collection = ?",
+            (tenant_id, inst_id, collection),
+        )
         await self.commit()
 
     async def get_setting(self, key: str, default: str = "") -> str:
-        row = await self.fetchone(f"SELECT value FROM {_SET} WHERE key = ?", (key,))
+        tenant_id, inst_id = self._scope()
+        row = await self.fetchone(
+            f"SELECT value FROM {_SET} WHERE tenant_id = ? AND instance_id = ? AND key = ?",
+            (tenant_id, inst_id, key),
+        )
         return row["value"] if row else default
 
     async def set_setting(self, key: str, value: str) -> None:
+        tenant_id, inst_id = self._scope()
         await self.execute(
             f"""
-            INSERT INTO {_SET} (key, value) VALUES (?, ?)
-            ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+            INSERT INTO {_SET} (tenant_id, instance_id, key, value) VALUES (?, ?, ?, ?)
+            ON CONFLICT (tenant_id, instance_id, key) DO UPDATE SET value = EXCLUDED.value
             """,
-            (key, value),
+            (tenant_id, inst_id, key, value),
         )
         await self.commit()
 
     async def get_all_settings(self) -> dict[str, str]:
-        rows = await self.fetchall(f"SELECT key, value FROM {_SET}")
+        tenant_id, inst_id = self._scope()
+        rows = await self.fetchall(
+            f"SELECT key, value FROM {_SET} WHERE tenant_id = ? AND instance_id = ?",
+            (tenant_id, inst_id),
+        )
         return {r["key"]: r["value"] for r in rows}
 
 

--- a/src/cuga/backend/knowledge/metadata/sqlite_store.py
+++ b/src/cuga/backend/knowledge/metadata/sqlite_store.py
@@ -12,39 +12,30 @@ from pathlib import Path
 from typing import Any
 
 from cuga.backend.knowledge.metadata.base import (
+    current_scope,
     mark_file_tasks_interrupted,
     normalize_file_tasks,
     utc_now_iso,
 )
 from cuga.backend.storage.relational.local import LocalRelationalStore
 
-
-class SqliteKnowledgeMetadata(LocalRelationalStore):
-    def __init__(self, db_path: Path):
-        db_path = Path(db_path)
-        db_path.parent.mkdir(parents=True, exist_ok=True)
-        super().__init__(str(db_path))
-        self._init_schema()
-
-    def _on_connection_opened(self, conn: sqlite3.Connection) -> None:
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA busy_timeout=5000")
-
-    def _init_schema(self) -> None:
-        conn = self._get_conn()
-        conn.executescript("""
+_SCHEMA_SQL = """
             CREATE TABLE IF NOT EXISTS documents (
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
                 collection TEXT NOT NULL,
                 filename TEXT NOT NULL,
                 chunk_count INTEGER DEFAULT 0,
                 status TEXT NOT NULL DEFAULT 'indexed',
                 ingested_at TEXT NOT NULL,
                 preview TEXT NOT NULL DEFAULT '',
-                PRIMARY KEY (collection, filename)
+                PRIMARY KEY (tenant_id, instance_id, collection, filename)
             );
 
             CREATE TABLE IF NOT EXISTS tasks (
-                task_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL,
                 collection TEXT NOT NULL,
                 status TEXT NOT NULL DEFAULT 'pending'
                     CHECK(status IN ('pending','running','completed','failed','cancelled')),
@@ -54,79 +45,204 @@ class SqliteKnowledgeMetadata(LocalRelationalStore):
                 failed_files INTEGER NOT NULL DEFAULT 0,
                 file_tasks_json TEXT NOT NULL DEFAULT '{}',
                 created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, task_id)
             );
 
             CREATE TABLE IF NOT EXISTS collection_config (
-                collection TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                collection TEXT NOT NULL,
                 embedding_provider TEXT NOT NULL,
                 embedding_model TEXT NOT NULL,
                 embedding_dim INTEGER NOT NULL,
-                created_at TEXT NOT NULL
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, collection)
             );
 
             CREATE TABLE IF NOT EXISTS settings (
-                key TEXT PRIMARY KEY,
-                value TEXT NOT NULL
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, key)
             );
 
+        """
+
+_INDEX_SQL = """
             CREATE INDEX IF NOT EXISTS idx_tasks_collection_status
-                ON tasks(collection, status, updated_at);
+                ON tasks(tenant_id, instance_id, collection, status, updated_at);
             CREATE INDEX IF NOT EXISTS idx_docs_collection
-                ON documents(collection, status);
-        """)
+                ON documents(tenant_id, instance_id, collection, status);
+        """
+
+_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
+    (
+        "documents",
+        """CREATE TABLE documents (
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                collection TEXT NOT NULL,
+                filename TEXT NOT NULL,
+                chunk_count INTEGER DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'indexed',
+                ingested_at TEXT NOT NULL,
+                preview TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (tenant_id, instance_id, collection, filename)
+            )""",
+        "INSERT INTO documents (tenant_id, instance_id, collection, filename, chunk_count, status, ingested_at, preview) "
+        "SELECT '', '', collection, filename, chunk_count, status, ingested_at, "
+        "COALESCE(preview, '') FROM documents__old",
+    ),
+    (
+        "tasks",
+        """CREATE TABLE tasks (
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL,
+                collection TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(status IN ('pending','running','completed','failed','cancelled')),
+                total_files INTEGER NOT NULL DEFAULT 0,
+                processed_files INTEGER NOT NULL DEFAULT 0,
+                successful_files INTEGER NOT NULL DEFAULT 0,
+                failed_files INTEGER NOT NULL DEFAULT 0,
+                file_tasks_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, task_id)
+            )""",
+        "INSERT INTO tasks (tenant_id, instance_id, task_id, collection, status, total_files, "
+        "processed_files, successful_files, failed_files, file_tasks_json, created_at, updated_at) "
+        "SELECT '', '', task_id, collection, status, total_files, processed_files, successful_files, "
+        "failed_files, file_tasks_json, created_at, updated_at FROM tasks__old",
+    ),
+    (
+        "collection_config",
+        """CREATE TABLE collection_config (
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                collection TEXT NOT NULL,
+                embedding_provider TEXT NOT NULL,
+                embedding_model TEXT NOT NULL,
+                embedding_dim INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, collection)
+            )""",
+        "INSERT INTO collection_config (tenant_id, instance_id, collection, embedding_provider, "
+        "embedding_model, embedding_dim, created_at) "
+        "SELECT '', '', collection, embedding_provider, embedding_model, embedding_dim, created_at "
+        "FROM collection_config__old",
+    ),
+    (
+        "settings",
+        """CREATE TABLE settings (
+                tenant_id TEXT NOT NULL DEFAULT '',
+                instance_id TEXT NOT NULL DEFAULT '',
+                key TEXT NOT NULL,
+                value TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, instance_id, key)
+            )""",
+        "INSERT INTO settings (tenant_id, instance_id, key, value) "
+        "SELECT '', '', key, value FROM settings__old",
+    ),
+)
+
+
+class SqliteKnowledgeMetadata(LocalRelationalStore):
+    def __init__(self, db_path: Path):
+        db_path = Path(db_path)
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        super().__init__(str(db_path))
+        self._init_schema()
+
+    def _scope(self) -> tuple[str, str]:
+        return current_scope()
+
+    def _on_connection_opened(self, conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+
+    def _init_schema(self) -> None:
+        conn = self._get_conn()
+        conn.executescript(_SCHEMA_SQL)
         try:
             conn.execute("ALTER TABLE documents ADD COLUMN preview TEXT NOT NULL DEFAULT ''")
         except sqlite3.OperationalError:
             pass
+        self._migrate_scope_columns(conn)
+        conn.executescript(_INDEX_SQL)
         conn.commit()
+
+    def _migrate_scope_columns(self, conn: sqlite3.Connection) -> None:
+        for table, create_sql, copy_sql in _MIGRATIONS:
+            cols = [r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()]
+            if not cols or "tenant_id" in cols:
+                continue
+            conn.execute(f"ALTER TABLE {table} RENAME TO {table}__old")
+            conn.execute(create_sql)
+            conn.execute(copy_sql)
+            conn.execute(f"DROP TABLE {table}__old")
 
     async def ensure_ready(self) -> None:
         return
 
     async def add_document(self, collection: str, filename: str, chunk_count: int, preview: str = "") -> None:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            """INSERT OR REPLACE INTO documents (collection, filename, chunk_count, status, ingested_at, preview)
-               VALUES (?, ?, ?, 'indexed', ?, ?)""",
-            (collection, filename, chunk_count, now, preview),
+            """INSERT OR REPLACE INTO documents
+               (tenant_id, instance_id, collection, filename, chunk_count, status, ingested_at, preview)
+               VALUES (?, ?, ?, ?, ?, 'indexed', ?, ?)""",
+            (tenant_id, inst_id, collection, filename, chunk_count, now, preview),
         )
         await self.commit()
 
     async def mark_deleting(self, collection: str, filename: str) -> bool:
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            "UPDATE documents SET status='deleting' WHERE collection=? AND filename=?",
-            (collection, filename),
+            "UPDATE documents SET status='deleting' "
+            "WHERE tenant_id=? AND instance_id=? AND collection=? AND filename=?",
+            (tenant_id, inst_id, collection, filename),
         )
         ok = self._last_rowcount > 0
         await self.commit()
         return ok
 
     async def remove_document(self, collection: str, filename: str) -> None:
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            "DELETE FROM documents WHERE collection=? AND filename=?",
-            (collection, filename),
+            "DELETE FROM documents WHERE tenant_id=? AND instance_id=? AND collection=? AND filename=?",
+            (tenant_id, inst_id, collection, filename),
         )
         await self.commit()
 
     async def list_documents(self, collection: str) -> list[dict[str, Any]]:
+        tenant_id, inst_id = self._scope()
         rows = await self.fetchall(
             "SELECT filename, chunk_count, status, ingested_at, preview FROM documents "
-            "WHERE collection=? AND status != 'deleting' ORDER BY ingested_at DESC",
-            (collection,),
+            "WHERE tenant_id=? AND instance_id=? AND collection=? AND status != 'deleting' "
+            "ORDER BY ingested_at DESC",
+            (tenant_id, inst_id, collection),
         )
         return [dict(r) for r in rows]
 
     async def get_deleting_documents(self) -> list[dict[str, Any]]:
+        tenant_id, inst_id = self._scope()
         rows = await self.fetchall(
-            "SELECT collection, filename FROM documents WHERE status='deleting'",
+            "SELECT collection, filename FROM documents "
+            "WHERE tenant_id=? AND instance_id=? AND status='deleting'",
+            (tenant_id, inst_id),
         )
         return [dict(r) for r in rows]
 
     async def document_exists(self, collection: str, filename: str) -> bool:
+        tenant_id, inst_id = self._scope()
         row = await self.fetchone(
-            "SELECT 1 AS one FROM documents WHERE collection=? AND filename=? AND status != 'deleting'",
-            (collection, filename),
+            "SELECT 1 AS one FROM documents "
+            "WHERE tenant_id=? AND instance_id=? AND collection=? AND filename=? AND status != 'deleting'",
+            (tenant_id, inst_id, collection, filename),
         )
         return row is not None
 
@@ -134,17 +250,22 @@ class SqliteKnowledgeMetadata(LocalRelationalStore):
         self, task_id: str, collection: str, total_files: int, file_tasks: dict[str, dict]
     ) -> dict[str, Any]:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            """INSERT INTO tasks (task_id, collection, status, total_files, processed_files,
-               successful_files, failed_files, file_tasks_json, created_at, updated_at)
-               VALUES (?, ?, 'pending', ?, 0, 0, 0, ?, ?, ?)""",
-            (task_id, collection, total_files, json.dumps(file_tasks), now, now),
+            """INSERT INTO tasks (tenant_id, instance_id, task_id, collection, status, total_files,
+               processed_files, successful_files, failed_files, file_tasks_json, created_at, updated_at)
+               VALUES (?, ?, ?, ?, 'pending', ?, 0, 0, 0, ?, ?, ?)""",
+            (tenant_id, inst_id, task_id, collection, total_files, json.dumps(file_tasks), now, now),
         )
         await self.commit()
         return await self.get_task(task_id)
 
     async def get_task(self, task_id: str) -> dict[str, Any] | None:
-        row = await self.fetchone("SELECT * FROM tasks WHERE task_id=?", (task_id,))
+        tenant_id, inst_id = self._scope()
+        row = await self.fetchone(
+            "SELECT * FROM tasks WHERE tenant_id=? AND instance_id=? AND task_id=?",
+            (tenant_id, inst_id, task_id),
+        )
         if not row:
             return None
         task = dict(row)
@@ -153,22 +274,31 @@ class SqliteKnowledgeMetadata(LocalRelationalStore):
 
     async def update_task(self, task_id: str, **kwargs: Any) -> None:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         if "file_tasks" in kwargs:
             kwargs["file_tasks_json"] = json.dumps(kwargs.pop("file_tasks"))
         kwargs["updated_at"] = now
         set_clause = ", ".join(f"{k}=?" for k in kwargs)
-        values = list(kwargs.values()) + [task_id]
-        await self.execute(f"UPDATE tasks SET {set_clause} WHERE task_id=?", values)
+        values = list(kwargs.values()) + [tenant_id, inst_id, task_id]
+        await self.execute(
+            f"UPDATE tasks SET {set_clause} WHERE tenant_id=? AND instance_id=? AND task_id=?",
+            values,
+        )
         await self.commit()
 
     async def list_tasks(self, collection: str | None = None) -> list[dict[str, Any]]:
+        tenant_id, inst_id = self._scope()
         if collection:
             rows = await self.fetchall(
-                "SELECT * FROM tasks WHERE collection=? ORDER BY created_at DESC",
-                (collection,),
+                "SELECT * FROM tasks WHERE tenant_id=? AND instance_id=? AND collection=? "
+                "ORDER BY created_at DESC",
+                (tenant_id, inst_id, collection),
             )
         else:
-            rows = await self.fetchall("SELECT * FROM tasks ORDER BY created_at DESC")
+            rows = await self.fetchall(
+                "SELECT * FROM tasks WHERE tenant_id=? AND instance_id=? ORDER BY created_at DESC",
+                (tenant_id, inst_id),
+            )
         result: list[dict[str, Any]] = []
         for r in rows:
             task = dict(r)
@@ -178,68 +308,101 @@ class SqliteKnowledgeMetadata(LocalRelationalStore):
 
     async def recover_stale_tasks(self) -> int:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         rows = await self.fetchall(
-            "SELECT task_id, file_tasks_json FROM tasks WHERE status IN ('running', 'pending')",
+            "SELECT task_id, file_tasks_json FROM tasks "
+            "WHERE tenant_id=? AND instance_id=? AND status IN ('running', 'pending')",
+            (tenant_id, inst_id),
         )
         count = 0
         for row in rows:
             task_id = row["task_id"]
             file_tasks = mark_file_tasks_interrupted(normalize_file_tasks(row["file_tasks_json"]))
             await self.execute(
-                "UPDATE tasks SET status='failed', file_tasks_json=?, updated_at=? WHERE task_id=?",
-                (json.dumps(file_tasks), now, task_id),
+                "UPDATE tasks SET status='failed', file_tasks_json=?, updated_at=? "
+                "WHERE tenant_id=? AND instance_id=? AND task_id=?",
+                (json.dumps(file_tasks), now, tenant_id, inst_id, task_id),
             )
             count += 1
         await self.commit()
         return count
 
     async def purge_old_tasks(self, max_age_days: int = 7) -> int:
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            "DELETE FROM tasks WHERE updated_at < datetime('now', ?)",
-            (f"-{max_age_days} days",),
+            "DELETE FROM tasks WHERE tenant_id=? AND instance_id=? AND updated_at < datetime('now', ?)",
+            (tenant_id, inst_id, f"-{max_age_days} days"),
         )
         n = self._last_rowcount
         await self.commit()
         return n
 
     async def get_collection_config(self, collection: str) -> dict[str, Any] | None:
-        return await self.fetchone("SELECT * FROM collection_config WHERE collection=?", (collection,))
+        tenant_id, inst_id = self._scope()
+        return await self.fetchone(
+            "SELECT * FROM collection_config WHERE tenant_id=? AND instance_id=? AND collection=?",
+            (tenant_id, inst_id, collection),
+        )
 
     async def set_collection_config(
         self, collection: str, embedding_provider: str, embedding_model: str, embedding_dim: int
     ) -> None:
         now = utc_now_iso()
+        tenant_id, inst_id = self._scope()
         await self.execute(
             """INSERT OR IGNORE INTO collection_config
-               (collection, embedding_provider, embedding_model, embedding_dim, created_at)
-               VALUES (?, ?, ?, ?, ?)""",
-            (collection, embedding_provider, embedding_model, embedding_dim, now),
+               (tenant_id, instance_id, collection, embedding_provider, embedding_model, embedding_dim, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (tenant_id, inst_id, collection, embedding_provider, embedding_model, embedding_dim, now),
         )
         await self.commit()
 
     async def list_all_collection_configs(self) -> list[str]:
-        rows = await self.fetchall("SELECT collection FROM collection_config")
+        tenant_id, inst_id = self._scope()
+        rows = await self.fetchall(
+            "SELECT collection FROM collection_config WHERE tenant_id=? AND instance_id=?",
+            (tenant_id, inst_id),
+        )
         return [dict(r)["collection"] for r in rows]
 
     async def delete_collection_metadata(self, collection: str) -> None:
-        await self.execute("DELETE FROM documents WHERE collection=?", (collection,))
-        await self.execute("DELETE FROM tasks WHERE collection=?", (collection,))
-        await self.execute("DELETE FROM collection_config WHERE collection=?", (collection,))
+        tenant_id, inst_id = self._scope()
+        await self.execute(
+            "DELETE FROM documents WHERE tenant_id=? AND instance_id=? AND collection=?",
+            (tenant_id, inst_id, collection),
+        )
+        await self.execute(
+            "DELETE FROM tasks WHERE tenant_id=? AND instance_id=? AND collection=?",
+            (tenant_id, inst_id, collection),
+        )
+        await self.execute(
+            "DELETE FROM collection_config WHERE tenant_id=? AND instance_id=? AND collection=?",
+            (tenant_id, inst_id, collection),
+        )
         await self.commit()
 
     async def get_setting(self, key: str, default: str = "") -> str:
-        row = await self.fetchone("SELECT value FROM settings WHERE key=?", (key,))
+        tenant_id, inst_id = self._scope()
+        row = await self.fetchone(
+            "SELECT value FROM settings WHERE tenant_id=? AND instance_id=? AND key=?",
+            (tenant_id, inst_id, key),
+        )
         return row["value"] if row else default
 
     async def set_setting(self, key: str, value: str) -> None:
+        tenant_id, inst_id = self._scope()
         await self.execute(
-            "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
-            (key, value),
+            "INSERT OR REPLACE INTO settings (tenant_id, instance_id, key, value) VALUES (?, ?, ?, ?)",
+            (tenant_id, inst_id, key, value),
         )
         await self.commit()
 
     async def get_all_settings(self) -> dict[str, str]:
-        rows = await self.fetchall("SELECT key, value FROM settings")
+        tenant_id, inst_id = self._scope()
+        rows = await self.fetchall(
+            "SELECT key, value FROM settings WHERE tenant_id=? AND instance_id=?",
+            (tenant_id, inst_id),
+        )
         return {dict(r)["key"]: dict(r)["value"] for r in rows}
 
 

--- a/src/cuga/backend/knowledge/session_provider.py
+++ b/src/cuga/backend/knowledge/session_provider.py
@@ -5,7 +5,9 @@ knowledge state (uploaded documents, filters, overrides).
 
 Routes MUST always go through the provider's save() method — never write
 to the JSON file directly.  SessionProvider.save() is in-memory only;
-PersistentSessionProvider.save() writes through to disk automatically.
+StorageBackedSessionProvider (used by the server) writes through to the
+relational store selected by ``storage.mode``; PersistentSessionProvider
+writes through to a JSON file (tests / legacy import).
 """
 
 from __future__ import annotations
@@ -214,6 +216,196 @@ class SessionProvider:
 
     def list_agents(self) -> dict[str, AgentKnowledgeState]:
         return dict(self._agents)
+
+
+def _run_sync(coro):
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
+
+_SESSION_TABLE = "knowledge_session_state"
+
+
+async def _ensure_session_schema(store) -> None:
+    await store.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_SESSION_TABLE} (
+            tenant_id TEXT NOT NULL DEFAULT '',
+            instance_id TEXT NOT NULL DEFAULT '',
+            kind TEXT NOT NULL,
+            record_key TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, instance_id, kind, record_key)
+        )
+        """
+    )
+    await store.commit()
+
+
+class StorageBackedSessionProvider(SessionProvider):
+    """Session knowledge persisted through ``storage.mode`` (SQLite local / Postgres prod).
+
+    Every row is scoped by ``tenant_id`` + ``instance_id``, matching policies and
+    other relational stores. The in-memory maps remain the API; mutations write
+    through one row at a time.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._load()
+
+    def _store(self):
+        from cuga.backend.storage import get_storage
+
+        return get_storage().get_relational_store("config")
+
+    def _scope(self) -> tuple[str, str]:
+        from cuga.config import get_service_instance_id, get_tenant_id
+
+        return get_tenant_id(), get_service_instance_id()
+
+    def _load(self) -> None:
+        self._sessions, self._agents = _run_sync(self._load_async())
+
+    async def _load_async(self) -> tuple[dict[str, SessionKnowledgeState], dict[str, AgentKnowledgeState]]:
+        store = self._store()
+        await _ensure_session_schema(store)
+        tenant_id, inst_id = self._scope()
+        rows = await store.fetchall(
+            f"SELECT kind, record_key, payload FROM {_SESSION_TABLE} WHERE tenant_id = ? AND instance_id = ?",
+            (tenant_id, inst_id),
+        )
+        sessions: dict[str, SessionKnowledgeState] = {}
+        agents: dict[str, AgentKnowledgeState] = {}
+        for row in rows:
+            kind = row["kind"]
+            try:
+                data = json.loads(row["payload"])
+            except (TypeError, ValueError):
+                continue
+            if kind == "session":
+                sessions[row["record_key"]] = SessionKnowledgeState.from_dict(data)
+            elif kind == "agent":
+                agents[row["record_key"]] = AgentKnowledgeState.from_dict(data)
+        logger.info(
+            "Loaded knowledge session state from storage: %d sessions, %d agents",
+            len(sessions),
+            len(agents),
+        )
+        return sessions, agents
+
+    def _upsert(self, kind: str, record_key: str, payload: dict[str, Any]) -> None:
+        _run_sync(self._upsert_async(kind, record_key, payload))
+
+    async def _upsert_async(self, kind: str, record_key: str, payload: dict[str, Any]) -> None:
+        store = self._store()
+        await _ensure_session_schema(store)
+        tenant_id, inst_id = self._scope()
+        now = datetime.now(timezone.utc).isoformat()
+        body = json.dumps(payload)
+        is_prod = type(store).__name__ == "ProdRelationalStore"
+        if is_prod:
+            await store.execute(
+                f"""
+                INSERT INTO {_SESSION_TABLE} (tenant_id, instance_id, kind, record_key, payload, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT (tenant_id, instance_id, kind, record_key)
+                DO UPDATE SET payload = EXCLUDED.payload, updated_at = EXCLUDED.updated_at
+                """,
+                (tenant_id, inst_id, kind, record_key, body, now),
+            )
+        else:
+            await store.execute(
+                f"""
+                INSERT OR REPLACE INTO {_SESSION_TABLE}
+                (tenant_id, instance_id, kind, record_key, payload, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (tenant_id, inst_id, kind, record_key, body, now),
+            )
+        await store.commit()
+
+    def _delete_row(self, kind: str, record_key: str) -> None:
+        _run_sync(self._delete_row_async(kind, record_key))
+
+    async def _delete_row_async(self, kind: str, record_key: str) -> None:
+        store = self._store()
+        await _ensure_session_schema(store)
+        tenant_id, inst_id = self._scope()
+        await store.execute(
+            f"DELETE FROM {_SESSION_TABLE} WHERE tenant_id = ? AND instance_id = ? "
+            f"AND kind = ? AND record_key = ?",
+            (tenant_id, inst_id, kind, record_key),
+        )
+        await store.commit()
+
+    def save_session(self, thread_id: str, state: SessionKnowledgeState) -> None:
+        super().save_session(thread_id, state)
+        self._upsert("session", thread_id, state.to_dict())
+
+    def delete_session(self, thread_id: str) -> None:
+        super().delete_session(thread_id)
+        self._delete_row("session", thread_id)
+
+    def patch_session_overrides(
+        self,
+        thread_id: str,
+        patch: dict[str, Any],
+        user_id: str = "",
+        tenant_id: str = "",
+    ) -> SessionKnowledgeState:
+        state = super().patch_session_overrides(thread_id, patch, user_id=user_id, tenant_id=tenant_id)
+        self._upsert("session", thread_id, state.to_dict())
+        return state
+
+    def save_agent(self, state: AgentKnowledgeState) -> None:
+        super().save_agent(state)
+        self._upsert("agent", state.key, state.to_dict())
+
+
+def create_session_provider(*, json_legacy_path: Path | None = None) -> SessionProvider:
+    """Build the session provider that follows ``storage.mode``.
+
+    If a legacy ``session_knowledge.json`` exists and this tenant+instance has
+    no rows yet, import it once so a switch to prod (or the new table) keeps
+    existing session state.
+    """
+    provider = StorageBackedSessionProvider()
+    if (
+        json_legacy_path is not None
+        and json_legacy_path.exists()
+        and not provider.list_sessions()
+        and not provider.list_agents()
+    ):
+        legacy = PersistentSessionProvider(json_legacy_path)
+        for session in legacy.list_sessions().values():
+            provider.save_session(session.thread_id, session)
+        for agent in legacy.list_agents().values():
+            provider.save_agent(agent)
+        logger.info("Imported legacy session_knowledge.json into storage-backed session state")
+    return provider
+
+
+async def delete_scoped_session_knowledge() -> None:
+    """Drop session/agent knowledge rows for the current tenant+instance (demo reset)."""
+    from cuga.backend.storage import get_storage
+    from cuga.config import get_service_instance_id, get_tenant_id
+
+    store = get_storage().get_relational_store("config")
+    await _ensure_session_schema(store)
+    await store.execute(
+        f"DELETE FROM {_SESSION_TABLE} WHERE tenant_id = ? AND instance_id = ?",
+        (get_tenant_id(), get_service_instance_id()),
+    )
+    await store.commit()
 
 
 class PersistentSessionProvider(SessionProvider):

--- a/src/cuga/backend/server/conversation_history.py
+++ b/src/cuga/backend/server/conversation_history.py
@@ -454,10 +454,13 @@ class ConversationHistoryDB:
             await self._ensure_schema()
             store = self._get_store()
             cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
+            tenant_id = _tenant_id()
+            inst_id = _instance_id()
             await store.execute(
                 """
                 DELETE FROM stream_events
-                WHERE updated_at < ?
+                WHERE tenant_id = ? AND instance_id = ?
+                  AND updated_at < ?
                   AND NOT EXISTS (
                     SELECT 1 FROM conversation_history ch
                     WHERE ch.tenant_id = stream_events.tenant_id
@@ -467,7 +470,7 @@ class ConversationHistoryDB:
                       AND ch.user_id = stream_events.user_id
                   )
                 """,
-                (cutoff,),
+                (tenant_id, inst_id, cutoff),
             )
             # Both LocalRelationalStore and ProdRelationalStore set _last_rowcount
             # on execute(); use it to avoid SELECT changes() (SQLite-only) or

--- a/src/cuga/backend/server/demo_manage_setup.py
+++ b/src/cuga/backend/server/demo_manage_setup.py
@@ -593,6 +593,11 @@ def setup_demo_manage_config(
                 if session_state.exists():
                     session_state.unlink()
                     logger.info("Knowledge reset: removed session_knowledge.json")
+                from cuga.backend.knowledge.session_provider import delete_scoped_session_knowledge
+                from cuga.backend.server.config_store import run_sync
+
+                run_sync(delete_scoped_session_knowledge())
+                logger.info("Knowledge reset: cleared scoped session knowledge rows")
             finally:
                 _lock_release(_lock_fd)
                 _lock_fd.close()

--- a/src/cuga/backend/server/main.py
+++ b/src/cuga/backend/server/main.py
@@ -694,11 +694,11 @@ async def lifespan(app: FastAPI):
         app_state.knowledge_engine = KnowledgeEngine(kb_config, chat_generator=CugaChatGenerator())
 
         # Initialize session provider for ownership enforcement
-        from cuga.backend.knowledge.session_provider import PersistentSessionProvider
+        from cuga.backend.knowledge.session_provider import create_session_provider
 
         if not getattr(app_state, "knowledge_provider", None):
             _kb_state_path = Path.cwd() / ".cuga" / "session_knowledge.json"
-            app_state.knowledge_provider = PersistentSessionProvider(_kb_state_path)
+            app_state.knowledge_provider = create_session_provider(json_legacy_path=_kb_state_path)
 
         # Wire per-session citation overrides into the knowledge sources module
         # so citations_enabled_for() can honor session-level toggles.

--- a/src/cuga/backend/storage/embedding/local.py
+++ b/src/cuga/backend/storage/embedding/local.py
@@ -168,7 +168,7 @@ class LocalEmbeddingStore:
             scope_vals.append(tenant_id)
         if "instance_id" in scope:
             scope_vals.append(instance_id)
-        if scope and any(scope_vals):
+        if scope:
             where_parts = [f"{c} = ?" for c in scope]
             where_parts.append(f"{id_col} = ?")
             row = conn.execute(
@@ -196,7 +196,7 @@ class LocalEmbeddingStore:
             scope_vals.append(tenant_id)
         if "instance_id" in scope:
             scope_vals.append(instance_id)
-        if scope and any(scope_vals):
+        if scope:
             where_parts = [f"{c} = ?" for c in scope]
             where_parts.append(f"{id_col} = ?")
             conn.execute(

--- a/src/cuga/backend/storage/embedding/prod.py
+++ b/src/cuga/backend/storage/embedding/prod.py
@@ -182,7 +182,7 @@ class ProdEmbeddingStore:
             scope_vals.append(tenant_id)
         if "instance_id" in scope:
             scope_vals.append(instance_id)
-        if scope and any(scope_vals):
+        if scope:
             where_parts = [f"{c} = ${i + 1}" for i, c in enumerate(scope)]
             where_parts.append(f"{id_col} = ${len(scope) + 1}")
             async with pool.acquire() as conn:
@@ -210,7 +210,7 @@ class ProdEmbeddingStore:
             scope_vals.append(tenant_id)
         if "instance_id" in scope:
             scope_vals.append(instance_id)
-        if scope and any(scope_vals):
+        if scope:
             where_parts = [f"{c} = ${i + 1}" for i, c in enumerate(scope)]
             where_parts.append(f"{id_col} = ${len(scope) + 1}")
             async with pool.acquire() as conn:

--- a/src/cuga/settings.toml
+++ b/src/cuga/settings.toml
@@ -157,9 +157,15 @@ pass_variables_a2a = false  # When true, A2A delegate tool accepts variables and
 #
 # | Data | local | prod |
 # |------|-------|------|
-# | Policy vectors | sqlite-vec in `[policy].policy_db_path` or `storage.local_db_path` (default `DBS_DIR/cuga.db`); table `[policy].collection_name` | `storage.postgres_url` (pgvector) |
+# | Policy vectors | sqlite-vec in `[policy].policy_db_path` or `storage.local_db_path` (default `DBS_DIR/cuga.db`); table `[policy].collection_name` | `storage.postgres_url` (pgvector). `[policy].policy_db_path` is ignored in prod. |
 # | Knowledge vectors | `{knowledge.persist_dir}/knowledge_vectors.db` (vec0 tables per collection) | `storage.postgres_url` (same stack as policy) |
 # | Knowledge metadata (tasks, documents, collection_config, settings) | `{knowledge.persist_dir}/metadata.db` (default `<cwd>/.cuga/knowledge/`) | Postgres tables `cuga_knowledge_meta_*` on `storage.postgres_url` (uploaded **files** stay under `persist_dir/files/`) |
+# | Agent configs / secrets | `storage.local_db_path` tables `agent_configs`, `secrets` | same tables on `storage.postgres_url` |
+# | Conversation history / stream events | `storage.local_db_path` tables `conversation_history`, `stream_events` | same tables on `storage.postgres_url` |
+# | Session knowledge state | `storage.local_db_path` table `knowledge_session_state` | same table on `storage.postgres_url` |
+#
+# All of the above rows are scoped by `service.tenant_id` + `service.instance_id`
+# (env: DYNACONF_SERVICE__TENANT_ID / DYNACONF_SERVICE__INSTANCE_ID).
 #
 # Defaults: `DBS_DIR` = package `dbs/` or `CUGA_DBS_DIR`. Override `knowledge.persist_dir` in knowledge_settings.toml.
 mode = "local"  # "local" | "prod"

--- a/tests/unit/test_knowledge_pgvector_metadata.py
+++ b/tests/unit/test_knowledge_pgvector_metadata.py
@@ -28,6 +28,8 @@ from cuga.backend.knowledge.metadata.postgres_store import (
 )
 from cuga.backend.knowledge.routes import _enrich_task
 
+pytestmark = pytest.mark.unit
+
 
 class _FakePostgresMetadata(PostgresKnowledgeMetadata):
     """Override the asyncpg I/O with an in-memory recorder.
@@ -49,6 +51,8 @@ class _FakePostgresMetadata(PostgresKnowledgeMetadata):
         # call patterns and update our in-memory row store.
         if "INSERT INTO" in sql and "_tasks" in sql:
             (
+                _tenant_id,
+                _instance_id,
                 task_id,
                 collection,
                 total_files,
@@ -69,18 +73,18 @@ class _FakePostgresMetadata(PostgresKnowledgeMetadata):
                 "updated_at": updated_at,
             }
         elif "UPDATE" in sql and "_tasks" in sql:
-            # SET <col> = ?, ... WHERE task_id = ?
+            # SET <col> = ?, ... WHERE tenant_id = ? AND instance_id = ? AND task_id = ?
             set_section = sql.split("SET", 1)[1].split("WHERE", 1)[0]
             cols = [seg.split("=")[0].strip() for seg in set_section.strip().rstrip(",").split(",")]
             task_id = params[-1]
             if task_id in self._rows_by_task_id:
-                for col, val in zip(cols, params[:-1]):
+                for col, val in zip(cols, params[: len(cols)]):
                     self._rows_by_task_id[task_id][col] = val
 
     async def fetchone(self, sql: str, params: tuple = ()):  # type: ignore[override]
         self.fetched_one.append((sql, tuple(params)))
-        if "_tasks" in sql and "WHERE task_id" in sql:
-            return self._rows_by_task_id.get(params[0])
+        if "_tasks" in sql and "task_id" in sql:
+            return self._rows_by_task_id.get(params[-1])
         return None
 
     async def fetchall(self, sql: str, params: tuple = ()):  # type: ignore[override]
@@ -187,6 +191,13 @@ async def test_failure_path_writes_well_formed_sql_against_postgres_store():
         assert "?" in sql, f"UPDATE missing ``?`` placeholders: {sql}"
         assert "$1" not in sql, "Postgres-specific placeholders leaked: " + sql
         assert "%s" not in sql, "Mysql/psycopg-style placeholders leaked: " + sql
+        assert "tenant_id" in sql
+        assert "instance_id" in sql
+    insert_sqls = [s for s, _ in store.executed if "INSERT INTO" in s]
+    assert insert_sqls
+    for sql in insert_sqls:
+        assert "tenant_id" in sql
+        assert "instance_id" in sql
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_knowledge_recover_stale_tasks.py
+++ b/tests/unit/test_knowledge_recover_stale_tasks.py
@@ -56,7 +56,8 @@ class _RecoveryFakePostgres(PostgresKnowledgeMetadata):
         return list(self._rows)
 
     async def execute(self, sql: str, params: tuple = ()) -> None:  # type: ignore[override]
-        status, file_tasks_json, _updated_at, task_id = params
+        status, file_tasks_json, _updated_at = params[:3]
+        task_id = params[-1]
         self.written[task_id] = {"status": status, "file_tasks_json": file_tasks_json}
 
     async def commit(self) -> None:  # type: ignore[override]

--- a/tests/unit/test_storage_tenant_instance_isolation.py
+++ b/tests/unit/test_storage_tenant_instance_isolation.py
@@ -1,0 +1,280 @@
+"""Tenant + instance isolation for every store that lands in Postgres in prod."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cuga.backend.cuga_graph.policy.configurable import resolve_local_policy_db_path
+from cuga.backend.knowledge.metadata import create_knowledge_metadata
+from cuga.backend.knowledge.metadata.postgres_store import PostgresKnowledgeMetadata
+from cuga.backend.knowledge.metadata.sqlite_store import SqliteKnowledgeMetadata
+from cuga.backend.knowledge.session_provider import (
+    AgentKnowledgeState,
+    SessionKnowledgeState,
+    StorageBackedSessionProvider,
+    create_session_provider,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _patch_scope(monkeypatch, tenant: str, instance: str) -> None:
+    monkeypatch.setattr("cuga.backend.knowledge.metadata.base.get_tenant_id", lambda: tenant)
+    monkeypatch.setattr("cuga.backend.knowledge.metadata.base.get_service_instance_id", lambda: instance)
+    monkeypatch.setattr("cuga.backend.server.conversation_history.get_tenant_id", lambda: tenant)
+    monkeypatch.setattr("cuga.backend.server.conversation_history.get_service_instance_id", lambda: instance)
+    monkeypatch.setattr("cuga.config.get_tenant_id", lambda: tenant)
+    monkeypatch.setattr("cuga.config.get_service_instance_id", lambda: instance)
+
+
+@pytest.fixture
+def meta_db(tmp_path):
+    db = SqliteKnowledgeMetadata(tmp_path / "metadata.db")
+    yield db
+
+
+@pytest.mark.asyncio
+async def test_knowledge_metadata_isolates_documents_by_tenant_and_instance(meta_db, monkeypatch):
+    _patch_scope(monkeypatch, "tenant-a", "inst-1")
+    await meta_db.add_document("kb_agent_default", "a.pdf", 3)
+
+    _patch_scope(monkeypatch, "tenant-b", "inst-1")
+    await meta_db.add_document("kb_agent_default", "b.pdf", 5)
+
+    docs_b = await meta_db.list_documents("kb_agent_default")
+    assert [d["filename"] for d in docs_b] == ["b.pdf"]
+    assert not await meta_db.document_exists("kb_agent_default", "a.pdf")
+
+    _patch_scope(monkeypatch, "tenant-a", "inst-1")
+    docs_a = await meta_db.list_documents("kb_agent_default")
+    assert [d["filename"] for d in docs_a] == ["a.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_metadata_isolates_tasks_and_settings(meta_db, monkeypatch):
+    _patch_scope(monkeypatch, "t1", "i1")
+    await meta_db.create_task("task-shared-id", "col", 1, {"f.pdf": {"filename": "f.pdf"}})
+    await meta_db.set_setting("chunk_size", "100")
+    await meta_db.set_collection_config("col", "hf", "m", 384)
+
+    _patch_scope(monkeypatch, "t2", "i1")
+    assert await meta_db.get_task("task-shared-id") is None
+    assert await meta_db.list_tasks("col") == []
+    assert await meta_db.get_setting("chunk_size", "missing") == "missing"
+    assert await meta_db.get_collection_config("col") is None
+    await meta_db.create_task("task-shared-id", "col", 1, {"g.pdf": {"filename": "g.pdf"}})
+    task = await meta_db.get_task("task-shared-id")
+    assert task is not None
+    assert "g.pdf" in task["file_tasks"]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_metadata_maintenance_does_not_cross_scope(meta_db, monkeypatch):
+    _patch_scope(monkeypatch, "t1", "i1")
+    await meta_db.add_document("col", "stale.pdf", 1)
+    await meta_db.mark_deleting("col", "stale.pdf")
+    await meta_db.create_task("t-run", "col", 1, {"f.pdf": {"filename": "f.pdf", "status": "processing"}})
+    await meta_db.update_task("t-run", status="running")
+
+    _patch_scope(monkeypatch, "t2", "i2")
+    assert await meta_db.get_deleting_documents() == []
+    assert await meta_db.recover_stale_tasks() == 0
+
+    _patch_scope(monkeypatch, "t1", "i1")
+    deleting = await meta_db.get_deleting_documents()
+    assert len(deleting) == 1
+    assert deleting[0]["filename"] == "stale.pdf"
+    assert await meta_db.recover_stale_tasks() == 1
+
+
+@pytest.mark.asyncio
+async def test_sqlite_migrates_legacy_schema_without_scope_columns(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE documents (
+            collection TEXT NOT NULL,
+            filename TEXT NOT NULL,
+            chunk_count INTEGER DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'indexed',
+            ingested_at TEXT NOT NULL,
+            preview TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (collection, filename)
+        );
+        INSERT INTO documents VALUES ('col', 'old.pdf', 2, 'indexed', '2020-01-01T00:00:00+00:00', 'hi');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    _patch_scope(monkeypatch, "", "")
+    store = SqliteKnowledgeMetadata(db_path)
+    docs = await store.list_documents("col")
+    assert len(docs) == 1
+    assert docs[0]["filename"] == "old.pdf"
+    await store.close()
+
+
+def test_create_knowledge_metadata_wires_prod_to_postgres():
+    store = create_knowledge_metadata(
+        Path("/tmp/unused"),
+        mode="prod",
+        postgres_url="postgresql://example/cuga",
+    )
+    assert isinstance(store, PostgresKnowledgeMetadata)
+
+
+def test_create_knowledge_metadata_prod_requires_url(tmp_path):
+    with pytest.raises(ValueError, match="postgres_url"):
+        create_knowledge_metadata(tmp_path, mode="prod", postgres_url="")
+
+
+def test_resolve_local_policy_db_path_ignores_settings_in_prod():
+    assert resolve_local_policy_db_path(None, "/tmp/policies.db", "prod") is None
+    assert resolve_local_policy_db_path(None, "/tmp/policies.db", "local") == "/tmp/policies.db"
+    assert resolve_local_policy_db_path("/explicit.db", "/tmp/policies.db", "prod") == "/explicit.db"
+
+
+def test_gc_stream_events_only_touches_current_tenant_instance(monkeypatch):
+    import asyncio
+
+    import cuga.backend.storage.facade as facade
+    from cuga.backend.server.conversation_history import ConversationHistoryDB
+
+    tmpfile = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    tmpfile.close()
+    original = facade._local_db_path
+    facade._local_db_path = lambda: tmpfile.name
+    facade.get_storage().invalidate_relational_stores()
+    db = ConversationHistoryDB()
+    db._schema_ensured = False
+    try:
+
+        async def _run():
+            events = [{"event_name": "Answer", "event_data": "x", "timestamp": "t", "sequence": 0}]
+            _patch_scope(monkeypatch, "tenant-a", "inst-a")
+            await db.save_stream_events("agent", "orphan-a", "user", events)
+            _patch_scope(monkeypatch, "tenant-b", "inst-b")
+            await db.save_stream_events("agent", "orphan-b", "user", events)
+            removed = await db.gc_ephemeral_stream_events(older_than_days=0)
+            assert removed == 1
+            assert await db.get_stream_events("agent", "orphan-b", "user") is None
+            _patch_scope(monkeypatch, "tenant-a", "inst-a")
+            kept = await db.get_stream_events("agent", "orphan-a", "user")
+            assert kept is not None
+            assert len(kept.events) == 1
+
+        asyncio.run(_run())
+    finally:
+        facade._local_db_path = original
+        facade.get_storage().invalidate_relational_stores()
+        Path(tmpfile.name).unlink(missing_ok=True)
+
+
+def test_storage_backed_session_provider_isolates_by_scope(monkeypatch, tmp_path):
+    import cuga.backend.storage.facade as facade
+
+    db_path = str(tmp_path / "cuga.db")
+    original = facade._local_db_path
+    facade._local_db_path = lambda: db_path
+    facade.get_storage().invalidate_relational_stores()
+    try:
+        _patch_scope(monkeypatch, "tenant-a", "inst-1")
+        a = StorageBackedSessionProvider()
+        a.save_session(
+            "thread-1",
+            SessionKnowledgeState(thread_id="thread-1", user_id="alice", tenant_id="tenant-a"),
+        )
+        a.save_agent(AgentKnowledgeState(agent_id="cuga-default", config_version="1"))
+
+        _patch_scope(monkeypatch, "tenant-b", "inst-1")
+        b = StorageBackedSessionProvider()
+        assert b.get_session("thread-1") is None
+        assert b.list_agents() == {}
+        b.save_session(
+            "thread-1",
+            SessionKnowledgeState(thread_id="thread-1", user_id="bob", tenant_id="tenant-b"),
+        )
+
+        _patch_scope(monkeypatch, "tenant-a", "inst-1")
+        a2 = StorageBackedSessionProvider()
+        assert a2.get_session("thread-1").user_id == "alice"
+        assert "cuga-default:1" in a2.list_agents()
+    finally:
+        facade._local_db_path = original
+        facade.get_storage().invalidate_relational_stores()
+
+
+def test_create_session_provider_imports_legacy_json(monkeypatch, tmp_path):
+    import cuga.backend.storage.facade as facade
+    from cuga.backend.knowledge.session_provider import PersistentSessionProvider
+
+    db_path = str(tmp_path / "cuga.db")
+    original = facade._local_db_path
+    facade._local_db_path = lambda: db_path
+    facade.get_storage().invalidate_relational_stores()
+    try:
+        _patch_scope(monkeypatch, "t", "i")
+        json_path = tmp_path / "session_knowledge.json"
+        legacy = PersistentSessionProvider(json_path)
+        legacy.save_session("th", SessionKnowledgeState(thread_id="th", user_id="u", tenant_id="t"))
+        provider = create_session_provider(json_legacy_path=json_path)
+        assert provider.get_session("th") is not None
+        assert provider.get_session("th").user_id == "u"
+    finally:
+        facade._local_db_path = original
+        facade.get_storage().invalidate_relational_stores()
+
+
+@pytest.mark.asyncio
+async def test_postgres_metadata_sql_always_includes_scope_predicates():
+    store = PostgresKnowledgeMetadata("postgresql://fake/test")
+    executed: list[tuple[str, tuple]] = []
+
+    async def _execute(sql: str, params: tuple = ()):
+        executed.append((sql, tuple(params)))
+
+    async def _fetchone(sql: str, params: tuple = ()):
+        executed.append((sql, tuple(params)))
+        return None
+
+    async def _fetchall(sql: str, params: tuple = ()):
+        executed.append((sql, tuple(params)))
+        return []
+
+    async def _commit() -> None:
+        return None
+
+    store.execute = _execute  # type: ignore[method-assign]
+    store.fetchone = _fetchone  # type: ignore[method-assign]
+    store.fetchall = _fetchall  # type: ignore[method-assign]
+    store.commit = _commit  # type: ignore[method-assign]
+    store._schema_initialized = True
+    store._last_rowcount = 0
+
+    with (
+        patch("cuga.backend.knowledge.metadata.base.get_tenant_id", return_value="ten"),
+        patch("cuga.backend.knowledge.metadata.base.get_service_instance_id", return_value="inst"),
+    ):
+        await store.add_document("col", "f.pdf", 1)
+        await store.list_documents("col")
+        await store.get_deleting_documents()
+        await store.get_task("t1")
+        await store.list_tasks()
+        await store.recover_stale_tasks()
+        await store.purge_old_tasks()
+        await store.get_all_settings()
+        await store.list_all_collection_configs()
+
+    assert executed
+    for sql, params in executed:
+        assert "tenant_id" in sql, sql
+        assert "instance_id" in sql, sql
+        assert params[0] == "ten"
+        assert params[1] == "inst"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug fix

Fixes #

### Summary

Production Postgres was not isolating every persisted record the way policies already do (`tenant_id` + `instance_id`). Shared `storage.postgres_url` could leak or mutate another tenant/instance’s knowledge metadata, and a few writes did not follow `storage.mode`.

**Already isolated (unchanged):** policy vectors, knowledge vectors, `agent_configs`, `secrets`, `conversation_history` / `stream_events` CRUD.

**Fixed in this PR:**
- Knowledge metadata tables (`cuga_knowledge_meta_*` / local `metadata.db`) now stamp and filter every query by tenant + instance, with a schema migration for existing DBs.
- Ephemeral stream-event GC only deletes rows for the current tenant + instance.
- Embedding `get` / `delete` always apply scope columns (including empty-string IDs).
- Session knowledge is stored in `knowledge_session_state` via `storage.mode` (SQLite local / Postgres prod) instead of a process-wide JSON file.
- `[policy].policy_db_path` is ignored when `storage.mode=prod` so policies stay on `storage.postgres_url`. Explicit `initialize(policy_db_path=...)` still works for tests.

### Testing
- [x] Verified fix locally; tests pass (`uv run pytest` on isolation, knowledge metadata, session knowledge, stream-event GC, and config-store tenant tests — 96 passed)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3506a080-7b80-4aab-8e78-5f0dc07b57ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3506a080-7b80-4aab-8e78-5f0dc07b57ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tenant- and service-instance-scoped storage for knowledge metadata, sessions, agent state, conversations, and embeddings.
  - Added relational persistence for session and agent state, with automatic loading and legacy JSON import.
  - Added scoped cleanup and reset support for session knowledge and temporary conversation data.

- **Bug Fixes**
  - Improved isolation when reading, updating, or deleting stored data, including empty scope values.

- **Documentation**
  - Clarified storage locations and production policy database behavior.

- **Tests**
  - Added coverage for storage isolation, migrations, session import, and maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->