### PR TITLE
fix(skills): update cuga commit skill to not commit single files

### DIFF
--- a/.bob/skills/cuga-contributor-workflows/commit.md
+++ b/.bob/skills/cuga-contributor-workflows/commit.md
@@ -1,7 +1,7 @@
 # Commit
 
 1. Start with `git status` (and `git diff` / `git log` as needed). Selectively stage files — do not blindly `git add .` unless the user asks.
-2. Commit current changes **one per file**, or as the user asks. **Exception:** build/generated files may go in one commit together.
+2. Commit current changes, bundle relevant changes together. **Exception:** build/generated files may go in one commit together.
 3. Follow [Conventional Commits](https://www.conventionalcommits.org) with a scope when useful.
 4. Add bullet points in the commit description body explaining why / what changed.
 5. Always pass `-s` / `--signoff` (repo requires DCO on every commit).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit workflow guidance to recommend bundling related changes into a single commit, unless separate commits are specifically requested.
  * Retained the existing exception for build and generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->