### PR TITLE
fix(cuga-lite): preserve computed results in final answers

### DIFF
--- a/src/cuga/backend/cuga_graph/nodes/answer/final_answer.py
+++ b/src/cuga/backend/cuga_graph/nodes/answer/final_answer.py
@@ -145,7 +145,11 @@ class FinalAnswerNode(BaseNode):
             tracker.collect_step(step=Step(name=name, data=final_answer_output.model_dump_json()))
             return Command(update=state.model_dump(), goto=NodeNames.END)
         if state.sender == NodeNames.CUGA_LITE:
+            should_regenerate = (state.cuga_lite_metadata or {}).get("regenerate_final_answer", False)
             state.sender = name
+            if should_regenerate:
+                await FinalAnswerNode._generate_final_answer(state, agent, name)
+                return Command(update=state.model_dump(), goto=NodeNames.END)
             FinalAnswerNode.apply_citation_resolution(state)
             final_answer_output = FinalAnswerOutput(
                 thoughts=[],

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
@@ -219,7 +219,7 @@ class CugaLiteNode(BaseNode):
                 )
             if isinstance(value, (int, float, bool)):
                 candidates = {str(value), f"{value:,}"}
-                numeric_pattern = r"(?<![\w.,]){}(?![\w.,])"
+                numeric_pattern = r"(?<!\w)(?<!\d[.,]){}(?!\w)(?![.,]\d)"
                 return any(
                     re.search(numeric_pattern.format(re.escape(candidate)), answer_lower)
                     for candidate in candidates

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
@@ -199,6 +199,8 @@ class CugaLiteNode(BaseNode):
             "if you need",
             "anything else",
             "additional details",
+            "thanks",
+            "thank you",
         )
         if not any(pattern in answer_lower for pattern in signoff_patterns):
             return False
@@ -217,8 +219,9 @@ class CugaLiteNode(BaseNode):
                 )
             if isinstance(value, (int, float, bool)):
                 candidates = {str(value), f"{value:,}"}
+                numeric_pattern = r"(?<![\w.,]){}(?![\w.,])"
                 return any(
-                    re.search(rf"(?<!\w){re.escape(candidate)}(?!\w)", answer_lower)
+                    re.search(numeric_pattern.format(re.escape(candidate)), answer_lower)
                     for candidate in candidates
                 )
             return False

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
@@ -219,7 +219,7 @@ class CugaLiteNode(BaseNode):
                 )
             if isinstance(value, (int, float, bool)):
                 candidates = {str(value), f"{value:,}"}
