### PR TITLE
fix(executor): preserve multiline string literals when wrapping code

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/code_executor.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/code_executor.py
@@ -311,17 +311,7 @@ class CodeExecutor:
     def _wrap_code_for_code_agent(cls, code: str, fake_datetime: Optional[str] = None) -> str:
         """Wrap code for CodeAgent execution."""
         SecurityValidator.validate_syntax(code)
-        indented_code = '\n'.join('    ' + line for line in code.split('\n'))
-
-        # Freeze time (datetime/date/time) like AppWorld's sandbox when in benchmark
-        # mode — scoped inside _async_main so it restores after the user code runs.
-        async_main = CodeWrapper.build_async_main(indented_code, fake_datetime)
-
-        wrapped_code = f"""
-import asyncio
-import json
-{async_main}
-"""
+        wrapped_code = CodeWrapper.wrap_code_for_code_agent(code, fake_datetime=fake_datetime)
         SecurityValidator.validate_dangerous_modules(wrapped_code)
         return wrapped_code
 

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/code_wrapper.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/common/code_wrapper.py
@@ -1,12 +1,140 @@
-from typing import Optional
+import ast
+from typing import List, Optional, Sequence, Tuple
+
+
+def _is_future_import(node: ast.stmt) -> bool:
+    return isinstance(node, ast.ImportFrom) and node.module == "__future__"
+
+
+def _is_print_call(node: ast.AST) -> bool:
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "print"
+
+
+def _split_user_code(code: str) -> Tuple[List[ast.stmt], List[ast.stmt]]:
+    tree = ast.parse(code)
+    futures = [stmt for stmt in tree.body if _is_future_import(stmt)]
+    body = [stmt for stmt in tree.body if not _is_future_import(stmt)]
+    return futures, body
+
+
+def _maybe_auto_print(body: List[ast.stmt]) -> List[ast.stmt]:
+    if not body:
+        return body
+    last = body[-1]
+    if not isinstance(last, ast.Expr) or _is_print_call(last.value):
+        return body
+    printed = ast.Expr(
+        value=ast.Call(
+            func=ast.Name(id="print", ctx=ast.Load()),
+            args=[last.value],
+            keywords=[],
+        )
+    )
+    return [*body[:-1], printed]
+
+
+def _return_locals() -> ast.Return:
+    return ast.Return(value=ast.Call(func=ast.Name(id="locals", ctx=ast.Load()), args=[], keywords=[]))
+
+
+_FREEZE_SETUP = """\
+import datetime as _cuga_dtmod, time as _cuga_tmod, calendar as _cuga_cal
+_cuga_odt = _cuga_dtmod.datetime
+_cuga_odate = _cuga_dtmod.date
+_cuga_ft = _cuga_odt.fromisoformat({fake_datetime!r})
+_cuga_epoch = float(_cuga_cal.timegm(_cuga_ft.timetuple()))
+_cuga_tt = _cuga_ft.timetuple()
+_cuga_otime = (_cuga_tmod.time, _cuga_tmod.localtime, _cuga_tmod.gmtime, _cuga_tmod.strftime)
+class _CugaDatetime:
+    def __new__(cls, *a, **k): return _cuga_odt(*a, **k)
+    @staticmethod
+    def now(tz=None): return _cuga_ft.replace(tzinfo=tz) if tz else _cuga_ft
+    @staticmethod
+    def today(): return _cuga_ft
+    @staticmethod
+    def utcnow(): return _cuga_ft
+    @staticmethod
+    def fromisoformat(s): return _cuga_odt.fromisoformat(s)
+    @staticmethod
+    def strptime(s, f): return _cuga_odt.strptime(s, f)
+    @staticmethod
+    def combine(*a, **k): return _cuga_odt.combine(*a, **k)
+    @staticmethod
+    def fromtimestamp(ts, tz=None): return _cuga_odt.fromtimestamp(ts, tz)
+    @staticmethod
+    def utcfromtimestamp(ts): return _cuga_odt.utcfromtimestamp(ts)
+    @staticmethod
+    def fromordinal(o): return _cuga_odt.fromordinal(o)
+_CugaDatetime.min = _cuga_odt.min
+_CugaDatetime.max = _cuga_odt.max
+_CugaDatetime.resolution = _cuga_odt.resolution
+class _CugaDate:
+    def __new__(cls, *a, **k): return _cuga_odate(*a, **k)
+    @staticmethod
+    def today(): return _cuga_odate(_cuga_ft.year, _cuga_ft.month, _cuga_ft.day)
+    @staticmethod
+    def fromisoformat(s): return _cuga_odate.fromisoformat(s)
+    @staticmethod
+    def fromtimestamp(ts): return _cuga_odate.fromtimestamp(ts)
+    @staticmethod
+    def fromordinal(o): return _cuga_odate.fromordinal(o)
+_CugaDate.min = _cuga_odate.min
+_CugaDate.max = _cuga_odate.max
+_CugaDate.resolution = _cuga_odate.resolution
+_cuga_dtmod.datetime = _CugaDatetime
+_cuga_dtmod.date = _CugaDate
+_cuga_tmod.time = lambda: _cuga_epoch
+_cuga_tmod.localtime = lambda secs=None: (_cuga_tt if secs is None else _cuga_otime[1](secs))
+_cuga_tmod.gmtime = lambda secs=None: (_cuga_tt if secs is None else _cuga_otime[2](secs))
+_cuga_tmod.strftime = lambda fmt, t=None: _cuga_otime[3](fmt, _cuga_tt if t is None else t)
+"""
+
+_FREEZE_FINALLY = """\
+_cuga_dtmod.datetime = _cuga_odt
+_cuga_dtmod.date = _cuga_odate
+_cuga_tmod.time, _cuga_tmod.localtime, _cuga_tmod.gmtime, _cuga_tmod.strftime = _cuga_otime
+"""
+
+
+def _function_body(user_body: List[ast.stmt], fake_datetime: Optional[str]) -> List[ast.stmt]:
+    payload = [*user_body, _return_locals()]
+    if not fake_datetime:
+        return payload
+    setup = ast.parse(_FREEZE_SETUP.format(fake_datetime=fake_datetime)).body
+    finally_body = ast.parse(_FREEZE_FINALLY).body
+    try_stmt = ast.Try(body=payload, handlers=[], orelse=[], finalbody=finally_body)
+    return [*setup, try_stmt]
+
+
+def _render_async_def(
+    func_name: str,
+    func_body: List[ast.stmt],
+    *,
+    futures: Sequence[ast.stmt] = (),
+    imports: Sequence[str] = (),
+) -> str:
+    import_src = "\n".join(f"import {name}" for name in imports)
+    prefix = f"{import_src}\n" if import_src else ""
+    tree = ast.parse(f"{prefix}async def {func_name}():\n    pass\n")
+    tree.body = [*futures, *tree.body]
+    func = tree.body[-1]
+    if not isinstance(func, ast.AsyncFunctionDef):
+        raise TypeError(f"expected AsyncFunctionDef, got {type(func).__name__}")
+    func.body = func_body or [ast.Pass()]
+    ast.fix_missing_locations(tree)
+    return ast.unparse(tree) + "\n"
 
 
 class CodeWrapper:
     """Handles wrapping user code for async execution."""
 
     @staticmethod
