### PR TITLE
fix(llm): correct stale RITS registrations — dead Gemma endpoint and 32k Mistral context window

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ CUGA supports LiteLLM through the OpenAI configuration by overriding the base UR
    # direct RITS setups, since each model has a model-specific URL path.
    # Setting MODEL_NAME alone will leave you pointed at the previous model's URL.
    MODEL_NAME=google/gemma-4-31B-it
-   RITS_BASE_URL="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+   RITS_BASE_URL="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
    ```
 
 To front RITS with a local LiteLLM proxy instead, use `AGENT_SETTING_CONFIG="settings.rits.proxy.toml"`.

--- a/src/cuga/backend/cuga_graph/utils/token_counter.py
+++ b/src/cuga/backend/cuga_graph/utils/token_counter.py
@@ -201,14 +201,19 @@ MODEL_CONTEXT_SIZES = {
     # ============================================================================
     # Google Gemma 4 Models
     # ============================================================================
-    # Deployment cap, not the 262,144 native window: the RITS vLLM deployment serves
-    # max_model_len=131072 (probed via GET .../v1/models, 2026-07-28). Registering the
-    # native window put the 70% summarization trigger (~183k) beyond the deployment's
-    # 131k cliff, so summarization could never engage on Gemma (issue #563).
-    "gemma-4-31B-it": 131072,
-    "gemma-4-31b-it": 131072,
-    "google/gemma-4-31B-it": 131072,
-    "google/gemma-4-31b-it": 131072,
+    # Matches the RITS vLLM deployment, which now serves max_model_len=262144 — the
+    # full native window (probed via GET .../v1/models, 2026-08-27; enforced, and
+    # verified with a live 144k-token request).
+    #
+    # This was pinned to 131072 under #563, when the deployment capped the window at
+    # half the native size and registering 262144 put the 70% summarization trigger
+    # (~183k) beyond that 131k cliff. The cap has since been lifted, so the pin now
+    # errs the other way: it would summarize at ~92k and waste ~130k of usable window.
+    # These are deployment facts, not model facts — re-probe before trusting them.
+    "gemma-4-31B-it": 262144,
+    "gemma-4-31b-it": 262144,
+    "google/gemma-4-31B-it": 262144,
+    "google/gemma-4-31b-it": 262144,
     # ============================================================================
     # Meta Llama Models
     # ============================================================================
@@ -247,6 +252,15 @@ MODEL_CONTEXT_SIZES = {
     "mistral-large": 128000,
     "mistral-large-latest": 128000,
     "mistral-large-2411": 128000,
+    # Needed because lookup falls back to a longest-prefix match: without this specific
+    # key, the 3.5 model matches the generic "mistral-medium" below and inherits its
+    # 32000 — an 8x underestimate, and a silent one, since the "unknown model" warning
+    # only fires when nothing matches at all. (Longest key wins, so dict order here is
+    # irrelevant.) "128B" is the parameter count, not the window:
+    # the RITS deployment serves max_model_len=262144 (probed 2026-08-27; enforced, and
+    # verified with a live 182k-token request).
+    "mistral-medium-3.5-128b": 262144,
+    "mistralai/mistral-medium-3.5-128b": 262144,
     "mistral-medium": 32000,
     "mistral-small": 32000,
     "mistral-7b": 32000,

--- a/src/cuga/configurations/models/settings.rits.toml
+++ b/src/cuga/configurations/models/settings.rits.toml
@@ -1,7 +1,7 @@
 [agent.task_decomposition.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -10,7 +10,7 @@ max_tokens = 1000
 [agent.planner.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -19,7 +19,7 @@ max_tokens = 7000
 [agent.shortlister.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -29,7 +29,7 @@ max_tokens = 7000
 [agent.chat.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -38,7 +38,7 @@ max_tokens = 5000
 [agent.plan_controller.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -48,7 +48,7 @@ max_tokens = 5000
 [agent.final_answer.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -57,7 +57,7 @@ max_tokens = 15000
 [agent.code.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -66,7 +66,7 @@ max_tokens = 3000
 [agent.code_planner.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -75,7 +75,7 @@ max_tokens = 3000
 [agent.qa.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -84,7 +84,7 @@ max_tokens = 4000
 [agent.action.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -93,7 +93,7 @@ max_tokens = 400
 [memory.mem0.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -102,7 +102,7 @@ max_tokens = 1000
 [memory.milvus.step_processing.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -111,7 +111,7 @@ max_tokens = 1000
 [memory.milvus.fact_extraction.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0
@@ -120,7 +120,7 @@ max_tokens = 1000
 [memory.tips_extractor.model]
 platform = "rits"
 model_name = "google/gemma-4-31B-it"
-url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it/v1"
+url="https://inference-3scale-apicast-production.apps.rits.fmaas.res.ibm.com/google-gemma-4-31b-it-a100/v1"
 apikey_name = "RITS_API_KEY"
 temperature = 0.1
 top_p = 1.0

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -96,6 +96,29 @@ class TestTokenCounter:
     def test_lookup_model_context_size_with_provider_prefix(self):
         assert lookup_model_context_size("openai/gpt-oss-120b") == 131072
 
+    def test_lookup_mistral_medium_35_not_shadowed_by_generic_entry(self):
+        """A longer, more specific key must win over the generic ``mistral-medium``.
+
+        Without a dedicated entry, ``Mistral-Medium-3.5-128B`` prefix-matches
+        ``mistral-medium`` and silently resolves to 32000 instead of the 262144 the
+        RITS deployment serves — no warning, because a key *did* match (issue #719).
+        """
+        assert lookup_model_context_size("mistralai/Mistral-Medium-3.5-128B") == 262144
+        # Double provider prefix (e.g. MODEL_NAME="rits/mistralai/...") strips only the
+        # first segment, so the vendor-qualified key has to resolve too.
+        assert lookup_model_context_size("rits/mistralai/Mistral-Medium-3.5-128B") == 262144
+        # The generic entry must keep working for models that legitimately want it.
+        assert lookup_model_context_size("mistralai/mistral-medium") == 32000
+
+    def test_lookup_gemma_4_matches_rits_deployment_window(self):
+        """Gemma 4 on RITS serves the full 262144 native window (issue #719).
+
+        Previously pinned to 131072 when the deployment capped it at half; that cap has
+        since been lifted, so the pin under-reported the window by ~130k tokens.
+        """
+        for name in ("gemma-4-31b-it", "google/gemma-4-31B-it"):
+            assert lookup_model_context_size(name) == 262144
+
     def test_resolve_model_identifier_prefers_model_id(self):
         model = Mock()
         model.model_id = "openai/gpt-oss-120b"

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -96,6 +96,7 @@ class TestTokenCounter:
     def test_lookup_model_context_size_with_provider_prefix(self):
         assert lookup_model_context_size("openai/gpt-oss-120b") == 131072
 
+    @pytest.mark.unit
     def test_lookup_mistral_medium_35_not_shadowed_by_generic_entry(self):
         """A longer, more specific key must win over the generic ``mistral-medium``.
 
@@ -110,6 +111,7 @@ class TestTokenCounter:
         # The generic entry must keep working for models that legitimately want it.
         assert lookup_model_context_size("mistralai/mistral-medium") == 32000
 
+    @pytest.mark.unit
     def test_lookup_gemma_4_matches_rits_deployment_window(self):
         """Gemma 4 on RITS serves the full 262144 native window (issue #719).
 


### PR DESCRIPTION
## Bug fix

Fixes #719

### Summary

Three RITS registrations had drifted from the live deployments. Two failed silently.

**1. `settings.rits.toml` pointed every agent at a retired endpoint.** All 14 `url=` entries used the slug `google-gemma-4-31b-it`, which now returns 404; the served deployment is `google-gemma-4-31b-it-a100`. Masked in practice by the `RITS_BASE_URL` env override added in #374, so only runs without that variable were affected — those got a 404 on every agent. The same stale URL was in the README example, so copying it verbatim failed the same way.

**2. `mistralai/Mistral-Medium-3.5-128B` resolved to a 32,000-token window.** `lookup_model_context_size()` falls back to a longest-prefix match, and with no specific key the model matched the generic `"mistral-medium": 32000`. The deployment serves **262,144** — an 8× underestimate. It was silent: the "unknown model … defaulting to" warning only fires when *nothing* matches, and here something did. With `context_summarization.enabled = true` and the default `trigger_fraction = 0.70`, that triggers a summary at ~22.4k instead of ~183.5k, degrading results rather than erroring, with nothing in the logs pointing at the cause.

Note "128B" is the parameter count, not the window — registering `128000` would also have been wrong.

**3. The Gemma 4 entry was stale.** Pinned to `131072` under #563, when the deployment capped the window at half native and registering the full size pushed the summarization trigger past that cliff. The cap has since been lifted, so the pin now errs the other way and under-reports by ~130k. The explanatory comment was rewritten so the old rationale isn't re-applied by someone reading it later.

### Root cause

These constants encode **deployment** facts, not model facts, and nothing re-validates them. Gemma's window changed under a stable slug during a single afternoon of testing. The comments now say so explicitly and carry probe dates.

### Verification

All values re-probed on 2026-08-27 immediately before writing them, then confirmed three ways rather than trusting the advertised number:

| Check | Gemma 4 31B | Mistral Medium 3.5 |
|---|---|---|
| `GET /v1/models` | `max_model_len: 262144` | `max_model_len: 262144` |
| Enforced (over-large `max_tokens`) | 400 naming 262144 | 400 naming 262144 |
| Live long-context request | 144,046 tokens, correct retrieval | 182,051 tokens, correct retrieval |

Endpoint slugs: `google-gemma-4-31b-it` → 404, `google-gemma-4-31b-it-a100` → 200, `mistral-medium-3-5-128b-a100` → 200.

### Testing

- [x] Verified fix locally; tests pass

- Added two regression tests in `tests/unit/test_token_counter.py`. The Mistral one also covers the double-prefix form (`MODEL_NAME="rits/mistralai/..."`), which strips only the first segment and so needs the vendor-qualified key, and asserts the generic `mistral-medium` still resolves to 32000 for models that want it.
- `tests/unit tests/integration`: **1600 passed** vs **1598** on a clean `main` — +2, exactly the new tests. The 9 failures and 13 errors are byte-identical to a baseline run on stashed changes, i.e. pre-existing and environment-related (they need live LLM credentials).
- Remaining CI unit suites under `src/` run; their 7 failures also reproduce on clean `main` (confirmed the 3 `test_tool_approval_full_graph` ones by running that file on both trees).
- `uv run ruff check --fix` and `uv run ruff format`: clean.

### Notes for review

- The README change is outside the three items listed in #719 — found while sweeping for other references to the dead slug. Happy to split it out.
- Not addressed here, and arguably the more durable gap: `lookup_model_context_size()` silently returns a shorter relative's window on a prefix-only match. A warning distinguishing exact from prefix matches would have surfaced defect 2 immediately, but that changes shared behavior for every model and belongs in its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RITS model configurations to use the A100 Gemma deployment.
  * Increased supported context windows for Gemma 4 and Mistral Medium 3.5 models to 262,144 tokens.
  * Corrected model detection so Mistral Medium 3.5 uses its intended context limit.

* **Documentation**
  * Updated the RITS configuration example with the new Gemma A100 endpoint.

* **Tests**
  * Added coverage for the updated Gemma and Mistral context-window behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->