-                numeric_pattern = r"(?<!\w)(?<!\d[.,]){}(?!\w)(?![.,]\d)"
+                numeric_pattern = r"(?<![\w+-])(?<!\d[.,]){}(?![\w+-])(?![.,]\d)"
                 return any(
                     re.search(numeric_pattern.format(re.escape(candidate)), answer_lower)
                     for candidate in candidates

--- a/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
+++ b/src/cuga/backend/cuga_graph/nodes/cuga_lite/cuga_lite_node.py
@@ -3,6 +3,7 @@ CugaLite Node - Fast execution node using CugaLite subgraph
 """
 
 import json
+import re
 from typing import Literal, Dict, Any, List, Optional, Callable
 from langgraph.types import Command
 from langchain_core.runnables import RunnableConfig
@@ -181,6 +182,48 @@ class CugaLiteNode(BaseNode):
         # Use creation_order to ensure chronological ordering
         current_var_names = state.variable_creation_order
         return [name for name in current_var_names if name not in initial_var_names]
+
+    @staticmethod
+    def _should_regenerate_final_answer(state: AgentState, answer: str, new_var_names: List[str]) -> bool:
+        """Return whether a CugaLite sign-off omitted a newly-created result."""
+        if not answer or not new_var_names:
+            return False
+
+        answer_lower = answer.casefold()
+        signoff_patterns = (
+            "let me know",
+            "feel free to",
+            "would you like",
+            "if you'd like",
+            "if you would like",
+            "if you need",
+            "anything else",
+            "additional details",
+        )
+        if not any(pattern in answer_lower for pattern in signoff_patterns):
+            return False
+
+        def contains_scalar(value: Any) -> bool:
+            if isinstance(value, dict):
+                return any(contains_scalar(item) for item in value.values())
+            if isinstance(value, (list, tuple, set)):
+                return any(contains_scalar(item) for item in value)
+            if value is None:
+                return False
+            if isinstance(value, str):
+                value = value.strip().casefold()
+                return (
+                    bool(value) and re.search(rf"(?<!\w){re.escape(value)}(?!\w)", answer_lower) is not None
+                )
+            if isinstance(value, (int, float, bool)):
+                candidates = {str(value), f"{value:,}"}
+                return any(
+                    re.search(rf"(?<!\w){re.escape(candidate)}(?!\w)", answer_lower)
+                    for candidate in candidates
+                )
+            return False
+
+        return not contains_scalar(state.variables_manager.get_variable(new_var_names[-1]))
 
     @staticmethod
     def _log_variable_changes(state: AgentState, initial_var_names: List[str]) -> None:
@@ -477,6 +520,10 @@ class CugaLiteNode(BaseNode):
 
         state.final_answer = answer
         state.sender = NodeNames.CUGA_LITE
+        state.cuga_lite_metadata = {
+            **(state.cuga_lite_metadata or {}),
+            "regenerate_final_answer": self._should_regenerate_final_answer(state, answer, new_var_names),
+        }
         if state.hybrid_phase == "api":
             state.hybrid_api_answer = answer
             state.hybrid_phase = "web"

--- a/tests/unit/test_cuga_lite_final_answer.py
+++ b/tests/unit/test_cuga_lite_final_answer.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cuga.backend.cuga_graph.nodes.answer.final_answer import FinalAnswerNode
+from cuga.backend.cuga_graph.nodes.cuga_lite.cuga_lite_node import CugaLiteNode
+from cuga.backend.cuga_graph.state.agent_state import AgentState
+from cuga.backend.cuga_graph.utils.nodes_names import NodeNames
+
+
+pytestmark = pytest.mark.unit
+
+
+class _Variables:
+    def __init__(self, values):
+        self._values = values
+
+    def get_variable(self, name):
+        return self._values.get(name)
+
+
+def _state_with_top_account():
+    return SimpleNamespace(
+        variables_manager=_Variables({"top_account": {"name": "Andromeda Inc.", "revenue": 9_700_000}})
+    )
+
+
+def test_signoff_without_result_requests_final_answer_generation():
+    state = _state_with_top_account()
+    answer = "Great! Let me know if you'd like any additional details about that account."
+
+    assert CugaLiteNode._should_regenerate_final_answer(state, answer, ["top_account"])
+
+
+def test_signoff_with_result_value_keeps_fast_path():
+    state = _state_with_top_account()
+    answer = (
+        "The top account is Andromeda Inc. with revenue of 9,700,000. Let me know if you need anything else."
+    )
+
+    assert not CugaLiteNode._should_regenerate_final_answer(state, answer, ["top_account"])
+
+
+def test_incidental_earlier_scalar_does_not_hide_omitted_latest_result():
+    state = SimpleNamespace(
+        variables_manager=_Variables(
+            {
+                "status": "done",
+                "top_account": {"name": "Andromeda Inc.", "revenue": 9_700_000},
+            }
+        )
+    )
+    answer = "The status is done. Let me know if you'd like any additional details."
+
+    assert CugaLiteNode._should_regenerate_final_answer(state, answer, ["status", "top_account"])
+
+
+def test_signoff_without_new_variables_keeps_fast_path():
+    state = _state_with_top_account()
+    answer = "Great! Let me know if you'd like any additional details."
+
+    assert not CugaLiteNode._should_regenerate_final_answer(state, answer, [])
+
+
+@pytest.mark.asyncio
+async def test_regeneration_metadata_dispatches_to_final_answer_generator(monkeypatch):
+    state = AgentState(
+        sender=NodeNames.CUGA_LITE,
+        cuga_lite_metadata={"regenerate_final_answer": True},
+    )
+    agent = SimpleNamespace(name="FinalAnswerAgent")
+    calls = []
+
+    async def fake_generate(state_arg, agent_arg, name_arg):
+        calls.append((state_arg, agent_arg, name_arg))
+
+    monkeypatch.setattr(FinalAnswerNode, "_generate_final_answer", fake_generate)
+
+    result = await FinalAnswerNode.node_handler(
+        state,
+        agent=agent,
+        name=agent.name,
+        hitl_handler=SimpleNamespace(),
+    )
+
+    assert calls == [(state, agent, agent.name)]
+    assert result.goto == NodeNames.END

--- a/tests/unit/test_cuga_lite_final_answer.py
+++ b/tests/unit/test_cuga_lite_final_answer.py
@@ -62,6 +62,13 @@ def test_numeric_candidate_is_not_found_inside_decimal_answer():
     assert CugaLiteNode._should_regenerate_final_answer(state, "The result is 9.5. Thanks!", ["result"])
 
 
+@pytest.mark.parametrize("answer", ["The result is -9. Thanks!", "The result is +9. Thanks!"])
+def test_unsigned_numeric_candidate_is_not_found_inside_signed_answer(answer):
+    state = SimpleNamespace(variables_manager=_Variables({"result": 9}))
+
+    assert CugaLiteNode._should_regenerate_final_answer(state, answer, ["result"])
+
+
 def test_signoff_with_result_value_keeps_fast_path():
     state = _state_with_top_account()
     answer = (

--- a/tests/unit/test_cuga_lite_final_answer.py
+++ b/tests/unit/test_cuga_lite_final_answer.py
@@ -38,6 +38,24 @@ def test_terminal_thanks_without_result_requests_final_answer_generation():
     assert CugaLiteNode._should_regenerate_final_answer(state, "Thanks!", ["top_account"])
 
 
+def test_numeric_integer_followed_by_sentence_terminator_keeps_fast_path():
+    state = SimpleNamespace(variables_manager=_Variables({"result": 9}))
+
+    assert not CugaLiteNode._should_regenerate_final_answer(state, "The result is 9. Thanks!", ["result"])
+
+
+def test_numeric_comma_value_followed_by_punctuation_keeps_fast_path():
+    state = SimpleNamespace(variables_manager=_Variables({"result": 9_000}))
+
+    assert not CugaLiteNode._should_regenerate_final_answer(state, "The result is 9,000. Thanks!", ["result"])
+
+
+def test_numeric_decimal_followed_by_punctuation_keeps_fast_path():
+    state = SimpleNamespace(variables_manager=_Variables({"result": 9.5}))
+
+    assert not CugaLiteNode._should_regenerate_final_answer(state, "The result is 9.5! Thanks!", ["result"])
+
+
 def test_numeric_candidate_is_not_found_inside_decimal_answer():
     state = SimpleNamespace(variables_manager=_Variables({"result": 9}))
 

--- a/tests/unit/test_cuga_lite_final_answer.py
+++ b/tests/unit/test_cuga_lite_final_answer.py
@@ -32,6 +32,18 @@ def test_signoff_without_result_requests_final_answer_generation():
     assert CugaLiteNode._should_regenerate_final_answer(state, answer, ["top_account"])
 
 
+def test_terminal_thanks_without_result_requests_final_answer_generation():
+    state = _state_with_top_account()
+
+    assert CugaLiteNode._should_regenerate_final_answer(state, "Thanks!", ["top_account"])
+
+
+def test_numeric_candidate_is_not_found_inside_decimal_answer():
+    state = SimpleNamespace(variables_manager=_Variables({"result": 9}))
+
+    assert CugaLiteNode._should_regenerate_final_answer(state, "The result is 9.5. Thanks!", ["result"])
+
+
 def test_signoff_with_result_value_keeps_fast_path():
     state = _state_with_top_account()
     answer = (


### PR DESCRIPTION
## Bug fix

Fixes #700

### Summary

CugaLite can finish with a conversational sign-off after execution has produced a computed variable, causing the user-visible final answer to omit the result. This change:

- detects sign-off text that omits the latest newly-created result value;
- passes a narrow regeneration flag through CugaLite metadata;
- routes only flagged CugaLite results through the existing `FinalAnswerAgent` generation path;
- preserves the existing fast path when the result is already present or no new result exists.

### Testing

- [x] Added marked unit regression coverage for omitted results, incidental earlier variables, preserved fast paths, and metadata dispatch.
- [x] `uv run pytest tests/unit/test_cuga_lite_final_answer.py tests/unit/test_final_answer_citations.py -q` - 25 passed.
- [x] `uv run ruff format --check ...` and `uv run ruff check ...` - passed.
- [x] `git diff --check` - passed.
- [x] CugaLite subtree validation: 626 passed, 4 skipped, 7 pre-existing/environment failures; the same 7 failures occur on clean `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved final answers when sign-off responses omit newly generated result values.
  - Final answers now regenerate automatically when required values are missing.
  - Improved handling of “Thanks” and “Thank you” sign-offs.
  - Numeric results are matched more accurately, including signed values, decimals, and punctuation.
  - Answers containing the correct result or no new results remain unchanged.
- **Tests**
  - Added coverage for result detection, sign-off handling, and final-answer regeneration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->