-    def build_async_main(indented_body: str, fake_datetime: Optional[str] = None) -> str:
+    def build_async_main(user_code: str, fake_datetime: Optional[str] = None) -> str:
         """Build the ``async def _async_main():`` block wrapping the user code.
+
+        ``user_code`` is the original agent source (module-level, not pre-indented).
+        The wrapper is assembled with ``ast`` so string-literal values are not
+        rewritten by a textual indent.
 
         When ``fake_datetime`` is set (benchmark mode), freeze the **wall clock**
         that AppWorld freezes for the agent's own code — ``datetime.datetime``,
@@ -25,76 +153,19 @@ class CodeWrapper:
 
         The patch is scoped with try/finally: originals are restored the moment
         the user code finishes, so nothing leaks into cuga's own clock.
-
-        ``indented_body`` must already be indented 4 spaces (function-body level).
         """
-        if not fake_datetime:
-            return f"async def _async_main():\n{indented_body}\n    return locals()"
-
-        # One extra indent level: the user body now lives inside `try:` inside the function.
-        deeper = "\n".join("    " + line for line in indented_body.split("\n"))
-        # `_cuga_*` names are underscore-prefixed so VariableUtils.filter_new_variables
-        # drops them from the returned agent variables. `time.time()` uses the UTC
-        # interpretation of the naive datetime (timegm), matching AppWorld/freezegun.
-        return (
-            "async def _async_main():\n"
-            "    import datetime as _cuga_dtmod, time as _cuga_tmod, calendar as _cuga_cal\n"
-            "    _cuga_odt = _cuga_dtmod.datetime\n"
-            "    _cuga_odate = _cuga_dtmod.date\n"
-            f'    _cuga_ft = _cuga_odt.fromisoformat("{fake_datetime}")\n'
-            "    _cuga_epoch = float(_cuga_cal.timegm(_cuga_ft.timetuple()))\n"
-            "    _cuga_tt = _cuga_ft.timetuple()\n"
-            "    _cuga_otime = (_cuga_tmod.time, _cuga_tmod.localtime, _cuga_tmod.gmtime, _cuga_tmod.strftime)\n"
-            "    class _CugaDatetime:\n"
-            "        def __new__(cls, *a, **k): return _cuga_odt(*a, **k)\n"
-            "        @staticmethod\n"
-            "        def now(tz=None): return _cuga_ft.replace(tzinfo=tz) if tz else _cuga_ft\n"
-            "        @staticmethod\n"
-            "        def today(): return _cuga_ft\n"
-            "        @staticmethod\n"
-            "        def utcnow(): return _cuga_ft\n"
-            "        @staticmethod\n"
-            "        def fromisoformat(s): return _cuga_odt.fromisoformat(s)\n"
-            "        @staticmethod\n"
-            "        def strptime(s, f): return _cuga_odt.strptime(s, f)\n"
-            "        @staticmethod\n"
-            "        def combine(*a, **k): return _cuga_odt.combine(*a, **k)\n"
-            "        @staticmethod\n"
-            "        def fromtimestamp(ts, tz=None): return _cuga_odt.fromtimestamp(ts, tz)\n"
-            "        @staticmethod\n"
-            "        def utcfromtimestamp(ts): return _cuga_odt.utcfromtimestamp(ts)\n"
-            "        @staticmethod\n"
-            "        def fromordinal(o): return _cuga_odt.fromordinal(o)\n"
-            "    _CugaDatetime.min = _cuga_odt.min\n"
-            "    _CugaDatetime.max = _cuga_odt.max\n"
-            "    _CugaDatetime.resolution = _cuga_odt.resolution\n"
-            "    class _CugaDate:\n"
-            "        def __new__(cls, *a, **k): return _cuga_odate(*a, **k)\n"
-            "        @staticmethod\n"
-            "        def today(): return _cuga_odate(_cuga_ft.year, _cuga_ft.month, _cuga_ft.day)\n"
-            "        @staticmethod\n"
-            "        def fromisoformat(s): return _cuga_odate.fromisoformat(s)\n"
-            "        @staticmethod\n"
-            "        def fromtimestamp(ts): return _cuga_odate.fromtimestamp(ts)\n"
-            "        @staticmethod\n"
-            "        def fromordinal(o): return _cuga_odate.fromordinal(o)\n"
-            "    _CugaDate.min = _cuga_odate.min\n"
-            "    _CugaDate.max = _cuga_odate.max\n"
-            "    _CugaDate.resolution = _cuga_odate.resolution\n"
-            "    _cuga_dtmod.datetime = _CugaDatetime\n"
-            "    _cuga_dtmod.date = _CugaDate\n"
-            "    _cuga_tmod.time = lambda: _cuga_epoch\n"
-            "    _cuga_tmod.localtime = lambda secs=None: (_cuga_tt if secs is None else _cuga_otime[1](secs))\n"
-            "    _cuga_tmod.gmtime = lambda secs=None: (_cuga_tt if secs is None else _cuga_otime[2](secs))\n"
-            "    _cuga_tmod.strftime = lambda fmt, t=None: _cuga_otime[3](fmt, _cuga_tt if t is None else t)\n"
-            "    try:\n"
-            f"{deeper}\n"
-            "        return locals()\n"
-            "    finally:\n"
-            "        _cuga_dtmod.datetime = _cuga_odt\n"
-            "        _cuga_dtmod.date = _cuga_odate\n"
-            "        _cuga_tmod.time, _cuga_tmod.localtime, _cuga_tmod.gmtime, _cuga_tmod.strftime = _cuga_otime\n"
+        futures, body = _split_user_code(user_code)
+        return _render_async_def(
+            "_async_main",
+            _function_body(body, fake_datetime),
+            futures=futures,
         )
+
+    @staticmethod
+    def wrap_in_async_def(code: str, func_name: str) -> str:
+        """Splice ``code`` into ``async def {func_name}():`` without text-indent."""
+        futures, body = _split_user_code(code)
+        return _render_async_def(func_name, body or [ast.Pass()], futures=futures)
 
     @staticmethod
     def wrap_code(code: str, fake_datetime: Optional[str] = None) -> str:
@@ -115,68 +186,22 @@ class CodeWrapper:
             namespace means SecurityValidator.validate_imports() remains the
             sole gate on what imports the wrapped code can reach.
         """
-        indented_code = '\n'.join('    ' + line for line in code.split('\n'))
-        lines = [line.strip() for line in code.split('\n') if line.strip()]
-
-        if not lines:
-            body = CodeWrapper.build_async_main(indented_code, fake_datetime)
-            return f"""
-import asyncio
-{body}
-
-# Execute the wrapped function
-"""
-
-        # Check if the last statement is already a print, return, or assignment
-        # Look backwards through lines to find the start of the last statement
-        last_line = lines[-1]
-        has_print = False
-        has_return = False
-
-        # Check if any line contains print( - handles multi-line print statements
-        # Also check for print statements that span multiple lines
-        code_text = '\n'.join(lines)
-        if 'print(' in code_text:
-            # More sophisticated check: look for print( that might span multiple lines
-            # Check if we're in the middle of a print statement by counting brackets
-            has_print = True
-
-        # Check for return statements
-        for line in reversed(lines):
-            stripped = line.strip()
-            if stripped.startswith('return '):
-                has_return = True
-                break
-            if '=' in stripped and not stripped.startswith('#'):
-                # If assignment is on last line, don't auto-print
-                if line == last_line:
-                    break
-
-        # Check if last line is just closing brackets (part of multi-line statement)
-        is_closing_only = last_line in ('}', ')', '})', '])', '))', ']}', ')}')
-
-        # Only auto-print if:
-        # 1. Last line doesn't start with print/return/#
-        # 2. No print statement found in any line
-        # 3. Last line is not an assignment
-        # 4. Last line is not just closing brackets (part of multi-line statement)
-        should_auto_print = (
-            not last_line.startswith(('print', 'return', '#'))
-            and not has_print
-            and not has_return
-            and '=' not in last_line
-            and not is_closing_only
+        futures, body = _split_user_code(code)
+        body = _maybe_auto_print(body)
+        return _render_async_def(
+            "_async_main",
+            _function_body(body, fake_datetime),
+            futures=futures,
+            imports=("asyncio",),
         )
 
-        if should_auto_print:
-            indented_code += f"\n    print({last_line})"
-
-        body = CodeWrapper.build_async_main(indented_code, fake_datetime)
-
-        wrapped_code = f"""
-import asyncio
-{body}
-
-# Execute the wrapped function
-"""
-        return wrapped_code
+    @staticmethod
+    def wrap_code_for_code_agent(code: str, fake_datetime: Optional[str] = None) -> str:
+        """Wrap CodeAgent source: asyncio+json imports, no last-expression auto-print."""
+        futures, body = _split_user_code(code)
+        return _render_async_def(
+            "_async_main",
+            _function_body(body, fake_datetime),
+            futures=futures,
+            imports=("asyncio", "json"),
+        )

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_code_wrapper_literals.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_code_wrapper_literals.py
@@ -1,0 +1,184 @@
+"""CodeWrapper must not rewrite the contents of string literals.
+
+Text-indent via ``'\\n'.join('    ' + line ...)`` prepends spaces to every
+source line, including the interior of triple-quoted / implicit-join strings.
+These checks pin the runtime value of those literals in both wrap modes, plus
+join-adjacent edge cases (blank lines, leading spaces, await, auto-print).
+
+Loaded directly (not via the cuga package) to stay fast/import-light.
+"""
+
+import asyncio
+import importlib.util
+import pathlib
+import threading
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_CW = pathlib.Path(__file__).resolve().parents[1] / "common" / "code_wrapper.py"
+_spec = importlib.util.spec_from_file_location("code_wrapper_literals", _CW)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+CodeWrapper = _mod.CodeWrapper
+
+FT = "2021-03-14T15:09:26"
+
+
+def _run(user_code: str, fake_datetime=None, limit: float = 8.0) -> dict:
+    wrapped = CodeWrapper.wrap_code(user_code, fake_datetime=fake_datetime)
+    compile(wrapped, "<wrapped>", "exec")
+    box: dict = {}
+
+    def target():
+        try:
+            g: dict = {}
+            exec(wrapped, g)
+            box["res"] = asyncio.run(g["_async_main"]())
+        except Exception as e:  # noqa: BLE001 — surfaced below
+            box["err"] = e
+
+    t = threading.Thread(target=target, daemon=True)
+    t.start()
+    t.join(limit)
+    assert not t.is_alive(), "wrapped async code did not finish"
+    if "err" in box:
+        raise box["err"]
+    return box["res"]
+
+
+@pytest.mark.parametrize("fake_datetime", [None, FT], ids=["no_freeze", "benchmark"])
+def test_triple_double_quoted_multiline_keeps_source_value(fake_datetime):
+    code = 'body = """line1\nline2\nline3"""\n'
+    res = _run(code, fake_datetime=fake_datetime)
+    assert res["body"] == "line1\nline2\nline3"
+
+
+@pytest.mark.parametrize("fake_datetime", [None, FT], ids=["no_freeze", "benchmark"])
+def test_triple_single_quoted_multiline_keeps_source_value(fake_datetime):
+    code = "body = '''line1\nline2\nline3'''\n"
+    res = _run(code, fake_datetime=fake_datetime)
+    assert res["body"] == "line1\nline2\nline3"
+
+
+@pytest.mark.parametrize("fake_datetime", [None, FT], ids=["no_freeze", "benchmark"])
+def test_blank_line_inside_triple_quoted_string_is_not_filled_with_spaces(fake_datetime):
+    code = 'body = """line1\n\nline3"""\n'
+    res = _run(code, fake_datetime=fake_datetime)
+    assert res["body"] == "line1\n\nline3"
+    assert "    " not in res["body"]
+
+
+@pytest.mark.parametrize("fake_datetime", [None, FT], ids=["no_freeze", "benchmark"])
+def test_intentional_leading_spaces_inside_string_are_preserved_exactly(fake_datetime):
+    code = 'body = """line1\n    indented\nline3"""\n'
+    res = _run(code, fake_datetime=fake_datetime)
+    assert res["body"] == "line1\n    indented\nline3"
+
+
+@pytest.mark.parametrize("fake_datetime", [None, FT], ids=["no_freeze", "benchmark"])
+def test_multiline_string_inside_indented_block_keeps_value(fake_datetime):
+    code = "if True:\n    body = \"\"\"line1\nline2\nline3\"\"\"\n"
+    res = _run(code, fake_datetime=fake_datetime)
+    assert res["body"] == "line1\nline2\nline3"
+
+
+@pytest.mark.parametrize("fake_datetime", [None, FT], ids=["no_freeze", "benchmark"])
+def test_multiline_fstring_interpolates_without_indent_corruption(fake_datetime):
+    code = 'name = "Ada"\nbody = f"""Hello {name}\nline2"""\n'
+    res = _run(code, fake_datetime=fake_datetime)
+    assert res["body"] == "Hello Ada\nline2"
+
+
+@pytest.mark.parametrize("fake_datetime", [None, FT], ids=["no_freeze", "benchmark"])
+def test_raw_multiline_string_keeps_backslashes_and_newlines(fake_datetime):
+    code = 'body = r"""line1\\n\nline2"""\n'
+    res = _run(code, fake_datetime=fake_datetime)
+    assert res["body"] == "line1\\n\nline2"
+
+
+def test_implicit_concat_across_parentheses_is_not_corrupted():
+    code = 'body = (\n    "line1\\n"\n    "line2"\n)\n'
+    res = _run(code, fake_datetime=None)
+    assert res["body"] == "line1\nline2"
+
+
+def test_escaped_newlines_in_single_line_literal_unchanged():
+    code = 'body = "line1\\nline2\\nline3"\n'
+    res = _run(code, fake_datetime=None)
+    assert res["body"] == "line1\nline2\nline3"
+
+
+def test_string_containing_print_call_text_does_not_block_auto_print():
+    code = 'note = """please print(this)"""\n42'
+    wrapped = CodeWrapper.wrap_code(code, fake_datetime=None)
+    g: dict = {}
+    exec(wrapped, g)
+    # last expression must still be auto-printed; "print(" inside the string
+    # is not a real print() statement.
+    import io
+    from contextlib import redirect_stdout
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        res = asyncio.run(g["_async_main"]())
+    assert res["note"] == "please print(this)"
+    assert "42" in buf.getvalue()
+
+
+def test_await_inside_wrapped_multiline_block_still_runs():
+    code = "import asyncio\nbody = \"\"\"line1\nline2\"\"\"\nawait asyncio.sleep(0)\ndone = True\n"
+    res = _run(code, fake_datetime=FT)
+    assert res["body"] == "line1\nline2"
+    assert res["done"] is True
+
+
+def test_nested_def_with_multiline_docstring_keeps_doc():
+    code = (
+        "def helper():\n    \"\"\"first\n    second\n    \"\"\"\n    return helper.__doc__\ndoc = helper()\n"
+    )
+    res = _run(code, fake_datetime=None)
+    assert res["doc"] == "first\n    second\n    "
+
+
+def test_future_import_is_lifted_out_of_the_function():
+    code = "from __future__ import annotations\nx = 1\n"
+    wrapped = CodeWrapper.wrap_code(code, fake_datetime=None)
+    compile(wrapped, "<wrapped>", "exec")
+    res = _run(code, fake_datetime=None)
+    assert res["x"] == 1
+
+
+def test_empty_and_comment_only_code_still_wrap():
+    assert "return locals()" in CodeWrapper.wrap_code("", fake_datetime=None)
+    res = _run("# only a comment\n", fake_datetime=None)
+    assert isinstance(res, dict)
+
+
+def test_assignment_last_statement_is_not_auto_printed():
+    wrapped = CodeWrapper.wrap_code('body = """a\nb"""\n', fake_datetime=None)
+    assert "print(" not in wrapped
+
+
+def test_wrap_in_async_def_preserves_multiline_and_blank_lines():
+    wrapped = CodeWrapper.wrap_in_async_def(
+        'body = """line1\n\nline3"""\nreturn body\n',
+        "__cuga_async_wrapper__",
+    )
+    g: dict = {}
+    exec(wrapped, g)
+    assert asyncio.run(g["__cuga_async_wrapper__"]()) == "line1\n\nline3"
+
+
+def test_code_agent_wrap_preserves_multiline_without_auto_print():
+    """CodeAgent wrap adds json and must not text-indent literals."""
+    wrap = getattr(CodeWrapper, "wrap_code_for_code_agent", None)
+    assert wrap is not None, "CodeAgent wrap must live on CodeWrapper so it cannot reintroduce join-indent"
+    for fake in (None, FT):
+        wrapped = wrap('body = """line1\nline2\nline3"""\n', fake_datetime=fake)
+        assert "import json" in wrapped
+        g: dict = {}
+        exec(wrapped, g)
+        res = asyncio.run(g["_async_main"]())
+        assert res["body"] == "line1\nline2\nline3"

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_direct.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_e2b_direct.py
@@ -76,6 +76,8 @@ result = {
 }
 """
 
+    from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.code_wrapper import CodeWrapper
+
     # Step 4: Combine everything into complete code for E2B
     complete_code = f"""
 import asyncio
@@ -84,9 +86,7 @@ import asyncio
 
 {variables_code}
 
-async def _async_main():
-{_indent_code(user_code, 1)}
-    return locals()
+{CodeWrapper.build_async_main(user_code)}
 
 # Execute
 _result_locals = await asyncio.wait_for(_async_main(), timeout=30)
@@ -196,9 +196,3 @@ def _serialize_tools(tools: dict) -> str:
             continue
 
     return "\n".join(lines)
-
-
-def _indent_code(code: str, levels: int = 1) -> str:
-    """Indent code by specified number of levels (4 spaces per level)."""
-    indent = "    " * levels
-    return "\n".join(indent + line for line in code.split("\n"))

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_timeout_evidence.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/executors/tests/test_timeout_evidence.py
@@ -12,6 +12,7 @@ instead.
 
 import pytest
 
+from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.code_wrapper import CodeWrapper
 from cuga.backend.cuga_graph.nodes.cuga_lite.executors.local.local_executor import LocalExecutor
 from cuga.backend.cuga_graph.nodes.cuga_lite.tracking.tracker import BlockToolCallCounter
 
@@ -19,13 +20,7 @@ pytestmark = pytest.mark.unit
 
 
 def _wrap(body: str) -> str:
-    indented = "\n".join("    " + line for line in body.split("\n"))
-    return f"""
-import asyncio
-async def _async_main():
-{indented}
-    return locals()
-"""
+    return CodeWrapper.wrap_code(body)
 
 
 @pytest.mark.asyncio

--- a/src/cuga/backend/tools_env/code_sandbox/sandbox.py
+++ b/src/cuga/backend/tools_env/code_sandbox/sandbox.py
@@ -346,9 +346,9 @@ async def run_code(
     python_file_dir = os.path.join(LOGGING_DIR, python_file_dir)
     file_path = python_file_dir + "/" + f"{mask_with_timestamp(tracker.task_id)}.py"
 
-    wrapped_code = f"""async def __cuga_async_wrapper__():
-{chr(10).join('    ' + line for line in code.split(chr(10)))}
-"""
+    from cuga.backend.cuga_graph.nodes.cuga_lite.executors.common.code_wrapper import CodeWrapper
+
+    wrapped_code = CodeWrapper.wrap_in_async_def(code, "__cuga_async_wrapper__")
 
     # Docker/Podman: Use asyncio.run() to execute from sync context
     wrapped_code_with_call = wrapped_code + "\nimport asyncio\nasyncio.run(__cuga_async_wrapper__())\n"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug fix

Fixes #752

### Summary

`CodeWrapper` and the CodeAgent wrap path indented agent source with `'\n'.join('    ' + line ...)`. That is a textual transform, so every line inside `"""` / `'''` literals gained 4 spaces (8 in benchmark mode). AppWorld task `fdc4b74_3` failed an email-body fidelity check for this reason.

The wrapper now parses the agent source with `ast`, splices those statements into `async def _async_main()`, and `ast.unparse`s the result. Literal values are preserved. The same path is used for:

- CugaLite `wrap_code` (including last-expression auto-print)
- CodeAgent wrap (`asyncio` + `json`, no auto-print)
- Benchmark clock freeze (`try`/`finally` is now an AST node, not a second join-indent)
- `tools_env` sandbox `__cuga_async_wrapper__`

`from __future__` imports are lifted to module level so they stay legal.

Join-indent was also removed from timeout/e2b test helpers so those copies cannot reintroduce the bug.

### Root cause

Line-wise indent rewrites source text, including the interior of multi-line string literals. A second indent in benchmark mode doubled the corruption.

### Why not keep join with a smarter splitter

A join-based indent cannot tell string interiors from real statements without a full parse. Edge cases that a “smarter join” still gets wrong:

- Blank lines inside a literal becoming four spaces
- Intentional leading spaces inside a literal
- Literals that start inside an already-indented `if`/`for` block
- `print(` text inside a string being treated as a real `print`
- `=` in `x == 2` blocking auto-print
- A second join for `fake_datetime` applying another 4 spaces

AST splice avoids all of those. `await` still works because the statements live in the async function (plain `exec` of the source would not).

### Testing
- [x] Verified fix locally; wrapper literal + freeze tests pass
- New `test_code_wrapper_literals.py` covers both wrap modes, blank lines, leading spaces, f/raw strings, indented blocks, auto-print vs `print(` in a string, await, nested docstrings, `__future__`, CodeAgent wrap, and `wrap_in_async_def`
- Existing freeze tests (clock freeze + asyncio-safe monotonic) still pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-decc8568-48a0-4f17-a3f7-d60b3e76a2dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-decc8568-48a0-4f17-a3f7-d60b3e76a2dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code execution wrapping to better preserve string literals, future imports, indentation, and asynchronous code.
  * Maintained validation for syntax errors and restricted modules.
  * Improved support for optional datetime and wall-clock freezing during execution.

* **Tests**
  * Added comprehensive coverage for code wrapping, including multiline strings, awaits, auto-printing, assignments, and empty input.
  * Updated execution and timeout tests to use the shared wrapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->