### PR TITLE
fix(events): replace literal AP_PASSWORD placeholder with an instruction

### DIFF
--- a/.env.events.example
+++ b/.env.events.example
@@ -81,7 +81,7 @@ EVENTS_TELEGRAM_BOT_USERNAME=<your_bot_username>                 # must match th
 # TELEGRAM_CHAT_ID=<your-telegram-chat-id>                       # [USER] your personal chat id (DM/capture target)
 DISCORD_BOT_TOKEN=<discord-bot-token>
 SLACK_BOT_TOKEN=xoxb-<your-slack-bot-token>
-# SLACK_SIGNING_SECRET=                                          # optional — locks Slack request verification
+# SLACK_SIGNING_SECRET=                                          # optional — locks Slack request verification  # pragma: allowlist secret
 # EVENTS_SLACK_BACKEND=                                          # unset = direct (default). "ap" = the parked AP path
 # EVENTS_DISCORD_BACKEND=                                        # unset = direct gateway (default). "ap" = AP polling
 
@@ -101,7 +101,7 @@ EVENTS_BOX_BACKEND=direct                                        # direct token 
 #    them to log into the AP UI at http://localhost:8081. AP needs a strong password.
 AP_BASE_URL=http://localhost:8081
 AP_EMAIL=you@example.com
-AP_PASSWORD=Sup3rSecret!                                         # ≥8 chars, mixed case + number + symbol
+AP_PASSWORD=<invent-a-strong-password>                           # ≥8 chars, mixed case + number + symbol
 HOST_CALLBACK_URL=http://host.containers.internal:8100/invoke    # how AP reaches CUGA (Docker: host.docker.internal)
 EVENTS_AP_PROJECT_GRAIN=shared
 


### PR DESCRIPTION
## Bug fix

Fixes: https://github.com/cuga-project/cuga-agent/security/secret-scanning/3

### Summary

GitHub secret-scanning flagged `AP_PASSWORD=Sup3rSecret!` in `.env.events.example` as a "Password" secret (line 104, alert #3). It's not a real credential — it's a placeholder value in the events-runtime example env file that the setup docs tell readers to invent themselves — but a literal string that looks like a password will keep tripping scanners on this repo and on every fork/copy of the file.

Replaced it with `<invent-a-strong-password>`, matching the placeholder style already used for every other secret-shaped value in this file (`AP_EMAIL`, `WATSONX_APIKEY`, `DISCORD_BOT_TOKEN`, etc). No behavior change: nothing reads this file's values directly, it's copied to `.env` and edited by the reader per the header instructions.

Also allowlisted a pre-existing, unrelated `detect-secrets` false positive on line 84 (`SLACK_SIGNING_SECRET=`, empty value, commented out) that was blocking the `detect-secrets` pre-commit hook for any edit to this file.

### Testing
- [x] `detect-secrets` pre-commit hook passes on `.env.events.example`
- [x] Confirmed no code reads the literal placeholder value (grepped for `Sup3rSecret` repo-wide)
