### PR TITLE
fix(tests): parse OAuth authorize URL instead of substring matching

### DIFF
--- a/tests/events/test_events_dimensions.py
+++ b/tests/events/test_events_dimensions.py
@@ -13,6 +13,7 @@ fallback gating).
 
 import os
 import sys
+from urllib.parse import parse_qs, urlparse
 
 _EVENTS = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "src", "cuga", "backend", "events")
@@ -500,7 +501,12 @@ def test_oauth_registry_and_authorize_url():
     try:
         assert oauth.is_configured("gmail") is True
         url = oauth.authorize_url("gmail", "st123")
-        assert url and "accounts.google.com" in url and "client_id=cid" in url and "state=st123" in url
+        assert url
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        assert parsed.hostname == "accounts.google.com"
+        assert params.get("client_id") == ["cid"]
+        assert params.get("state") == ["st123"]
         assert oauth.redirect_uri("gmail").endswith("/api/events/connect/gmail/callback")
         assert oauth.decode_state(oauth.encode_state(scope="acme/·/alice", app="gmail"))["app"] == "gmail"
     finally:


### PR DESCRIPTION
## Bug fix

Fixes #

### Summary

`test_oauth_registry_and_authorize_url` (tests/events/test_events_dimensions.py) asserted
`"accounts.google.com" in url` to check the OAuth authorize URL's host. CodeQL flagged this
as incomplete URL substring sanitization (`py/incomplete-url-substring-sanitization`, CWE-020):
the substring could also match a URL where `accounts.google.com` appears anywhere else (e.g.
as a query value), not just as the host.

Replaced the substring checks with `urlparse`/`parse_qs`, asserting on `parsed.hostname` and
the individual query parameters instead.

Generated via GitHub Copilot's autofix for this alert, reviewed and applied as-is.

### Testing
- [x] `uv run pytest tests/events/test_events_dimensions.py -k test_oauth_registry_and_authorize_url` — passes

Alert: https://github.com/cuga-project/cuga-agent/security/code-scanning/219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened OAuth authorization URL validation by checking the expected hostname and required query parameters, including the client ID and state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->